### PR TITLE
docs: fix README i18n examples and devcontainer plugin name

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cached containers will help you start developing in seconds.
 1. Create a `dev.env` file inside the `.devcontainer` folder with the correct values for your cluster:
 
 ```bash
-OC_PLUGIN_NAME=console-plugin-template
+OC_PLUGIN_NAME=kuadrant-console-plugin
 OC_URL=https://api.example.com:6443
 OC_USER=kubeadmin
 OC_PASS=<password>
@@ -113,14 +113,14 @@ Install via the [`kuadrant-operator`](https://www.github.com/kuadrant/kuadrant-o
 
 ## i18n
 
-The plugin template demonstrates how you can translate messages in with [react-i18next](https://react.i18next.com/). The i18n namespace must match
+The plugin demonstrates how you can translate messages with [react-i18next](https://react.i18next.com/). The i18n namespace must match
 the name of the `ConsolePlugin` resource with the `plugin__` prefix to avoid
-naming conflicts. For example, the plugin template uses the
-`plugin__kuadrant-console` namespace. You can use the `useTranslation` hook
+naming conflicts. For example, this plugin uses the
+`plugin__kuadrant-console-plugin` namespace. You can use the `useTranslation` hook
 with this namespace as follows:
 
 ```tsx
-conster Header: React.FC = () => {
+const Header: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   return <h1>{t('Hello, World!')}</h1>;
 };
@@ -128,7 +128,7 @@ conster Header: React.FC = () => {
 
 For labels in `console-extensions.json`, you can use the format
 `%plugin__kuadrant-console-plugin~My Label%`. Console will replace the value with
-the message for the current language from the `plugin__kuadrant-console`
+the message for the current language from the `plugin__kuadrant-console-plugin`
 namespace. For example:
 
 ```json
@@ -137,13 +137,13 @@ namespace. For example:
   "properties": {
     "id": "admin-demo-section",
     "perspective": "admin",
-    "name": "%plugin__kuadrant-console-plugin~Plugin Template%"
+    "name": "%plugin__kuadrant-console-plugin~Kuadrant%"
   }
 }
 ```
 
 Running `yarn i18n` updates the JSON files in the `locales` folder of the
-plugin template when adding or changing messages.
+plugin when adding or changing messages.
 
 ## Linting
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ cached containers will help you start developing in seconds.
 1. Create a `dev.env` file inside the `.devcontainer` folder with the correct values for your cluster:
 
 ```bash
-OC_PLUGIN_NAME=console-plugin-template
+OC_PLUGIN_NAME=kuadrant-console-plugin
 OC_URL=https://api.example.com:6443
 OC_USER=kubeadmin
 OC_PASS=<password>
@@ -113,10 +113,10 @@ Install via the [`kuadrant-operator`](https://www.github.com/kuadrant/kuadrant-o
 
 ## i18n
 
-The plugin template demonstrates how you can translate messages in with [react-i18next](https://react.i18next.com/). The i18n namespace must match
+The plugin demonstrates how you can translate messages with [react-i18next](https://react.i18next.com/). The i18n namespace must match
 the name of the `ConsolePlugin` resource with the `plugin__` prefix to avoid
-naming conflicts. For example, the plugin template uses the
-`plugin__kuadrant-console` namespace. You can use the `useTranslation` hook
+naming conflicts. For example, this plugin uses the
+`plugin__kuadrant-console-plugin` namespace. You can use the `useTranslation` hook
 with this namespace as follows:
 
 ```tsx
@@ -128,7 +128,7 @@ const Header: React.FC = () => {
 
 For labels in `console-extensions.json`, you can use the format
 `%plugin__kuadrant-console-plugin~My Label%`. Console will replace the value with
-the message for the current language from the `plugin__kuadrant-console`
+the message for the current language from the `plugin__kuadrant-console-plugin`
 namespace. For example:
 
 ```json
@@ -137,13 +137,13 @@ namespace. For example:
   "properties": {
     "id": "admin-demo-section",
     "perspective": "admin",
-    "name": "%plugin__kuadrant-console-plugin~Plugin Template%"
+    "name": "%plugin__kuadrant-console-plugin~Kuadrant%"
   }
 }
 ```
 
 Running `yarn i18n` updates the JSON files in the `locales` folder of the
-plugin template when adding or changing messages.
+plugin when adding or changing messages.
 
 ## Linting
 


### PR DESCRIPTION
## Summary

While going through the docs, I found a few places where the older plugin naming and examples were still being used. This PR updates those references so the README and related docs stay aligned with the current Kuadrant console plugin naming and navigation.

## Changes

* Updated the `.devcontainer` example in the README to use:

  * `OC_PLUGIN_NAME=kuadrant-console-plugin`

* Cleaned up examples in the i18n section:

  * fixed `conster Header` → `const Header`
  * updated namespace references to `plugin__kuadrant-console-plugin`
  * changed the JSON label example from `Plugin Template` to `Kuadrant`
  * replaced remaining mentions of "plugin template" with "plugin"

* Updated `docs/overview.md` to mention that the **Kuadrant** section appears in the navigation after installation.

## Why

I found a few docs references that were still pointing to older naming/examples, which could be confusing while following the setup or i18n docs. This keeps the documentation consistent with the current plugin naming and UI navigation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README setup to reference the current console plugin name and related configuration.
  * Revised i18n guidance to use the correct translation namespace and corrected example React snippet.
  * Fixed console extensions label example and clarified wording around running the localisation command for the plugin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->