### PR TITLE
Fix wrong navigation label in overview.md

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -30,7 +30,7 @@ kubectl patch consoles.operator.openshift.io cluster --type=merge \
   --patch '{"spec":{"plugins":["kuadrant-console-plugin"]}}'
 ```
 
-Refresh the console and the Connectivity Link section should appear in the navigation.
+Refresh the console and the **Kuadrant** section should appear in the navigation.
 
 ## Post-install: RBAC
 


### PR DESCRIPTION
Fixes a copy-paste mistake in the post-install section.

The console adds a **Kuadrant** section, but the docs were referring to "Connectivity Link". This could be confusing for users following the setup steps, since the UI label wouldn’t match what they see.

Updating the wording to reflect the correct console section makes the instructions consistent and easier to follow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation and enablement instructions to reflect that the Kuadrant section appears in the navigation following console refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->