### PR TITLE
Add latest API Management APIs to the development environment

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install oinc
         run: |
-          OINC_VERSION="${OINC_VERSION:-v0.2.0}"
+          OINC_VERSION="${OINC_VERSION:-v0.1.2}"
           curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
           chmod +x oinc
           sudo mv oinc /usr/local/bin/

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -28,7 +28,7 @@ jobs:
 
       - name: Install oinc
         run: |
-          OINC_VERSION="${OINC_VERSION:-v0.1.1}"
+          OINC_VERSION="${OINC_VERSION:-v0.2.0}"
           curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
           chmod +x oinc
           sudo mv oinc /usr/local/bin/

--- a/kuadrant-dev-setup/kuadrant/catalogsource.yaml
+++ b/kuadrant-dev-setup/kuadrant/catalogsource.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kuadrant-system
 spec:
   sourceType: grpc
-  image: quay.io/kuadrant/kuadrant-operator-catalog:v1.4.2
+  image: quay.io/kuadrant/kuadrant-operator-catalog:latest
   displayName: Kuadrant Operators
   publisher: grpc
   updateStrategy:

--- a/kuadrant-dev-setup/kuadrant/subscription.yaml
+++ b/kuadrant-dev-setup/kuadrant/subscription.yaml
@@ -4,7 +4,7 @@ metadata:
   name: kuadrant-operator
   namespace: kuadrant-system
 spec:
-  channel: stable
+  channel: preview
   installPlanApproval: Automatic
   name: kuadrant-operator
   source: kuadrant-operator-catalog

--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -24,8 +24,8 @@ PLUGIN_NAME=$(node -p "require('${REPO_DIR}/package.json').consolePlugin.name")
 
 log "creating oinc cluster with addons..."
 oinc create \
-  --addons gateway-api,cert-manager,metallb,istio,kuadrant \
-  --console-plugin "${PLUGIN_NAME}=http://${HOST}:${PLUGIN_PORT}"
+	--addons gateway-api,cert-manager,metallb,istio,kuadrant@latest \
+	--console-plugin "${PLUGIN_NAME}=http://${HOST}:${PLUGIN_PORT}"
 
 # --- MetalLB IP pool ---
 


### PR DESCRIPTION
* Requires https://github.com/jasonmadigan/oinc v0.2.0 (which has not been released yet) for oinc deployment.
* For local deployment (requiring external cluster access), this works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * E2E tooling default updated to v0.1.2
  * Kuadrant operator catalogue set to use latest image
  * Kuadrant subscription channel switched to preview
  * Development cluster setup updated to install the Kuadrant addon at latest

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/420)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->