### PR TITLE
docs: add react-router v6 migration plan

### DIFF
--- a/REACT_ROUTER_MIGRATION.md
+++ b/REACT_ROUTER_MIGRATION.md
@@ -1,0 +1,66 @@
+# React Router v6/v7 Migration Plan
+
+> [!IMPORTANT]
+> This document is intended to guide incremental migration and should be executed in small, reviewable PRs.
+
+This document outlines the detailed upgrade path to migrate the Kuadrant Console Plugin from the `react-router-dom-v5-compat` layer to the native React Router v6/v7 routing architecture.
+
+## 1. Current State
+- The plugin uses `react-router-dom-v5-compat` to bridge old React Router v5 usage with v6.
+- All navigation hooks (`useNavigate`, `useParams`, `useLocation`) are already imported from the compat layer.
+- Routes still rely on the compatibility layer.
+
+## 2. Target State
+- Completely replace the compatibility package with native `react-router-dom` v6/v7.
+- Migrate to use the new `<Routes>` and `element` API.
+- Remove `react-router-dom-v5-compat` from `package.json`.
+
+## 3. Step-by-Step Transition Plan
+
+### Phase 1: Audit & Identify
+- Audit all files for any lingering v5 imports or usage.
+- Ensure exact alignment across exposed components.
+
+### Phase 2: Migrate Route Definitions
+- Transition root route definitions to the native `<Routes>` component.
+- Switch the `component` and `render` props to use the `element` prop.
+
+### Phase 3: Update Navigation & Context
+- Transition the `NavigateFunction` and hooks directly to the native `react-router-dom` package.
+
+### Phase 4: Remove Compat Layer
+- Remove the dependency from `package.json`.
+- Perform full validation and end-to-end routing testing.
+
+## 4. Candidate Areas for Migration
+- `src/components/DropdownWithKebab.tsx` (Update navigation logic)
+- `src/components/*Page.tsx` (Transition route usage)
+- `console-extensions.json` (Update route definitions)
+
+## 5. Risks & Mitigation
+- **Navigation breakage:** Incorrect route migration can break user workflows. Mitigate by doing phased changes.
+- **Inconsistent behavior:** Partial migration may lead to unexpected routing. Mitigate via comprehensive testing.
+- **Integration issues:** Changes need validation against OpenShift console dynamic plugin context.
+
+## 6. Suggested First Step
+- Migrate a single low-risk route from compat to native v6 to validate the approach before broader changes.
+
+## 7. Example Migration Diff
+
+### Before:
+```tsx
+import { Switch, Route } from 'react-router-dom';
+
+<Switch>
+  <Route path="/example" component={ExamplePage} />
+</Switch>
+```
+
+### After:
+```tsx
+import { Routes, Route } from 'react-router-dom';
+
+<Routes>
+  <Route path="/example" element={<ExamplePage />} />
+</Routes>
+```

--- a/src/utils/cancel.tsx
+++ b/src/utils/cancel.tsx
@@ -1,3 +1,7 @@
+/**
+ * Migration note: React Router v6 migration aligns routing patterns
+ * using the compatibility layer from 'react-router-dom-v5-compat'.
+ */
 import { NavigateFunction } from 'react-router-dom-v5-compat';
 
 export function handleCancel(namespace: string, data, navigate: NavigateFunction) {


### PR DESCRIPTION
What
Adds a migration plan for moving from the current compatibility layer to native React Router v6 APIs.

Why
The codebase already uses `react-router-dom-v5-compat`, but routing still depends on the compatibility layer. This document outlines a phased, incremental approach to complete the migration.

Details

1. Describes the current and target routing state
2. Provides a step-by-step migration plan
3. Includes example diffs for reference
4. Identifies candidate areas in the codebase
5. Highlights risks and mitigation strategies

Notes

1. No functional changes in this PR
2. Intended to guide future migration work in small, incremental steps