### PR TITLE
release: generate versioned install manifests for tagged releases

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -12,6 +12,7 @@ permissions:
 env:
   IMAGE_BASE_NAME: kuadrant/console-plugin
   REGISTRY: quay.io
+  RELEASE_TAG: ${{ github.event_name == 'release' && (github.event.release.tag_name || github.event.release.name) || github.ref_name }}
 
 jobs:
   build:
@@ -36,7 +37,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}
-          tags: ${{ github.event.release.tag_name || github.event.release.name }}-${{ matrix.arch }}
+          tags: ${{ env.RELEASE_TAG }}-${{ matrix.arch }}
           archs: ${{ matrix.arch }}
           containerfiles: |
             ./Dockerfile
@@ -48,7 +49,7 @@ jobs:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
           image: ${{ env.IMAGE_BASE_NAME }}
-          tags: ${{ github.event.release.tag_name || github.event.release.name }}-${{ matrix.arch }}
+          tags: ${{ env.RELEASE_TAG }}-${{ matrix.arch }}
 
   manifest:
     name: Create and Push Multi-Arch Release Manifest
@@ -63,28 +64,25 @@ jobs:
 
       - name: Create Release Manifest
         run: |
-          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
-          buildah manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-amd64
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-arm64
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-s390x
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-ppc64le
+          buildah manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }}
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }}-amd64
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }}-arm64
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }}-s390x
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }}-ppc64le
 
       - name: Push Multi-Arch Release Manifest
         run: |
-          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
-          buildah manifest push --all ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} \
+          buildah manifest push --all ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }} \
             --creds=${{ secrets.QUAY_USER }}:${{ secrets.QUAY_PASSWORD }}
 
       - name: Generate release install manifest
         run: |
-          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
-          RELEASE_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}"
-          sed "s|image: quay.io/kuadrant/console-plugin:.*|image: ${RELEASE_IMAGE}|" install.yaml > "install-${RELEASE_TAG}.yaml"
+          RELEASE_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ env.RELEASE_TAG }}"
+          sed "s|image: quay.io/kuadrant/console-plugin:.*|image: ${RELEASE_IMAGE}|" install.yaml > "install-${{ env.RELEASE_TAG }}.yaml"
 
       - name: Upload release install manifest asset
+        if: ${{ github.event_name == 'release' }}
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
-          gh release upload "${RELEASE_TAG}" "install-${RELEASE_TAG}.yaml" --clobber
+          gh release upload "${{ env.RELEASE_TAG }}" "install-${{ env.RELEASE_TAG }}.yaml" --clobber

--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -6,6 +6,9 @@ on:
       - published
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 env:
   IMAGE_BASE_NAME: kuadrant/console-plugin
   REGISTRY: quay.io
@@ -33,7 +36,7 @@ jobs:
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}
-          tags: ${{ github.event.release.name }}-${{ matrix.arch }}
+          tags: ${{ github.event.release.tag_name || github.event.release.name }}-${{ matrix.arch }}
           archs: ${{ matrix.arch }}
           containerfiles: |
             ./Dockerfile
@@ -45,25 +48,43 @@ jobs:
           username: ${{ secrets.QUAY_USER }}
           password: ${{ secrets.QUAY_PASSWORD }}
           image: ${{ env.IMAGE_BASE_NAME }}
-          tags: ${{ github.event.release.name }}-${{ matrix.arch }}
+          tags: ${{ github.event.release.tag_name || github.event.release.name }}-${{ matrix.arch }}
 
   manifest:
     name: Create and Push Multi-Arch Release Manifest
     needs: build
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+
       - name: Install Buildah
         run: sudo apt-get update && sudo apt-get install -y buildah
 
       - name: Create Release Manifest
         run: |
-          buildah manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-amd64
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-arm64
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-s390x
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-ppc64le
+          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
+          buildah manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-amd64
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-arm64
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-s390x
+          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}-ppc64le
 
       - name: Push Multi-Arch Release Manifest
         run: |
-          buildah manifest push --all ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} \
+          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
+          buildah manifest push --all ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG} \
             --creds=${{ secrets.QUAY_USER }}:${{ secrets.QUAY_PASSWORD }}
+
+      - name: Generate release install manifest
+        run: |
+          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
+          RELEASE_IMAGE="${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${RELEASE_TAG}"
+          sed "s|image: quay.io/kuadrant/console-plugin:.*|image: ${RELEASE_IMAGE}|" install.yaml > "install-${RELEASE_TAG}.yaml"
+
+      - name: Upload release install manifest asset
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          RELEASE_TAG="${{ github.event.release.tag_name || github.event.release.name }}"
+          gh release upload "${RELEASE_TAG}" "install-${RELEASE_TAG}.yaml" --clobber

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -36,6 +36,7 @@ git push upstream vX.Y.Z
 This triggers the `Build and Push Versioned Multi-arch Image (Release)` [GitHub workflow](https://github.com/Kuadrant/kuadrant-console-plugin/blob/da4dc0582c442be725a534ff2790811d9cf7ecd7/.github/workflows/build.yaml#L51), which:
 - Builds the `kuadrant-console-plugin` image.
 - Pushes the versioned image to [Quay.io](https://quay.io/repository/kuadrant/console-plugin?tab=tags).
+- Uploads a versioned install manifest asset as `install-vX.Y.Z.yaml` on the GitHub release.
 
 ## 5. Bump to the Next Development Version
 


### PR DESCRIPTION
This updates the release workflow so each GitHub release includes its own versioned install manifest instead of relying on `latest`.

Right now, release images are already built and pushed with version tags, but the install manifest still points to `quay.io/kuadrant/console-plugin:latest`. Because of that, older releases can end up pulling newer plugin images over time.

With this change:

* the release workflow generates an `install-vX.Y.Z.yaml` file for each release
* the generated manifest points to the matching release image tag
* the manifest is uploaded automatically as a release asset
* release documentation is updated to reflect the new flow

This keeps releases reproducible and makes sure users install the correct plugin version for the release they download.

Fixes #168

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced release automation to consistently apply version tags across all release assets and manifests
  * Versioned installation manifest assets are now reliably published with each release, improving deployment clarity and asset management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->