### PR TITLE
v0.3.7 patch release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuadrant-console-plugin",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "Kuadrant OpenShift Console plugin",
   "private": true,
   "license": "Apache-2.0",
@@ -74,7 +74,7 @@
   },
   "consolePlugin": {
     "name": "kuadrant-console-plugin",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "displayName": "Kuadrant OpenShift Console Plugin",
     "description": "Kuadrant OpenShift Console Plugin",
     "latestSupportedOpenshiftVersion": "4.19",


### PR DESCRIPTION
## Summary

Patch release `v0.3.7` — cherry-picked fixes from `main` onto `release-v0.3` (branched from `v0.3.6`).

This branch contains 10 cherry-picked PRs + version bump. Once merged, tag `v0.3.7` from `release-v0.3`.

### Bug fixes
- #325 — Fix connectivity-link release notes and cert-manager operator links on OCP 4.20/4.21
- #329 — Fix metrics (refactored config loading, helm chart metrics config)
- #331 — Fix navigation compatibility (replace deprecated `useHistory` with `useNavigate`)
- #335 — Fix page refresh every 20 seconds on KuadrantPoliciesPage
- #342 — Fix missing i18n keys
- #352 — Namespace-scoped overview page (fixes #298)

### Security
- #359 — Fix CVE-2026-4800 (lodash) and CVE-2026-29063 (immutable)
- #300 — Bump ajv from 6.12.6 to 6.14.0

### Platform support
- #332 — Add s390x to dev and release multi-arch builds
- #319 — Dev image build improvements (prerequisite for #332)

### Not included (deferred to v0.4.0)
- #344 — API Management RBAC
- #349 — API Product List & Details pages
- #345 — Dev portal design doc
- #339 — replace minc with oinc
- #363 — API key projection redesign

## Test plan
- [ ] Verify console plugin loads correctly on OCP 4.20 and 4.21
- [ ] Verify overview page renders in both cluster-scoped and namespace-scoped modes
- [ ] Verify policies page does not auto-refresh every 20 seconds
- [ ] Verify metrics/observability section loads correctly
- [ ] Verify navigation works without `useHistory` deprecation warnings
- [ ] Verify i18n keys resolve for all UI strings
- [ ] Run e2e tests against the built image

🤖 Generated with [Claude Code](https://claude.com/claude-code)