### PR TITLE
﻿fix: zero weight value silently dropped in DNSPolicy load balancing form

### DIFF
--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -99,7 +99,9 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
         ...(hasLoadBalancing
           ? {
               loadBalancing: {
-                ...(loadBalancing?.weight ? { weight: loadBalancing.weight } : {}),
+                ...(loadBalancing?.weight !== null && loadBalancing?.weight !== undefined
+                  ? { weight: loadBalancing.weight }
+                  : {}),
                 ...(loadBalancing?.geo ? { geo: loadBalancing.geo } : {}),
                 ...(loadBalancing.defaultGeo !== ''
                   ? { defaultGeo: loadBalancing.defaultGeo }


### PR DESCRIPTION
## What
Fixed a bug where a weight of 0 was silently dropped in the DNSPolicy creation form.

## Why
In JavaScript, 0 is falsy, so the existing truthiness check `loadBalancing?.weight ? ...` was evaluating to false and omitting the field from the generated YAML. This prevented users from deprioritizing endpoints using a 0 weight.

## Testing
- [x] Manually verified that entering 0 now appears correctly in the YAML view.
- [x] `yarn lint` passes.

Fixes #395


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed DNS Policy creation to properly include all weight configuration values in the generated output, even when set to zero.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->