### PR TITLE
chore(deps): fix CVE-2026-4800 (lodash) and CVE-2026-29063 (immutable)

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "resolutions": {
     "http-proxy-middleware": "2.0.7",
-    "lodash": "4.17.23",
+    "immutable": "3.8.3",
+    "lodash": "4.18.0",
     "node-forge": "^1.3.2",
     "qs": "6.14.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7552,10 +7552,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:3.x":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+"immutable@npm:3.8.3":
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
   languageName: node
   linkType: hard
 
@@ -8743,10 +8743,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.0":
+  version: 4.18.0
+  resolution: "lodash@npm:4.18.0"
+  checksum: 10c0/0c5a7c5a4ea1db59ade40ff03cc8bfc7ea79806f5639ff4c7ee581811c8d88248bf1da608199b9d3614d8db133088bd434f3307c3951a96a821044f72a5ba810
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumps `lodash` resolution from 4.17.23 to 4.18.0 (fixes CVE-2026-4800, CVSS 8.1)
- Adds `immutable` resolution pinned to 3.8.3 (fixes CVE-2026-29063, CVSS 8.8)

Both are transitive dependencies. The plugin does not directly import or use either library.

## CVE Details

| CVE | Package | From | To | CVSS |
|-----|---------|------|----|------|
| CVE-2026-4800 | lodash | 4.17.23 | 4.18.0 | 8.1 (High) |
| CVE-2026-29063 | immutable | 3.8.2 | 3.8.3 | 8.8 (High) |

## Test plan

CI — no source code changes, only transitive dependency version bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)