### PR TITLE
bug: topology permissions check using wrong verb

### DIFF
--- a/src/components/DropdownWithKebab.tsx
+++ b/src/components/DropdownWithKebab.tsx
@@ -17,9 +17,9 @@ import {
 
 import { k8sDelete, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import { useHistory } from 'react-router-dom';
-import { resourceGVKMapping } from '../utils/resources';
+import { RESOURCES, ResourceKind } from '../utils/resources';
 import useAccessReviews from '../utils/resourceRBAC';
-import { getModelFromResource } from '../utils/getModelFromResource';
+import { getModelFromResource, getResourceNameFromKind } from '../utils/getModelFromResource';
 type DropdownWithKebabProps = {
   obj: K8sResourceCommon;
 };
@@ -48,7 +48,10 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
   const policyType = obj.kind.toLowerCase();
 
   const resourceGVK: { group: string; kind: string }[] = [
-    { group: resourceGVKMapping[obj.kind].group, kind: obj.kind },
+    {
+      group: RESOURCES[obj.kind as ResourceKind].gvk.group,
+      kind: getResourceNameFromKind(obj.kind),
+    },
   ];
   const { userRBAC, loading: rbacLoading } = useAccessReviews(resourceGVK);
   const resourceRBAC = [

--- a/src/components/PolicyTopologyPage.tsx
+++ b/src/components/PolicyTopologyPage.tsx
@@ -113,8 +113,8 @@ const PolicyTopologyPage: React.FC = () => {
     return config
       ? {
           group: '',
-          resource: 'ConfigMap',
-          verb: 'read' as K8sVerb,
+          resource: 'configmaps',
+          verb: 'get' as K8sVerb,
           namespace: config.TOPOLOGY_CONFIGMAP_NAMESPACE,
           name: config.TOPOLOGY_CONFIGMAP_NAME,
         }

--- a/src/components/ResourceList.tsx
+++ b/src/components/ResourceList.tsx
@@ -282,7 +282,13 @@ const ResourceList: React.FC<ResourceListProps> = ({
                   </TableData>
                 );
               case 'target': {
-                const targetRef = (obj as any).spec?.targetRef;
+                const targetRef = (
+                  obj as K8sResourceCommon & {
+                    spec?: {
+                      targetRef?: { group: string; version?: string; kind: string; name: string };
+                    };
+                  }
+                ).spec?.targetRef;
                 return (
                   <TableData key={column.id} id={column.id} activeColumnIDs={activeColumnIDs}>
                     {targetRef ? (


### PR DESCRIPTION
Bug spotted by a user setting up a role for topology viewing. Their role was setup correctly, but our check of the permission was not. This fixes it - the wrong verb was used in the check.

This will be followed up a proper RBAC e2e test suite, to catch things like this.