### PR TITLE
fix: apply kuadrant- prefix to custom popover CSS classes (#414)

### DIFF
--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -608,14 +608,14 @@ const KuadrantOverviewPage: React.FC = () => {
     let lastCode = '';
     return (
       <Popover
-        className="custom-rounded-popover"
+        className="kuadrant-custom-rounded-popover"
         headerContent={t('Error Code')}
         bodyContent={
           <>
             <Content component={ContentVariants.p}>
               {t('Displays the distribution of error codes for request failures.')}
             </Content>
-            <div className="popover-codes">
+            <div className="kuadrant-popover-codes">
               {distribution.map(([code, dist]) => {
                 lastCode = code;
                 return (

--- a/src/components/kuadrant.css
+++ b/src/components/kuadrant.css
@@ -232,11 +232,11 @@
   font-family: RedHatText, helvetica, arial, sans-serif;
 }
 
-.custom-rounded-popover .pf-v6-c-popover__content {
+.kuadrant-custom-rounded-popover .pf-v6-c-popover__content {
   border-radius: 12px;
 }
 
-.popover-codes {
+.kuadrant-popover-codes {
   max-height: 240px;
   overflow-y: auto;
 }


### PR DESCRIPTION
## Description

Fix CSS scoping rule violations for custom popover classes to prevent styling conflicts with the host OpenShift console.

Closes #414

### Changes

#### CSS

Added Kuadrant scoping prefixes in `kuadrant.css`:

* `.custom-rounded-popover` → `.kuadrant-custom-rounded-popover`
* `.popover-codes` → `.kuadrant-popover-codes`

#### React Components

Updated `className` references in `KuadrantOverviewPage`:

* Updated the `ErrorCodeLabel` component to use the newly prefixed CSS classes for its popover component.

### Why

The project’s style guidelines require all custom CSS rules to be scoped with a `kuadrant-` prefix.

Global selectors such as `.custom-rounded-popover` can bleed into the host OpenShift console and cause unintended visual side effects for other plugins or the core UI.

### Verification

* `yarn lint` passes
* `yarn i18n` passes
* No new warnings or errors
* Popover displays correctly without visual regressions
