### PR TITLE
Fix incorrect resource filter badge count due to duplicate selections

### DIFF
--- a/src/components/PolicyTopologyPage.tsx
+++ b/src/components/PolicyTopologyPage.tsx
@@ -29,21 +29,23 @@ const PolicyTopologyPage: React.FC = () => {
   const [selectedResourceTypes, setSelectedResourceTypes] = React.useState<string[]>([]);
   const [selectedNamespace, setSelectedNamespace] = React.useState<string | null>(null);
 
-  // filter handlers
+  // filter handlers (functional updates + dedupe so count badge cannot drift from unique selections)
   const onResourceSelect = (
     _event: React.MouseEvent | React.ChangeEvent | undefined,
     selection: string,
   ) => {
-    if (selectedResourceTypes.includes(selection)) {
-      setSelectedResourceTypes(selectedResourceTypes.filter((r) => r !== selection));
-    } else {
-      setSelectedResourceTypes([...selectedResourceTypes, selection]);
-    }
+    setSelectedResourceTypes((prev) => {
+      const unique = [...new Set(prev)];
+      if (unique.includes(selection)) {
+        return unique.filter((r) => r !== selection);
+      }
+      return [...unique, selection];
+    });
   };
 
   const onDeleteResourceFilter = (_category: string, chip: string) => {
     if (chip) {
-      setSelectedResourceTypes(selectedResourceTypes.filter((r) => r !== chip));
+      setSelectedResourceTypes((prev) => [...new Set(prev)].filter((r) => r !== chip));
     }
   };
 
@@ -103,7 +105,7 @@ const PolicyTopologyPage: React.FC = () => {
     configMapData: configMap?.data?.topology || null,
     selectedResourceTypes,
     selectedNamespace,
-    onInitialSelection: setSelectedResourceTypes,
+    onInitialSelection: (types) => setSelectedResourceTypes([...new Set(types)]),
     loaded,
     loadError,
   });

--- a/src/components/topology/ResourceFilterToolbar.tsx
+++ b/src/components/topology/ResourceFilterToolbar.tsx
@@ -47,6 +47,12 @@ export const ResourceFilterToolbar: React.FC<ResourceFilterToolbarProps> = ({
   const [isOpen, setIsOpen] = React.useState(false);
   const [isNamespaceOpen, setIsNamespaceOpen] = React.useState(false);
 
+  // Dedupe for label chips, badge count, and Select value — duplicates break ToolbarFilter keys and inflate the badge.
+  const uniqueSelectedResourceTypes = React.useMemo(
+    () => [...new Set(selectedResourceTypes)],
+    [selectedResourceTypes],
+  );
+
   const handleSelect = (
     event: React.MouseEvent | React.ChangeEvent | undefined,
     selection: string,
@@ -72,7 +78,7 @@ export const ResourceFilterToolbar: React.FC<ResourceFilterToolbarProps> = ({
         <ToolbarItem variant="label-group">
           <ToolbarFilter
             categoryName="Resource"
-            labels={selectedResourceTypes}
+            labels={uniqueSelectedResourceTypes}
             deleteLabel={handleDeleteLabel}
             deleteLabelGroup={onDeleteGroup}
           >
@@ -82,12 +88,12 @@ export const ResourceFilterToolbar: React.FC<ResourceFilterToolbarProps> = ({
               isOpen={isOpen}
               onOpenChange={setIsOpen}
               onSelect={handleSelect}
-              selected={selectedResourceTypes}
+              selected={uniqueSelectedResourceTypes}
               toggle={(toggleRef: React.Ref<MenuToggleElement>) => (
                 <MenuToggle ref={toggleRef} onClick={() => setIsOpen(!isOpen)} isExpanded={isOpen}>
                   Resource{' '}
-                  {selectedResourceTypes.length > 0 && (
-                    <Badge isRead>{selectedResourceTypes.length}</Badge>
+                  {uniqueSelectedResourceTypes.length > 0 && (
+                    <Badge isRead>{uniqueSelectedResourceTypes.length}</Badge>
                   )}
                 </MenuToggle>
               )}
@@ -98,7 +104,7 @@ export const ResourceFilterToolbar: React.FC<ResourceFilterToolbarProps> = ({
                     key={type}
                     value={type}
                     hasCheckbox
-                    isSelected={selectedResourceTypes.includes(type)}
+                    isSelected={uniqueSelectedResourceTypes.includes(type)}
                   >
                     {type}
                   </SelectOption>

--- a/src/hooks/topology/useTopologyData.ts
+++ b/src/hooks/topology/useTopologyData.ts
@@ -74,13 +74,19 @@ export const useTopologyData = ({
       });
       setAllNamespaces(Array.from(namespaces).sort());
 
+      // Ensure unique resource types so the badge count matches actual selections.
+      // Duplicates can appear due to state updates and inflate the count.
+      const normalizedResourceSelection = [...new Set(selectedResourceTypes)].filter((r) =>
+        uniqueTypes.includes(r),
+      );
+
       // on initial load, default to showByDefault set
-      let activeSelection = selectedResourceTypes.filter((r) => uniqueTypes.includes(r));
-      if (selectedResourceTypes.length === 0 && isInitialLoad) {
+      let activeSelection = normalizedResourceSelection;
+      if (normalizedResourceSelection.length === 0 && isInitialLoad) {
         activeSelection = uniqueTypes.filter((t) => showByDefault.has(t));
         // notify parent component to update its state
         if (onInitialSelection && activeSelection.length > 0) {
-          onInitialSelection(activeSelection);
+          onInitialSelection([...new Set(activeSelection)]);
         }
       }
 


### PR DESCRIPTION
The resource filter badge count could sometimes show a higher number than the actual selected filters (e.g. 12/13 instead of 8).

This was happening because duplicate entries could end up in `selectedResourceTypes`, especially during rapid updates or due to stale state. Since the badge relied on array length, it counted duplicates as separate items.

Changes:
- Ensure selection is always treated as a unique set
- Use functional state updates to avoid stale/duplicate entries
- Align badge count and toolbar filter labels with the deduplicated selection

This keeps the badge count consistent with what is actually selected.

Note: Reset behavior between PF5 and PF6 is left unchanged since that appears to be a separate product decision.

Fixes #373

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate resource type entries that caused inflated badge counts and repeated filter labels.
  * Filter add/delete logic now deduplicates selections to ensure consistent behaviour across topology resource controls.
  * Initial resource-type selection is normalised on load to remove duplicate entries when restoring preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->