### PR TITLE
Fix for Gateways/HTTPRoutes not marked as enforced

### DIFF
--- a/src/components/ResourceList.tsx
+++ b/src/components/ResourceList.tsx
@@ -81,7 +81,11 @@ const getStatusLabel = (obj) => {
   const policiesAffected = policiesMap[kind] || [];
 
   const hasAllPoliciesEnforced = (conditions) => {
-    return policiesAffected.every((policy) =>
+    const relevantPolicies = policiesAffected.filter((policy) =>
+      conditions.some((cond) => cond.type === policy),
+    );
+
+    return relevantPolicies.every((policy) =>
       conditions.some((cond) => cond.type === policy && cond.status === 'True'),
     );
   };


### PR DESCRIPTION
Before:
![Screenshot 2024-11-11 at 10 40 13](https://github.com/user-attachments/assets/e06a93ab-0555-4880-9d63-fff24e432b73)



After:
![Screenshot 2024-11-11 at 10 39 48](https://github.com/user-attachments/assets/05ab486d-9d30-4bb8-86e8-b58fe17461c2)



Gateway:

`[{"lastTransitionTime":"2024-11-07T13:00:17Z","message":"Object affected by TLSPolicy [gateway-system/tls]","observedGeneration":1,"reason":"Accepted","status":"True","type":"kuadrant.io/TLSPolicyAffected"},{"lastTransitionTime":"2024-11-07T13:00:17Z","message":"Object affected by DNSPolicy [gateway-system/dnspolicy gateway-system/dnspolicy-t1b gateway-system/dnspolicy-t1a]","observedGeneration":1,"reason":"Accepted","status":"True","type":"kuadrant.io/DNSPolicyAffected"},{"lastTransitionTime":"2024-11-07T13:00:13Z","message":"Route was valid, bound to 4 parents","observedGeneration":1,"reason":"Accepted","status":"True","type":"Accepted"},{"lastTransitionTime":"2024-11-07T13:00:14Z","message":"All references resolved","observedGeneration":1,"reason":"ResolvedRefs","status":"True","type":"ResolvedRefs"}]`

