### PR TITLE
fix: wrap untranslated strings with i18n t() and use strict equality operators

### DIFF
--- a/src/components/DropdownWithKebab.tsx
+++ b/src/components/DropdownWithKebab.tsx
@@ -126,7 +126,7 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
         shouldFocusToggleOnSelect
       >
         <DropdownList>
-          {!rbacLoading && resourceRBAC[obj.kind]['edit'] == true ? (
+          {!rbacLoading && resourceRBAC[obj.kind]['edit'] === true ? (
             <DropdownItem value="edit" key="edit" onClick={onEditClick}>
               Edit
             </DropdownItem>
@@ -142,7 +142,7 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
               </DropdownItem>
             </Tooltip>
           )}
-          {!rbacLoading && resourceRBAC[obj.kind]['delete'] == true ? (
+          {!rbacLoading && resourceRBAC[obj.kind]['delete'] === true ? (
             <DropdownItem value="delete" key="delete">
               Delete
             </DropdownItem>

--- a/src/components/KuadrantAuthPolicyCreatePage.tsx
+++ b/src/components/KuadrantAuthPolicyCreatePage.tsx
@@ -83,7 +83,7 @@ const KuadrantAuthPolicyCreatePage: React.FC = () => {
         </ModalBody>
         <ModalFooter>
           <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            OK
+            {t('OK')}
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/components/KuadrantCreateUpdate.tsx
+++ b/src/components/KuadrantCreateUpdate.tsx
@@ -72,7 +72,7 @@ const KuadrantCreateUpdate: React.FC<GenericPolicyForm> = ({
   };
   return (
     <>
-      {errorAlertMsg != '' && (
+      {errorAlertMsg !== '' && (
         <AlertGroup className="kuadrant-alert-group">
           <Alert
             title={

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -74,10 +74,10 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
       healthCheck.endpoint ||
       healthCheck.failureThreshold ||
       healthCheck.port ||
-      healthCheck.protocol != '';
+      healthCheck.protocol !== '';
 
     const hasLoadBalancing =
-      loadBalancing.geo || loadBalancing.defaultGeo != '' || loadBalancing.weight;
+      loadBalancing.geo || loadBalancing.defaultGeo !== '' || loadBalancing.weight;
 
     return {
       apiVersion:

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -59,7 +59,7 @@ const KuadrantOIDCPolicyCreatePage: React.FC = () => {
         </ModalBody>
         <ModalFooter>
           <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            OK
+            {t('OK')}
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/components/KuadrantPlanPolicyCreatePage.tsx
+++ b/src/components/KuadrantPlanPolicyCreatePage.tsx
@@ -64,7 +64,7 @@ const KuadrantPlanPolicyCreatePage: React.FC = () => {
         </ModalBody>
         <ModalFooter>
           <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            OK
+            {t('OK')}
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/components/KuadrantRateLimitPolicyCreatePage.tsx
+++ b/src/components/KuadrantRateLimitPolicyCreatePage.tsx
@@ -76,7 +76,7 @@ const KuadrantRateLimitPolicyCreatePage: React.FC = () => {
         </ModalBody>
         <ModalFooter>
           <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            OK
+            {t('OK')}
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -232,7 +232,7 @@ const KuadrantTLSCreatePage: React.FC = () => {
       </Helmet>
       <PageSection hasBodyWrapper={false} className="pf-m-no-padding">
         <div className="co-m-nav-title">
-          <Title headingLevel="h1">{create ? 'Create TLS Policy' : 'Edit TLS Policy'}</Title>
+          <Title headingLevel="h1">{create ? t('Create TLS Policy') : t('Edit TLS Policy')}</Title>
           <p className="help-block">
             {t(
               'Targets Gateway API networking resources Gateways to provide TLS for gateway listeners by managing the lifecycle of TLS certificates using cert-manager',

--- a/src/components/KuadrantTokenRateLimitPolicyCreatePage.tsx
+++ b/src/components/KuadrantTokenRateLimitPolicyCreatePage.tsx
@@ -71,7 +71,7 @@ const KuadrantTokenRateLimitPolicyCreatePage: React.FC = () => {
         </ModalBody>
         <ModalFooter>
           <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            OK
+            {t('OK')}
           </Button>
         </ModalFooter>
       </Modal>


### PR DESCRIPTION
## Summary

Fix i18n compliance and code quality issues across multiple policy creation pages and shared components.

## Changes

### i18n: Missing translation wrappers
- **KuadrantTLSCreatePage**: `<Title>` heading used hardcoded English strings instead of `t()` — the `<Helmet>` title on the line above was already translated, but the visible heading was not
- **5 policy create pages**: "OK" button text in error modals was bare English instead of `{t('OK')}`. The translation key already exists in the locale file but wasn't being used
  - `KuadrantAuthPolicyCreatePage`
  - `KuadrantOIDCPolicyCreatePage`
  - `KuadrantRateLimitPolicyCreatePage`
  - `KuadrantTokenRateLimitPolicyCreatePage`
  - `KuadrantPlanPolicyCreatePage`

### Code quality: Strict equality operators
- **KuadrantDNSPolicyCreatePage**: `!=` → `!==` in `hasHealthCheck` and `hasLoadBalancing` checks (lines 77, 80)
- **KuadrantCreateUpdate**: `!=` → `!==` in error alert conditional (line 75)
- **DropdownWithKebab**: `==` → `===` in RBAC permission checks for edit/delete actions (lines 129, 145)

## Why

- Untranslated strings break i18n for non-English users
- Loose equality (`!=`, `==`) uses type coercion which can cause subtle bugs — strict equality (`!==`, `===`) is the project convention

## Verification

- [x] `yarn lint` passes
- [x] `yarn i18n` passes
- [x] No new warnings or errors
