### PR TITLE
Remove stale console.log debug statements from production code paths

### DIFF
--- a/src/components/DropdownWithKebab.tsx
+++ b/src/components/DropdownWithKebab.tsx
@@ -38,7 +38,6 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
   const onDeleteConfirm = async () => {
     try {
       await k8sDelete({ model, resource: obj });
-      console.log('Successfully deleted', obj.metadata.name);
     } catch (error) {
       console.error('Failed to delete', obj.metadata.name, error);
     } finally {

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -212,8 +212,6 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
               ? dnsPolicyUpdate.spec.loadBalancing?.defaultGeo
               : false, // Default to false if not present
         });
-
-        console.log('Initializing dns with existing dns for update');
       }
     } else if (dnsError) {
       console.error('Failed to fetch the resource:', dnsError);

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -156,8 +156,6 @@ const KuadrantTLSCreatePage: React.FC = () => {
             namespace: tlsPolicyUpdate.metadata?.namespace || '',
           });
         }
-
-        console.log('Initializing tls with existing TLS for update');
       }
     } else if (tlsError) {
       console.error('Failed to fetch the resource:', tlsError);


### PR DESCRIPTION
## Summary
Three leftover `console.log` statements ran on every successful resource delete (`DropdownWithKebab`) and on every TLSPolicy and DNSPolicy edit-page open, polluting the OpenShift console's browser console for end users.

This PR removes them. The other `console.error`/`console.warn` calls in `src/` are legitimate error paths and are left intact.

fixes : #416 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed TLS and DNS policy initialization when editing existing policies to ensure settings are properly restored in the form.

* **Chores**
  * Improved application logging by removing unnecessary debug messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->