### PR TITLE
Fix 'Hide for session' button cut off in overview card 

### DIFF
--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -258,6 +258,7 @@ const KuadrantOverviewPage: React.FC = () => {
     <>
       <Dropdown
         onSelect={onSelect}
+        popperProps={{ position: 'right' }}
         toggle={(toggleRef) => (
           <MenuToggle
             ref={toggleRef}


### PR DESCRIPTION
Fixed the button before 
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/f8868ba8-b5a8-42f3-ac13-e7ea6971738a" />
after :
<img width="3024" height="1964" alt="image" src="https://github.com/user-attachments/assets/7d7fe813-87a1-4af9-ba16-bec3ceea77cf" />
Closes #155

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the kebab menu dropdown on the Kuadrant Overview page to open to the right, improving visibility and interaction—particularly on narrower layouts and when near the page edge.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->