### PR TITLE
DRAFT: Visual coloring glitches on Plugin Overview Page

### DIFF
--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -655,7 +655,7 @@ const KuadrantOverviewPage: React.FC = () => {
               </Card>
             )}
 
-            <Flex className="pf-u-mt-xl">
+            <Flex className="pf-v5-u-mt-xl">
               <FlexItem flex={{ default: 'flex_1' }}>
                 <Card>
                   {/* TODO: Loading placeholder */}
@@ -731,7 +731,7 @@ const KuadrantOverviewPage: React.FC = () => {
               </FlexItem>
             </Flex>
 
-            <Flex className="pf-u-mt-xl">
+            <Flex className="pf-v5-u-mt-xl">
               {resourceRBAC['Gateway']?.list ? (
                 <FlexItem flex={{ default: 'flex_1' }}>
                   <Card>
@@ -740,7 +740,7 @@ const KuadrantOverviewPage: React.FC = () => {
                       {resourceRBAC['Gateway']?.create ? (
                         <Button
                           onClick={() => handleCreateResource('Gateway')}
-                          className="kuadrant-overview-create-button pf-u-mt-md pf-u-mr-md"
+                          className="kuadrant-overview-create-button pf-v5-u-mt-md pf-v5-u-mr-md"
                         >
                           {t(`Create Gateway`)}
                         </Button>
@@ -792,7 +792,7 @@ const KuadrantOverviewPage: React.FC = () => {
               )}
             </Flex>
 
-            <Flex className="pf-u-mt-xl">
+            <Flex className="pf-v5-u-mt-xl">
               {policyRBACNill ? (
                 <FlexItem flex={{ default: 'flex_1' }}>
                   <Card>
@@ -831,7 +831,7 @@ const KuadrantOverviewPage: React.FC = () => {
                             onClick={onToggleClick}
                             isExpanded={isCreateOpen}
                             variant="primary"
-                            className="kuadrant-overview-create-button pf-u-mt-md pf-u-mr-md"
+                            className="kuadrant-overview-create-button pf-v5-u-mt-md pf-v5-u-mr-md"
                           >
                             {t('Create Policy')}
                           </MenuToggle>
@@ -883,7 +883,7 @@ const KuadrantOverviewPage: React.FC = () => {
                       {resourceRBAC['HTTPRoute']?.create ? (
                         <Button
                           onClick={() => handleCreateResource('HTTPRoute')}
-                          className="kuadrant-overview-create-button pf-u-mt-md pf-u-mr-md"
+                          className="kuadrant-overview-create-button pf-v5-u-mt-md pf-v5-u-mr-md"
                         >
                           {t(`Create HTTPRoute`)}
                         </Button>

--- a/src/components/kuadrant.css
+++ b/src/components/kuadrant.css
@@ -140,6 +140,12 @@
   justify-content: flex-start;
 }
 
+.pf-v5-theme-dark .kuadrant-pagination-left {
+  display: flex;
+  justify-content: flex-start;
+  background-color: var(--pf-v5-global--BackgroundColor--100) !important; /* OCP 4.19 background color */
+}
+
 .kuadrant-policy-list-body {
   width: 100%;
 }
@@ -162,4 +168,12 @@
 .popover-codes {
   max-height: 240px;
   overflow-y: auto;
+}
+
+.pf-v5-theme-dark .pf-m-compact {
+  background-color: var(--pf-v5-global--BackgroundColor--100) !important; /* Note: OCP 4.19 background color */
+}
+
+.pf-v5-theme-dark .pf-m-border-rows {
+  background-color: var(--pf-v5-global--BackgroundColor--100) !important; /* Note: OCP 4.19 background color */
 }

--- a/src/components/kuadrant.css
+++ b/src/components/kuadrant.css
@@ -78,19 +78,19 @@
 }
 
 .kuadrant-dashboard-learning {
-  color: var(--pf-global--palette--purple-700);
+  color: var(--pf-v5-global--palette--purple-700);
 }
 
-.pf-theme-dark .kuadrant-dashboard-learning {
+.pf-v5-theme-dark .kuadrant-dashboard-learning {
   color: var(--pf-v5-global--palette--purple-200);
 }
 
 .kuadrant-dashboard-feature-highlights {
-  color: var(--pf-global--palette--blue-300);
+  color: var(--pf-v5-global--palette--blue-300);
 }
 
 .kuadrant-dashboard-enhance {
-  color: var(--pf-global--palette--orange-400);
+  color: var(--pf-v5-global--palette--orange-400);
 }
 
 .kuadrant-dashboard-resource-link {


### PR DESCRIPTION
Ref: https://github.com/Kuadrant/kuadrant-console-plugin/issues/254

### What is the bug?
While testing on OCP 4.19, user reported some visual bugs in Overview page of the plugin.

- Coloring on texts in Getting started resources section seems to not apply
- Background coloring in lists of resources seem to not match the new OCP 4.19 background color

### To reproduce
1. Visit Kuadrant Overview Page using side menu
2. Note the differences using OCP 4.17/4.18 overview pages as comparison

### It was
![image](https://github.com/user-attachments/assets/5f4bcaf5-a7ae-49dd-a291-c887a1b4985b)
![image](https://github.com/user-attachments/assets/e39e4674-574c-400b-82a0-004f092ee88f)


### It is now
![image](https://github.com/user-attachments/assets/ef0fa126-0c5d-4444-9c0d-e0574ab9211f)
![image](https://github.com/user-attachments/assets/ce9c27ed-0204-45cc-b973-0800b3ce4520)
![image](https://github.com/user-attachments/assets/52dd8e7b-5595-4a3f-996b-1a164db94281)

