### PR TITLE
.yarnrc.yml: fetch packages for both x64 and arm64 CPUs on Linux

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,12 @@
+# This instructs Yarn to fetch packages for both x64 and arm64 CPUs
+# on Linux, which is the typical build environment for Konflux.
+supportedArchitectures:
+  cpu:
+    - x64
+    - arm64
+  os:
+    - linux
+
 nodeLinker: node-modules
 
 # Enable Corepack for version management


### PR DESCRIPTION
Required to build in offline environments where prefetching deps is usually a preparation step. 