### PR TITLE
Policy topology fixes, centralise CRD versioning refs

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -22,11 +22,46 @@
     }
   },
   {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": "/kuadrant/policy-topology",
+      "component": { "$codeRef": "PolicyTopologyPage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": "/k8s/ns/:ns/tlspolicy/name/:name/edit",
+      "component": { "$codeRef": "KuadrantTLSCreatePage" }
+    }
+  },
+  {
+    "type": "console.page/route",
+    "properties": {
+      "exact": true,
+      "path": "/k8s/ns/:ns/dnspolicy/name/:name/edit",
+      "component": { "$codeRef": "KuadrantDNSPolicyCreatePage" }
+    }
+  },
+  {
     "type": "console.resource/create",
     "properties": {
       "model": {
         "group": "kuadrant.io",
         "version": "v1alpha1",
+        "kind": "DNSPolicy"
+      },
+      "component": { "$codeRef": "KuadrantDNSPolicyCreatePage" }
+    }
+  },
+  {
+    "type": "console.resource/create",
+    "properties": {
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1",
         "kind": "DNSPolicy"
       },
       "component": { "$codeRef": "KuadrantDNSPolicyCreatePage" }
@@ -44,11 +79,14 @@
     }
   },
   {
-    "type": "console.page/route",
+    "type": "console.resource/create",
     "properties": {
-      "exact": true,
-      "path": "/kuadrant/policy-topology",
-      "component": { "$codeRef": "PolicyTopologyPage" }
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1",
+        "kind": "RateLimitPolicy"
+      },
+      "component": { "$codeRef": "KuadrantRateLimitPolicyCreatePage" }
     }
   },
   {
@@ -63,19 +101,36 @@
     }
   },
   {
-    "type": "console.page/route",
+    "type": "console.resource/create",
     "properties": {
-      "exact": true,
-      "path": "/k8s/ns/:ns/tlspolicy/name/:name/edit",
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1",
+        "kind": "TLSPolicy"
+      },
       "component": { "$codeRef": "KuadrantTLSCreatePage" }
     }
   },
   {
-    "type": "console.page/route",
+    "type": "console.resource/create",
     "properties": {
-      "exact": true,
-      "path": "/k8s/ns/:ns/dnspolicy/name/:name/edit",
-      "component": { "$codeRef": "KuadrantDNSPolicyCreatePage" }
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1beta2",
+        "kind": "AuthPolicy"
+      },
+      "component": { "$codeRef": "KuadrantAuthPolicyCreatePage" }
+    }
+  },
+  {
+    "type": "console.resource/create",
+    "properties": {
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1",
+        "kind": "AuthPolicy"
+      },
+      "component": { "$codeRef": "KuadrantAuthPolicyCreatePage" }
     }
   },
   {
@@ -154,17 +209,6 @@
       "perspective": "dev",
       "section": "kuadrant-section-dev",
       "badge": "dev"
-    }
-  },
-  {
-    "type": "console.resource/create",
-    "properties": {
-      "model": {
-        "group": "kuadrant.io",
-        "version": "v1beta2",
-        "kind": "AuthPolicy"
-      },
-      "component": { "$codeRef": "KuadrantAuthPolicyCreatePage" }
     }
   }
 ]

--- a/install.yaml
+++ b/install.yaml
@@ -130,7 +130,7 @@ spec:
   type: ClusterIP
   sessionAffinity: None
 ---
-apiVersion: console.openshift.io/v1alpha1
+apiVersion: console.openshift.io/v1
 kind: ConsolePlugin
 metadata:
   name: kuadrant-console-plugin

--- a/src/components/KuadrantAuthPolicyCreatePage.tsx
+++ b/src/components/KuadrantAuthPolicyCreatePage.tsx
@@ -3,14 +3,15 @@ import Helmet from 'react-helmet';
 import { Button, Modal, ModalBox, ModalBoxHeader, ModalBoxBody, ModalBoxFooter, ButtonVariant } from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ResourceYAMLEditor, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import resourceGVKMapping from '../utils/latest';
 
 const KuadrantAuthPolicyCreatePage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [selectedNamespace] = useActiveNamespace();
 
   const yamlResource = {
-    apiVersion: 'kuadrant.io/v1beta2',
-    kind: 'AuthPolicy',
+    apiVersion: resourceGVKMapping['AuthPolicy'].group + '/' + resourceGVKMapping['AuthPolicy'].version,
+    kind: resourceGVKMapping['AuthPolicy'].kind,
     metadata: {
       name: 'example-authpolicy',
       namespace: selectedNamespace,

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -26,6 +26,7 @@ import GatewaySelect from './gateway/GatewaySelect';
 import yaml from 'js-yaml';
 import KuadrantCreateUpdate from './KuadrantCreateUpdate'
 import { handleCancel } from '../utils/cancel';
+import resourceGVKMapping from '../utils/latest';
 
 
 const KuadrantDNSPolicyCreatePage: React.FC = () => {
@@ -51,8 +52,8 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
   const createDNSPolicy = () => {
     const hasHealthCheck = healthCheck.endpoint || healthCheck.failureThreshold || healthCheck.port || healthCheck.protocol;
     return {
-      apiVersion: 'kuadrant.io/v1alpha1',
-      kind: 'DNSPolicy',
+      apiVersion: resourceGVKMapping['DNSPolicy'].group + '/' + resourceGVKMapping['DNSPolicy'].version,
+      kind: resourceGVKMapping['DNSPolicy'].kind,
       metadata: {
         name: policyName,
         namespace: selectedNamespace,
@@ -86,8 +87,11 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
 
   const [yamlInput, setYamlInput] = React.useState(createDNSPolicy)
   const dnsPolicy = createDNSPolicy();
-  const dnsPolicyGVK = getGroupVersionKindForResource({ apiVersion: 'kuadrant.io/v1alpha1', kind: 'DNSPolicy' });
-  const [dnsPolicyModel] = useK8sModel({ group: dnsPolicyGVK.group, version: dnsPolicyGVK.version, kind: dnsPolicyGVK.kind });
+  const dnsPolicyGVK = getGroupVersionKindForResource({
+    apiVersion: `${resourceGVKMapping['DNSPolicy'].group}/${resourceGVKMapping['DNSPolicy'].version}`,
+    kind: resourceGVKMapping['DNSPolicy'].kind,
+  });
+    const [dnsPolicyModel] = useK8sModel({ group: dnsPolicyGVK.group, version: dnsPolicyGVK.version, kind: dnsPolicyGVK.kind });
 
   const history = useHistory();
 

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -35,6 +35,7 @@ import './kuadrant.css';
 import ResourceList from './ResourceList';
 import { sortable } from '@patternfly/react-table';
 import { INTERNAL_LINKS, EXTERNAL_LINKS } from '../constants/links';
+import resourceGVKMapping from '../utils/latest';
 
 const KuadrantOverviewPage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
@@ -226,10 +227,10 @@ const KuadrantOverviewPage: React.FC = () => {
                 <CardBody className="pf-u-p-0">
                   <ResourceList
                     resources={[
-                      { group: 'kuadrant.io', version: 'v1beta2', kind: 'AuthPolicy' },
-                      { group: 'kuadrant.io', version: 'v1alpha1', kind: 'DNSPolicy' },
-                      { group: 'kuadrant.io', version: 'v1beta2', kind: 'RateLimitPolicy' },
-                      { group: 'kuadrant.io', version: 'v1alpha1', kind: 'TLSPolicy' }
+                      resourceGVKMapping['AuthPolicy'],
+                      resourceGVKMapping['DNSPolicy'],
+                      resourceGVKMapping['RateLimitPolicy'],
+                      resourceGVKMapping['TLSPolicy']
                     ]}
                     columns={columns}
                     namespace='#ALL_NS#'
@@ -247,7 +248,7 @@ const KuadrantOverviewPage: React.FC = () => {
                 <CardBody className="pf-u-p-0">
                   <ResourceList
                     resources={[
-                      { group: 'gateway.networking.k8s.io', version: 'v1', kind: 'Gateway' },
+                      resourceGVKMapping['Gateway']
                     ]}
                     columns={columns}
                     namespace='#ALL_NS#'
@@ -261,7 +262,7 @@ const KuadrantOverviewPage: React.FC = () => {
                 <CardBody className="pf-u-p-0">
                   <ResourceList
                     resources={[
-                      { group: 'gateway.networking.k8s.io', version: 'v1', kind: 'HTTPRoute' },
+                      resourceGVKMapping['HTTPRoute']
                     ]}
                     columns={columns}
                     namespace='#ALL_NS#'

--- a/src/components/KuadrantPoliciesPage.tsx
+++ b/src/components/KuadrantPoliciesPage.tsx
@@ -17,6 +17,7 @@ import { Title } from '@patternfly/react-core';
 import { Alert, AlertGroup } from '@patternfly/react-core';
 import ResourceList from './ResourceList';
 import './kuadrant.css';
+import resourceGVKMapping from '../utils/latest';
 
 interface Resource {
   name: string;
@@ -28,10 +29,10 @@ interface Resource {
 }
 
 export const resources: Resource[] = [
-  { name: 'AuthPolicies', gvk: { group: 'kuadrant.io', version: 'v1beta2', kind: 'AuthPolicy' } },
-  { name: 'DNSPolicies', gvk: { group: 'kuadrant.io', version: 'v1alpha1', kind: 'DNSPolicy' } },
-  { name: 'RateLimitPolicies', gvk: { group: 'kuadrant.io', version: 'v1beta2', kind: 'RateLimitPolicy' } },
-  { name: 'TLSPolicies', gvk: { group: 'kuadrant.io', version: 'v1alpha1', kind: 'TLSPolicy' } },
+  { name: 'AuthPolicies', gvk: resourceGVKMapping['AuthPolicy'] },
+  { name: 'DNSPolicies', gvk: resourceGVKMapping['DNSPolicy'] },
+  { name: 'RateLimitPolicies', gvk: resourceGVKMapping['RateLimitPolicy'] },
+  { name: 'TLSPolicies', gvk: resourceGVKMapping['TLSPolicy'] },
 ];
 
 export const AllPoliciesListPage: React.FC<{

--- a/src/components/KuadrantRateLimitPolicyCreatePage.tsx
+++ b/src/components/KuadrantRateLimitPolicyCreatePage.tsx
@@ -9,6 +9,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import './kuadrant.css';
 import { ResourceYAMLEditor, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
+import resourceGVKMapping from '../utils/latest';
 
 const KuadrantRateLimitPolicyCreatePage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
@@ -17,8 +18,8 @@ const KuadrantRateLimitPolicyCreatePage: React.FC = () => {
   const [errorModalMsg] = React.useState('');
 
   const rateLimitPolicy = {
-    apiVersion: 'kuadrant.io/v1beta2',
-    kind: 'RateLimitPolicy',
+    apiVersion: resourceGVKMapping['RateLimitPolicy'].group + '/' + resourceGVKMapping['RateLimitPolicy'].version,
+    kind: resourceGVKMapping['RateLimitPolicy'].kind,
     metadata: {
       name: 'example-ratelimitpolicy',
       namespace: selectedNamespace,

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -36,6 +36,7 @@ import { Gateway } from './gateway/types';
 import GatewaySelect from './gateway/GatewaySelect';
 import KuadrantCreateUpdate from './KuadrantCreateUpdate'
 import { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
+import resourceGVKMapping from '../utils/latest';
 
 
 const KuadrantTLSCreatePage: React.FC = () => {
@@ -59,8 +60,8 @@ const KuadrantTLSCreatePage: React.FC = () => {
 
   // Creates TLS policy object to be used for form and yaml creation of the resource
   const createTlsPolicy = () => ({
-    apiVersion: 'kuadrant.io/v1alpha1',
-    kind: 'TLSPolicy',
+    apiVersion: resourceGVKMapping['TLSPolicy'].group + '/' + resourceGVKMapping['TLSPolicy'].version,
+    kind: resourceGVKMapping['TLSPolicy'].kind,
     metadata: {
       name: policyName,
       namespace: selectedNamespace,
@@ -87,7 +88,10 @@ const KuadrantTLSCreatePage: React.FC = () => {
   })
 
   const tlsPolicy = createTlsPolicy();
-  const tlsPolicyGVK = getGroupVersionKindForResource({ apiVersion: 'kuadrant.io/v1alpha1', kind: 'TLSPolicy' });
+  const tlsPolicyGVK = getGroupVersionKindForResource({
+    apiVersion: `${resourceGVKMapping['TLSPolicy'].group}/${resourceGVKMapping['TLSPolicy'].version}`,
+    kind: resourceGVKMapping['TLSPolicy'].kind,
+  });
   const [tlsPolicyModel] = useK8sModel({ group: tlsPolicyGVK.group, version: tlsPolicyGVK.version, kind: tlsPolicyGVK.kind });
 
   // K8sResourceCommon by default does not contain spec etc which is needed for updating resource forms

--- a/src/components/PolicyTopologyPage.tsx
+++ b/src/components/PolicyTopologyPage.tsx
@@ -190,6 +190,7 @@ const CustomNode: React.FC<any> = ({
   onContextMenu,
   contextMenuOpen,
 }) => {
+  const excludedKinds = ['GatewayClass', 'HTTPRouteRule', 'Listener'];
   const data = element.getData();
   const { type, badge, badgeColor } = data;
 
@@ -214,6 +215,9 @@ const CustomNode: React.FC<any> = ({
     case 'GatewayClass':
       IconComponent = CubesIcon;
       break;
+    case 'HttpRouteRule':
+      IconComponent = RouteIcon;
+      break;
     default:
       IconComponent = TopologyIcon;
       break;
@@ -235,8 +239,9 @@ const CustomNode: React.FC<any> = ({
       onSelect={onSelect}
       selected={selected}
       className={isPolicyNode ? 'policy-node' : ''}
-      onContextMenu={onContextMenu}
-      contextMenuOpen={contextMenuOpen}
+      // Disable context menu for excluded kinds
+      onContextMenu={!excludedKinds.includes(type) ? onContextMenu : undefined}
+      contextMenuOpen={!excludedKinds.includes(type) && contextMenuOpen}
     >
       <g transform={`translate(${nodeWidth / 2}, ${paddingTop})`}>
         <foreignObject width={iconSize} height={iconSize} x={-iconSize / 2}>

--- a/src/components/PolicyTopologyPage.tsx
+++ b/src/components/PolicyTopologyPage.tsx
@@ -297,7 +297,7 @@ const goToResource = (resourceType: string, resourceName: string) => {
 const customLayoutFactory = (type: string, graph: any): any => {
   return new DagreLayout(graph, {
     rankdir: 'TB',
-    nodesep: 60,
+    nodesep: 0,
     ranksep: 0,
     nodeDistance: 80,
   });

--- a/src/utils/latest.tsx
+++ b/src/utils/latest.tsx
@@ -1,0 +1,14 @@
+const resourceGVKMapping: { [key: string]: { group: string; version: string; kind: string } } = {
+  Gateway: { group: 'gateway.networking.k8s.io', version: 'v1', kind: 'Gateway' },
+  HTTPRoute: { group: 'gateway.networking.k8s.io', version: 'v1', kind: 'HTTPRoute' },
+  TLSPolicy: { group: 'kuadrant.io', version: 'v1alpha1', kind: 'TLSPolicy' },
+  DNSPolicy: { group: 'kuadrant.io', version: 'v1alpha1', kind: 'DNSPolicy' },
+  AuthPolicy: { group: 'kuadrant.io', version: 'v1beta2', kind: 'AuthPolicy' },
+  RateLimitPolicy: { group: 'kuadrant.io', version: 'v1beta2', kind: 'RateLimitPolicy' },
+  ConfigMap: { group: '', version: 'v1', kind: 'ConfigMap' },
+  Listener: { group: 'gateway.networking.k8s.io', version: 'v1', kind: 'Listener' },
+  GatewayClass: { group: 'gateway.networking.k8s.io', version: 'v1', kind: 'GatewayClass' },
+  WasmPlugin: { group: 'extensions.istio.io', version: 'v1alpha1', kind: 'WasmPlugin' },
+};
+
+export default resourceGVKMapping;


### PR DESCRIPTION
- `ConsolePlugin` resource bump**
- `console-extensions.json` updates: reorder, and rev APIs for v1
- topology: ignore actions for meta-resources
- topology: nodesep change
- topology: Additional graph filtering for unaassociated policies, filter cert-manager resources
- centralise version refs
