### PR TITLE
Fix CVE-2026-40895: upgrade follow-redirects to 1.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "upstream-replacements": "node downstream.js --upstream && yarn i18n && yarn lint"
   },
   "resolutions": {
+    "follow-redirects": "^1.16.0",
     "http-proxy-middleware": "2.0.7",
     "immutable": "3.8.3",
     "lodash": "4.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7399,23 +7399,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
-  languageName: node
-  linkType: hard
-
-"follow-redirects@npm:^1.15.11":
-  version: 1.15.11
-  resolution: "follow-redirects@npm:1.15.11"
-  peerDependenciesMeta:
-    debug:
-      optional: true
-  checksum: 10c0/d301f430542520a54058d4aeeb453233c564aaccac835d29d15e050beb33f339ad67d9bddbce01739c5dc46a6716dbe3d9d0d5134b1ca203effa11a7ef092343
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Add yarn `resolutions` entry to pin `follow-redirects` to `>= 1.16.0`
- Fixes CVE-2026-40895: information disclosure via cross-domain redirects

### Details
Prior to 1.16.0, `follow-redirects` only strips `authorization`, `proxy-authorization`, and `cookie` headers on cross-domain redirects. Custom authentication headers (e.g., `X-API-Key`, `X-Auth-Token`) are forwarded verbatim to the redirect target.

### Dependency chain
- `axios@1.14.0` → `follow-redirects` (was 1.15.11, now 1.16.0)
- `http-proxy@1.18.1` → `follow-redirects` (was 1.15.6, now 1.16.0)