### PR TITLE
Fix Secure, Protect, Connect Broken link on Overview Page

### DIFF
--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -19,7 +19,7 @@ export const EXTERNAL_LINKS = {
   documentation: 'https://docs.kuadrant.io',
   releaseNotes: 'https://github.com/Kuadrant/kuadrant-operator/releases',
   secureConnectProtect:
-    'https://docs.kuadrant.io/latest/kuadrant-operator/doc/user-guides/secure-protect-connect-single-multi-cluster/',
+    'https://docs.kuadrant.io/latest/kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect/',
   highlights: 'https://kuadrant.io/blog/',
   blog: 'https://kuadrant.io/blog/',
 };


### PR DESCRIPTION
Fixing secure, protect & connect user guide link on overview page as it is broken

Closes: https://github.com/Kuadrant/kuadrant-console-plugin/issues/270