### PR TITLE
RBAC for Policy List pages

### DIFF
--- a/locales/en/plugin__kuadrant-console-plugin.json
+++ b/locales/en/plugin__kuadrant-console-plugin.json
@@ -6,7 +6,6 @@
   "All references for the resource have been resolved.": "All references for the resource have been resolved.",
   "An unhealthy gateway has a `false` status for the `Accepted` and/or `Programmed` conditions.": "An unhealthy gateway has a `false` status for the `Accepted` and/or `Programmed` conditions.",
   "Auth": "Auth",
-  "AuthPolicy": "AuthPolicy",
   "Cancel": "Cancel",
   "Cert manager issuer type": "Cert manager issuer type",
   "cert-manager Operator": "cert-manager Operator",
@@ -31,7 +30,6 @@
   "Disabled": "Disabled",
   "Displays the distribution of error codes for request failures.": "Displays the distribution of error codes for request failures.",
   "DNS": "DNS",
-  "DNSPolicy": "DNSPolicy",
   "DNSPolicy configures how North-South based traffic should be balanced and reach the gateways": "DNSPolicy configures how North-South based traffic should be balanced and reach the gateways",
   "Duration": "Duration",
   "Ease operational complexity with API management and App Connectivity by using additional Operators and tools.": "Ease operational complexity with API management and App Connectivity by using additional Operators and tools.",
@@ -99,7 +97,6 @@
   "Protocol": "Protocol",
   "Provider Ref": "Provider Ref",
   "RateLimit": "RateLimit",
-  "RateLimitPolicy": "RateLimitPolicy",
   "Read about the latest information and key features in the Kuadrant highlights.": "Read about the latest information and key features in the Kuadrant highlights.",
   "Reference to an existing secret resource containing DNS provider credentials and configuration": "Reference to an existing secret resource containing DNS provider credentials and configuration",
   "Release Notes": "Release Notes",
@@ -133,7 +130,6 @@
   "There is a conflict on the resource.": "There is a conflict on the resource.",
   "This view visualizes the relationships and interactions between different resources within your cluster related to Kuadrant, allowing you to explore connections between Gateways, HTTPRoutes and Kuadrant Policies.": "This view visualizes the relationships and interactions between different resources within your cluster related to Kuadrant, allowing you to explore connections between Gateways, HTTPRoutes and Kuadrant Policies.",
   "TLS": "TLS",
-  "TLSPolicy": "TLSPolicy",
   "to display - please create some.": "to display - please create some.",
   "Topology View": "Topology View",
   "Total Requests": "Total Requests",
@@ -148,5 +144,6 @@
   "You do not have permission to view Gateways": "You do not have permission to view Gateways",
   "You do not have permission to view HTTPRoutes": "You do not have permission to view HTTPRoutes",
   "You do not have permission to view Policies": "You do not have permission to view Policies",
-  "You do not have permission to view Policy Topology": "You do not have permission to view Policy Topology"
+  "You do not have permission to view Policy Topology": "You do not have permission to view Policy Topology",
+  "You do not have permission to view this resource": "You do not have permission to view this resource"
 }

--- a/src/components/DropdownWithKebab.tsx
+++ b/src/components/DropdownWithKebab.tsx
@@ -15,7 +15,7 @@ import { k8sDelete, K8sResourceCommon } from '@openshift-console/dynamic-plugin-
 import { useHistory } from 'react-router-dom';
 import resourceGVKMapping from '../utils/latest';
 import useAccessReviews from '../utils/resourceRBAC';
-import getModelFromResource from '../utils/getModelFromResource'; // Assume you have a utility for getting the model from the resource
+import { getModelFromResource } from '../utils/getModelFromResource';
 type DropdownWithKebabProps = {
   obj: K8sResourceCommon;
 };
@@ -47,8 +47,6 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
     { group: resourceGVKMapping[obj.kind].group, kind: obj.kind },
   ];
   const { userRBAC } = useAccessReviews(resourceGVK);
-  // console.log("LOADING",loading)
-
   const resourceRBAC = [
     'TLSPolicy',
     'DNSPolicy',

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -58,6 +58,7 @@ import { INTERNAL_LINKS, EXTERNAL_LINKS } from '../constants/links';
 import resourceGVKMapping from '../utils/latest';
 import { useHistory } from 'react-router-dom';
 import useAccessReviews from '../utils/resourceRBAC';
+import { getResourceNameFromKind } from '../utils/getModelFromResource';
 
 export type MenuToggleElement = HTMLDivElement | HTMLButtonElement;
 
@@ -121,7 +122,13 @@ const KuadrantOverviewPage: React.FC = () => {
     setIsCreateOpen(!isCreateOpen);
   };
 
-  const { userRBAC, loading } = useAccessReviews(resources.map((res) => res.gvk));
+  const resolvedNamespace = activeNamespace === '#ALL_NS#' ? 'default' : activeNamespace;
+  const rbacResources = resources.map((res) => ({
+    group: res.gvk.group,
+    kind: getResourceNameFromKind(res.gvk.kind),
+    namespace: resolvedNamespace,
+  }));
+  const { userRBAC, loading } = useAccessReviews(rbacResources);
 
   const policies = ['AuthPolicy', 'RateLimitPolicy', 'DNSPolicy', 'TLSPolicy'];
 
@@ -136,8 +143,8 @@ const KuadrantOverviewPage: React.FC = () => {
     (acc, resource) => ({
       ...acc,
       [resource]: {
-        list: userRBAC[`${resource}-list`],
-        create: userRBAC[`${resource}-create`],
+        list: userRBAC[`${getResourceNameFromKind(resource)}-list`],
+        create: userRBAC[`${getResourceNameFromKind(resource)}-create`],
       },
     }),
     {} as Record<string, { list: boolean; create: boolean }>,

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -123,7 +123,6 @@ const KuadrantOverviewPage: React.FC = () => {
 
   const { userRBAC, loading } = useAccessReviews(resources.map((res) => res.gvk));
 
-  console.log('LOADING', loading);
   const policies = ['AuthPolicy', 'RateLimitPolicy', 'DNSPolicy', 'TLSPolicy'];
 
   const resourceRBAC = [

--- a/src/components/NoPermissionsView.tsx
+++ b/src/components/NoPermissionsView.tsx
@@ -1,0 +1,36 @@
+import * as React from 'react';
+import {
+  Title,
+  Bullseye,
+  EmptyState,
+  EmptyStateIcon,
+  EmptyStateBody,
+  Text,
+} from '@patternfly/react-core';
+import { useTranslation } from 'react-i18next';
+import { LockIcon } from '@patternfly/react-icons';
+
+const NoPermissionsView: React.FC<{
+  heading?: React.ReactNode;
+  primaryMessage: React.ReactNode;
+  secondaryMessage?: React.ReactNode;
+}> = ({ heading, primaryMessage, secondaryMessage }) => {
+  const { t } = useTranslation('plugin__kuadrant-console-plugin');
+  const effectiveHeading = heading || t('Access Denied');
+  return (
+    <Bullseye>
+      <EmptyState>
+        <EmptyStateIcon icon={LockIcon} />
+        <Title headingLevel="h4" size="lg">
+          {effectiveHeading}
+        </Title>
+        <EmptyStateBody>
+          <Text component="p">{primaryMessage}</Text>
+          {secondaryMessage && <Text component="p">{secondaryMessage}</Text>}
+        </EmptyStateBody>
+      </EmptyState>
+    </Bullseye>
+  );
+};
+
+export default NoPermissionsView;

--- a/src/components/PolicyTopologyPage.tsx
+++ b/src/components/PolicyTopologyPage.tsx
@@ -18,10 +18,6 @@ import {
   SelectList,
   SelectOption,
   MenuToggle,
-  Bullseye,
-  EmptyState,
-  EmptyStateIcon,
-  EmptyStateBody,
 } from '@patternfly/react-core';
 import {
   useK8sWatchResource,
@@ -54,16 +50,11 @@ import {
 } from '@patternfly/react-topology';
 import { useTranslation } from 'react-i18next';
 
-import {
-  CubesIcon,
-  CloudUploadAltIcon,
-  TopologyIcon,
-  RouteIcon,
-  LockIcon,
-} from '@patternfly/react-icons';
+import { CubesIcon, CloudUploadAltIcon, TopologyIcon, RouteIcon } from '@patternfly/react-icons';
 
 import * as dot from 'graphlib-dot';
 import './kuadrant.css';
+import NoPermissionsView from './NoPermissionsView';
 
 interface GVK {
   group: string;
@@ -607,22 +598,16 @@ const PolicyTopologyPage: React.FC = () => {
 
   if (!canReadTopology) {
     return (
-      <Bullseye>
-        <EmptyState>
-          <EmptyStateIcon icon={LockIcon} />
-          <Title headingLevel="h4" size="lg">
-            {t('Access Denied')}
-          </Title>
-          <EmptyStateBody>
-            <Text component="p">{t('You do not have permission to view Policy Topology')}</Text>
-            <Text component="p">
-              {t('Specifically, you do not have permission to read the ConfigMap ')}
-              <strong>{config.TOPOLOGY_CONFIGMAP_NAME}</strong> {t('in the namespace ')}
-              <strong>{config.TOPOLOGY_CONFIGMAP_NAMESPACE}</strong>
-            </Text>
-          </EmptyStateBody>
-        </EmptyState>
-      </Bullseye>
+      <NoPermissionsView
+        primaryMessage={t('You do not have permission to view Policy Topology')}
+        secondaryMessage={
+          <>
+            {t('Specifically, you do not have permission to read the ConfigMap ')}
+            <strong>{config.TOPOLOGY_CONFIGMAP_NAME}</strong> {t('in the namespace ')}
+            <strong>{config.TOPOLOGY_CONFIGMAP_NAMESPACE}</strong>
+          </>
+        }
+      />
     );
   }
 

--- a/src/components/ResourceList.tsx
+++ b/src/components/ResourceList.tsx
@@ -26,17 +26,17 @@ import {
   useK8sWatchResources,
   VirtualizedTable,
   Timestamp,
-  TableData,
   RowProps,
   TableColumn,
   WatchK8sResource,
   ListPageBody,
+  TableData,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { SearchIcon } from '@patternfly/react-icons';
 import { getStatusLabel } from '../utils/statusLabel';
-
 import DropdownWithKebab from './DropdownWithKebab';
 import useAccessReviews from '../utils/resourceRBAC';
+import { getResourceNameFromKind } from '../utils/getModelFromResource';
 
 type ResourceListProps = {
   resources: Array<{
@@ -68,36 +68,30 @@ const ResourceList: React.FC<ResourceListProps> = ({
 }) => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
 
-  const { userRBAC } = useAccessReviews(resources);
-  // console.log("LOADING",loading)
+  const accessResources = resources.map((r) => ({
+    ...r,
+    kind: getResourceNameFromKind(r.kind),
+  }));
+
+  const { userRBAC } = useAccessReviews(accessResources);
 
   const resourceKinds = ['AuthPolicy', 'RateLimitPolicy', 'DNSPolicy', 'TLSPolicy'];
 
   const resourceMappings = resourceKinds.map((kind) => ({
-    key: `${kind}-list`,
+    key: `${getResourceNameFromKind(kind)}-list`,
     group: 'kuadrant.io',
     version: 'v1',
     kind,
   }));
-  const resourceRBAC = resourceMappings.map(({ key, group, version, kind }) => ({
-    flag: userRBAC[key] ?? false,
-    group,
-    version,
-    kind,
-  }));
 
-  resources = resourceRBAC.reduce(
-    (resources, { flag, group, version, kind }) =>
-      flag !== true
-        ? resources.filter(
-            (resource) =>
-              !(resource.group === group && resource.version === version && resource.kind === kind),
-          )
-        : resources,
-    resources,
-  );
+  // filter out resources that the user doesn't have permission to list
+  const filteredResources = resources.filter((resource) => {
+    const mapping = resourceMappings.find((m) => m.kind === resource.kind);
+    const allowed = mapping ? userRBAC[mapping.key] : false;
+    return allowed;
+  });
 
-  const resourceDescriptors: { [key: string]: WatchK8sResource } = resources.reduce(
+  const resourceDescriptors: { [key: string]: WatchK8sResource } = filteredResources.reduce(
     (acc, resource, index) => {
       const key = `${resource.group}-${resource.version}-${resource.kind}-${index}`;
       acc[key] = {
@@ -131,7 +125,6 @@ const ResourceList: React.FC<ResourceListProps> = ({
   const loadErrors = Object.values(watchedResources)
     .filter((res) => res.loadError)
     .map((res) => res.loadError);
-
   const combinedLoadError =
     loadErrors.length > 0 ? new Error(loadErrors.map((err) => err.message).join('; ')) : null;
 
@@ -141,9 +134,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
   const [filterSelected, setFilterSelected] = React.useState('Name');
   const [filteredData, setFilteredData] = React.useState<K8sResourceCommon[]>([]);
 
-  const onToggleClick = () => {
-    setIsOpen(!isOpen);
-  };
+  const onToggleClick = () => setIsOpen(!isOpen);
 
   const onFilterSelect = (
     _event: React.MouseEvent<Element, MouseEvent> | undefined,
@@ -155,7 +146,6 @@ const ResourceList: React.FC<ResourceListProps> = ({
 
   React.useEffect(() => {
     let data = allData;
-
     if (filters) {
       const filterValue = filters.toLowerCase();
       data = data.filter((item) => {
@@ -170,7 +160,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
       });
     }
     setFilteredData(data);
-  }, [allData, filters]);
+  }, [allData, filters, filterSelected]);
 
   const defaultColumns: TableColumn<K8sResourceCommon>[] = [
     {
@@ -350,7 +340,8 @@ const ResourceList: React.FC<ResourceListProps> = ({
                         filterValue: filterSelected.toLowerCase(),
                       })}
                       onChange={(_event, value) => handleFilterChange(value)}
-                      className="pf-v5-c-form-control co-text-filter-with-icon "
+                      className="pf-v5-c-form-control co-text-filter-with-icon"
+                      aria-label="Resource search"
                     />
                   </InputGroup>
                 </ToolbarItem>

--- a/src/components/ResourceList.tsx
+++ b/src/components/ResourceList.tsx
@@ -75,7 +75,14 @@ const ResourceList: React.FC<ResourceListProps> = ({
 
   const { userRBAC } = useAccessReviews(accessResources);
 
-  const resourceKinds = ['AuthPolicy', 'RateLimitPolicy', 'DNSPolicy', 'TLSPolicy'];
+  const resourceKinds = [
+    'AuthPolicy',
+    'RateLimitPolicy',
+    'DNSPolicy',
+    'TLSPolicy',
+    'Gateway',
+    'HTTPRoute',
+  ];
 
   const resourceMappings = resourceKinds.map((kind) => ({
     key: `${getResourceNameFromKind(kind)}-list`,

--- a/src/utils/getModelFromResource.ts
+++ b/src/utils/getModelFromResource.ts
@@ -1,13 +1,12 @@
 import { K8sModel, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 
-const getModelFromResource = (obj: K8sResourceCommon): K8sModel => {
+export const getModelFromResource = (obj: K8sResourceCommon): K8sModel => {
   const pluralizeKind = (kind: string) => {
     // Words ending in 'y', preceded by a consonant (e.g., "Category" -> "Categories")
     // Gateway will not become Gatewayies ;)
     if (kind.endsWith('y') && !/[aeiou]y$/i.test(kind)) {
       return `${kind.slice(0, -1)}ies`.toLowerCase();
     }
-
     return `${kind}s`.toLowerCase();
   };
 
@@ -23,4 +22,9 @@ const getModelFromResource = (obj: K8sResourceCommon): K8sModel => {
   };
 };
 
-export default getModelFromResource;
+export const getResourceNameFromKind = (kind: string) => {
+  if (kind.endsWith('y')) {
+    return kind.substring(0, kind.length - 1).toLowerCase() + 'ies';
+  }
+  return kind.toLowerCase() + 's';
+};

--- a/src/utils/getModelFromResource.ts
+++ b/src/utils/getModelFromResource.ts
@@ -23,7 +23,7 @@ export const getModelFromResource = (obj: K8sResourceCommon): K8sModel => {
 };
 
 export const getResourceNameFromKind = (kind: string) => {
-  if (kind.endsWith('y')) {
+  if (kind.endsWith('y') && !/[aeiou]y$/i.test(kind)) {
     return kind.substring(0, kind.length - 1).toLowerCase() + 'ies';
   }
   return kind.toLowerCase() + 's';


### PR DESCRIPTION
Resolves https://github.com/Kuadrant/kuadrant-console-plugin/issues/205

To verify, create users per: https://github.com/Kuadrant/kuadrant-console-plugin/pull/215

To test, I also create a rolebinding with perms for namespaces and authpolicies, for a user called `rbactest1`:

```bash
kubectl apply -f - <<'EOF'
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: authpolicy-reader
rules:
- apiGroups: ["kuadrant.io"]
  resources: ["authpolicies"]
  verbs: ["list", "get", "watch"]
- apiGroups: [""]
  resources: ["namespaces"]
  verbs: ["list", "get", "watch"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRoleBinding
metadata:
  name: read-authpolicies-binding
subjects:
- kind: User
  name: rbactest1
  apiGroup: rbac.authorization.k8s.io
roleRef:
  kind: ClusterRole
  name: authpolicy-reader
  apiGroup: rbac.authorization.k8s.io
EOF
```