### PR TITLE
fix dns/tls policy edit to use forms

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -120,6 +120,28 @@
     }
   },
   {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1",
+        "kind": "DNSPolicy"
+      },
+      "provider": { "$codeRef": "useDNSPolicyActions" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
+        "group": "kuadrant.io",
+        "version": "v1",
+        "kind": "TLSPolicy"
+      },
+      "provider": { "$codeRef": "useTLSPolicyActions" }
+    }
+  },
+  {
     "type": "console.navigation/section",
     "properties": {
       "id": "kuadrant-section-admin",

--- a/package.json
+++ b/package.json
@@ -79,7 +79,9 @@
       "KuadrantRateLimitPolicyCreatePage": "./components/KuadrantRateLimitPolicyCreatePage",
       "KuadrantTLSCreatePage": "./components/KuadrantTLSCreatePage",
       "HTTPRoutePoliciesPage": "./components/HTTPRoutePoliciesPage",
-      "GatewayPoliciesPage": "./components/GatewayPoliciesPage"
+      "GatewayPoliciesPage": "./components/GatewayPoliciesPage",
+      "useDNSPolicyActions": "./components/dnspolicy/useDNSPolicyActions",
+      "useTLSPolicyActions": "./components/tlspolicy/useTLSPolicyActions"
     },
     "dependencies": {
       "@console/pluginAPI": "*"

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -8,7 +8,6 @@ import {
   HelperText,
   HelperTextItem,
   FormHelperText,
-  Page,
   PageSection,
   Title,
   Radio,
@@ -232,129 +231,127 @@ const KuadrantTLSCreatePage: React.FC = () => {
           {create ? t('Create TLS Policy') : t('Edit TLS Policy')}
         </title>
       </Helmet>
-      <Page>
-        <PageSection hasBodyWrapper={false} className="pf-m-no-padding">
-          <div className="co-m-nav-title">
-            <Title headingLevel="h1">{create ? 'Create TLS Policy' : 'Edit TLS Policy'}</Title>
-            <p className="help-block co-m-pane__heading-help-text">
-              <div>
-                {t(
-                  'Targets Gateway API networking resources Gateways to provide TLS for gateway listeners by managing the lifecycle of TLS certificates using cert-manager',
-                )}
-              </div>
-            </p>
-          </div>
-          <FormGroup
-            className="kuadrant-editor-toggle"
-            role="radiogroup"
-            isInline
-            hasNoPaddingTop
-            fieldId="create-type-radio-group"
-            label={t('Configure via')}
-          >
-            <Flex alignItems={{ default: 'alignItemsCenter' }}>
-              <FlexItem>
-                <Radio
-                  label={t('Form View')}
-                  isChecked={view === 'form'}
-                  onChange={() => setView('form')}
-                  id="form-view"
-                  name="view-toggle"
-                />
-              </FlexItem>
-              <FlexItem>
-                <Radio
-                  label={t('YAML View')}
-                  isChecked={view === 'yaml'}
-                  onChange={() => setView('yaml')}
-                  id="yaml-view"
-                  name="view-toggle"
-                />
-              </FlexItem>
-            </Flex>
-          </FormGroup>
-        </PageSection>
-        {view === 'form' ? (
-          <PageSection hasBodyWrapper={false}>
-            <Form className="co-m-pane__form">
-              <FormGroup label={t('Policy name')} isRequired fieldId="simple-form-policy-name-01">
-                <TextInput
-                  isRequired
-                  type="text"
-                  id="simple-form-policy-name-01"
-                  name="simple-form-policy-name-01"
-                  aria-describedby="simple-form-policy-name-01-helper"
-                  value={policyName}
-                  onChange={handleNameChange}
-                  isDisabled={formDisabled}
-                  placeholder={t('Policy name')}
-                />
-                <FormHelperText>
-                  <HelperText>
-                    <HelperTextItem>{t('Unique name of the TLSPolicy.')}</HelperTextItem>
-                  </HelperText>
-                </FormHelperText>
-              </FormGroup>
-              <GatewaySelect selectedGateway={selectedGateway} onChange={setSelectedGateway} />
-              <FormGroup
-                role="radiogroup"
-                isInline
-                fieldId="cert-manager-issuer"
-                label={t('Cert manager issuer type')}
-                isRequired
-                aria-labelledby="issuer-label"
-              >
-                <Radio
-                  label={t('Cluster issuer')}
-                  isChecked={certIssuerType === 'clusterissuer'}
-                  onChange={() => {
-                    setCertIssuerType('clusterissuer');
-                  }}
-                  id="cluster-issuer"
-                  name="issuer"
-                />
-                <Radio
-                  label={t('Issuer')}
-                  isChecked={certIssuerType === 'issuer'}
-                  onChange={() => {
-                    setCertIssuerType('issuer');
-                  }}
-                  id="issuer"
-                  name="issuer"
-                />
-              </FormGroup>
-              {certIssuerType === 'clusterissuer' ? (
-                <ClusterIssuerSelect
-                  selectedClusterIssuer={selectedClusterIssuers}
-                  onChange={setSelectedClusterIssuers}
-                />
-              ) : (
-                <IssuerSelect selectedIssuer={selectedIssuer} onChange={setSelectedIssuers} />
+      <PageSection hasBodyWrapper={false} className="pf-m-no-padding">
+        <div className="co-m-nav-title">
+          <Title headingLevel="h1">{create ? 'Create TLS Policy' : 'Edit TLS Policy'}</Title>
+          <p className="help-block co-m-pane__heading-help-text">
+            <div>
+              {t(
+                'Targets Gateway API networking resources Gateways to provide TLS for gateway listeners by managing the lifecycle of TLS certificates using cert-manager',
               )}
-              <ActionGroup className="pf-u-mt-0">
-                <KuadrantCreateUpdate
-                  model={tlsPolicyModel}
-                  resource={tlsPolicy}
-                  policyType="tls"
-                  history={history}
-                  validation={isFormValid}
-                />
-                <Button variant="link" onClick={handleCancelResource}>
-                  {t('Cancel')}
-                </Button>
-              </ActionGroup>
-            </Form>
-          </PageSection>
-        ) : (
-          <React.Suspense fallback={<div> {t('Loading..')}.</div>}>
-            <ResourceYAMLEditor
-              initialResource={yamlInput}
-              create={create}
-              onChange={handleYAMLChange}
-            ></ResourceYAMLEditor>
-          </React.Suspense>
-        )}
-      </Page>
+            </div>
+          </p>
+        </div>
+        <FormGroup
+          className="kuadrant-editor-toggle"
+          role="radiogroup"
+          isInline
+          hasNoPaddingTop
+          fieldId="create-type-radio-group"
+          label={t('Configure via')}
+        >
+          <Flex alignItems={{ default: 'alignItemsCenter' }}>
+            <FlexItem>
+              <Radio
+                label={t('Form View')}
+                isChecked={view === 'form'}
+                onChange={() => setView('form')}
+                id="form-view"
+                name="view-toggle"
+              />
+            </FlexItem>
+            <FlexItem>
+              <Radio
+                label={t('YAML View')}
+                isChecked={view === 'yaml'}
+                onChange={() => setView('yaml')}
+                id="yaml-view"
+                name="view-toggle"
+              />
+            </FlexItem>
+          </Flex>
+        </FormGroup>
+      </PageSection>
+      {view === 'form' ? (
+        <PageSection hasBodyWrapper={false}>
+          <Form className="co-m-pane__form">
+            <FormGroup label={t('Policy name')} isRequired fieldId="simple-form-policy-name-01">
+              <TextInput
+                isRequired
+                type="text"
+                id="simple-form-policy-name-01"
+                name="simple-form-policy-name-01"
+                aria-describedby="simple-form-policy-name-01-helper"
+                value={policyName}
+                onChange={handleNameChange}
+                isDisabled={formDisabled}
+                placeholder={t('Policy name')}
+              />
+              <FormHelperText>
+                <HelperText>
+                  <HelperTextItem>{t('Unique name of the TLSPolicy.')}</HelperTextItem>
+                </HelperText>
+              </FormHelperText>
+            </FormGroup>
+            <GatewaySelect selectedGateway={selectedGateway} onChange={setSelectedGateway} />
+            <FormGroup
+              role="radiogroup"
+              isInline
+              fieldId="cert-manager-issuer"
+              label={t('Cert manager issuer type')}
+              isRequired
+              aria-labelledby="issuer-label"
+            >
+              <Radio
+                label={t('Cluster issuer')}
+                isChecked={certIssuerType === 'clusterissuer'}
+                onChange={() => {
+                  setCertIssuerType('clusterissuer');
+                }}
+                id="cluster-issuer"
+                name="issuer"
+              />
+              <Radio
+                label={t('Issuer')}
+                isChecked={certIssuerType === 'issuer'}
+                onChange={() => {
+                  setCertIssuerType('issuer');
+                }}
+                id="issuer"
+                name="issuer"
+              />
+            </FormGroup>
+            {certIssuerType === 'clusterissuer' ? (
+              <ClusterIssuerSelect
+                selectedClusterIssuer={selectedClusterIssuers}
+                onChange={setSelectedClusterIssuers}
+              />
+            ) : (
+              <IssuerSelect selectedIssuer={selectedIssuer} onChange={setSelectedIssuers} />
+            )}
+            <ActionGroup className="pf-u-mt-0">
+              <KuadrantCreateUpdate
+                model={tlsPolicyModel}
+                resource={tlsPolicy}
+                policyType="tls"
+                history={history}
+                validation={isFormValid}
+              />
+              <Button variant="link" onClick={handleCancelResource}>
+                {t('Cancel')}
+              </Button>
+            </ActionGroup>
+          </Form>
+        </PageSection>
+      ) : (
+        <React.Suspense fallback={<div> {t('Loading..')}.</div>}>
+          <ResourceYAMLEditor
+            initialResource={yamlInput}
+            create={create}
+            onChange={handleYAMLChange}
+          ></ResourceYAMLEditor>
+        </React.Suspense>
+      )}
     </>
   );
 };

--- a/src/components/dnspolicy/useDNSPolicyActions.tsx
+++ b/src/components/dnspolicy/useDNSPolicyActions.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
+import {
+  K8sResourceCommon,
+  useK8sModel,
+  getGroupVersionKindForResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { AccessReviewResourceAttributes } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+import {
+  useAnnotationsModal,
+  useDeleteModal,
+  useLabelsModal,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+const useDNSPolicyActions = (obj: K8sResourceCommon): ExtensionHookResult<Action[]> => {
+  const history = useHistory();
+  const gvk = obj ? getGroupVersionKindForResource(obj) : undefined;
+  const [dnsPolicyModel] = useK8sModel(
+    gvk
+      ? { group: gvk.group, version: gvk.version, kind: gvk.kind }
+      : { group: '', version: '', kind: '' },
+  );
+  const launchDeleteModal = useDeleteModal(obj);
+  const launchLabelsModal = useLabelsModal(obj);
+  const launchAnnotationsModal = useAnnotationsModal(obj);
+
+  const actions = React.useMemo<Action[]>(() => {
+    if (!obj || obj.kind !== 'DNSPolicy') return [];
+    const namespace = obj.metadata?.namespace || 'default';
+    const name = obj.metadata?.name || '';
+
+    const updateAccess: AccessReviewResourceAttributes | undefined = dnsPolicyModel
+      ? {
+          group: dnsPolicyModel.apiGroup,
+          resource: dnsPolicyModel.plural,
+          verb: 'update',
+          name,
+          namespace,
+        }
+      : undefined;
+    const deleteAccess: AccessReviewResourceAttributes | undefined = dnsPolicyModel
+      ? {
+          group: dnsPolicyModel.apiGroup,
+          resource: dnsPolicyModel.plural,
+          verb: 'delete',
+          name,
+          namespace,
+        }
+      : undefined;
+
+    const actionsList: Action[] = [
+      {
+        id: 'edit-labels-dnspolicy',
+        label: 'Edit labels',
+        cta: launchLabelsModal,
+        accessReview: updateAccess,
+      },
+      {
+        id: 'edit-annotations-dnspolicy',
+        label: 'Edit annotations',
+        cta: launchAnnotationsModal,
+        accessReview: updateAccess,
+      },
+      {
+        id: 'kuadrant-dns-policy-edit-form',
+        label: 'Edit',
+        description: 'Edit via form',
+        cta: () =>
+          history.push({
+            pathname: `/k8s/ns/${namespace}/dnspolicy/name/${name}/edit`,
+          }),
+        insertBefore: 'edit-yaml',
+        accessReview: updateAccess,
+      },
+      {
+        id: 'delete-dnspolicy',
+        label: 'Delete',
+        cta: launchDeleteModal,
+        accessReview: deleteAccess,
+      },
+    ];
+
+    return actionsList;
+  }, [history, obj, dnsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
+
+  return [actions, true, undefined];
+};
+
+export default useDNSPolicyActions;

--- a/src/components/tlspolicy/useTLSPolicyActions.tsx
+++ b/src/components/tlspolicy/useTLSPolicyActions.tsx
@@ -1,0 +1,91 @@
+import * as React from 'react';
+import { useHistory } from 'react-router-dom';
+import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
+import {
+  K8sResourceCommon,
+  useK8sModel,
+  getGroupVersionKindForResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { AccessReviewResourceAttributes } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+import {
+  useAnnotationsModal,
+  useDeleteModal,
+  useLabelsModal,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+const useTLSPolicyActions = (obj: K8sResourceCommon): ExtensionHookResult<Action[]> => {
+  const history = useHistory();
+  const gvk = obj ? getGroupVersionKindForResource(obj) : undefined;
+  const [tlsPolicyModel] = useK8sModel(
+    gvk
+      ? { group: gvk.group, version: gvk.version, kind: gvk.kind }
+      : { group: '', version: '', kind: '' },
+  );
+  const launchDeleteModal = useDeleteModal(obj);
+  const launchLabelsModal = useLabelsModal(obj);
+  const launchAnnotationsModal = useAnnotationsModal(obj);
+
+  const actions = React.useMemo<Action[]>(() => {
+    if (!obj || obj.kind !== 'TLSPolicy') return [];
+    const namespace = obj.metadata?.namespace || 'default';
+    const name = obj.metadata?.name || '';
+
+    const updateAccess: AccessReviewResourceAttributes | undefined = tlsPolicyModel
+      ? {
+          group: tlsPolicyModel.apiGroup,
+          resource: tlsPolicyModel.plural,
+          verb: 'update',
+          name,
+          namespace,
+        }
+      : undefined;
+    const deleteAccess: AccessReviewResourceAttributes | undefined = tlsPolicyModel
+      ? {
+          group: tlsPolicyModel.apiGroup,
+          resource: tlsPolicyModel.plural,
+          verb: 'delete',
+          name,
+          namespace,
+        }
+      : undefined;
+
+    const actionsList: Action[] = [
+      {
+        id: 'edit-labels-tlspolicy',
+        label: 'Edit labels',
+        cta: launchLabelsModal,
+        accessReview: updateAccess,
+      },
+      {
+        id: 'edit-annotations-tlspolicy',
+        label: 'Edit annotations',
+        cta: launchAnnotationsModal,
+        accessReview: updateAccess,
+      },
+      {
+        id: 'kuadrant-tls-policy-edit-form',
+        label: 'Edit',
+        description: 'Edit via form',
+        cta: () =>
+          history.push({
+            pathname: `/k8s/ns/${namespace}/tlspolicy/name/${name}/edit`,
+          }),
+        insertBefore: 'edit-yaml',
+        accessReview: updateAccess,
+      },
+      {
+        id: 'delete-tlspolicy',
+        label: 'Delete',
+        cta: launchDeleteModal,
+        accessReview: deleteAccess,
+      },
+    ];
+
+    return actionsList;
+  }, [history, obj, tlsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
+
+  return [actions, true, undefined];
+};
+
+export default useTLSPolicyActions;


### PR DESCRIPTION
Searching for TLS/DNS policies and clicking on three dots should now bring you to the custom form page when editing.