### PR TITLE
fix: replace latest image tag with versioned tag in install.yaml

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -26,7 +26,7 @@ spec:
     spec:
       containers:
       - name: kuadrant-console-plugin
-        image: quay.io/kuadrant/console-plugin:latest
+        image: quay.io/kuadrant/console-plugin:v0.3.6
         ports:
         - containerPort: 9443
           protocol: TCP


### PR DESCRIPTION
What
Replaces the `latest` image tag in install.yaml with a fixed version (v0.3.6).

Why :- 
Using `latest` makes deployments unpredictable, since the image can change over time. Pinning to a specific version ensures consistency across releases.

Changes :- 
 - Updated image reference in install.yaml to quay.io/kuadrant/console-plugin:v0.3.6

Notes :- 

1. Verified that v0.3.6 is the latest available release tag
2. Searched the repo to ensure no other usage of `latest` in manifests
3. Left README examples unchanged as they appear to be intended for local usage

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned console plugin container image to version v0.3.6 for improved deployment stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->