### PR TITLE
add i18n preload flag for ConsolePlugin

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -131,6 +131,8 @@ metadata:
   name: kuadrant-console-plugin
 spec:
   displayName: 'Kuadrant Console Plugin'
+  i18n:
+    loadType: Preload
   backend:
     type: Service
     service:

--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "version": "0.0.19-dev",
     "displayName": "Kuadrant OpenShift Console Plugin",
     "description": "Kuadrant OpenShift Console Plugin",
+    "i18n": {
+      "loadType": "Preload"
+    },
     "exposedModules": {
       "KuadrantOverviewPage": "./components/KuadrantOverviewPage",
       "PolicyTopologyPage": "./components/PolicyTopologyPage",


### PR DESCRIPTION
Related issue: https://github.com/Kuadrant/kuadrant-console-plugin/issues/166

Adds a flag to get `console` to preload i18n resources before rendering the plugin


Related operator PR: https://github.com/Kuadrant/kuadrant-operator/pull/1139