### PR TITLE
fix: use resilient assertions for status label counts

### DIFF
--- a/e2e/tests/api-product-list.spec.ts
+++ b/e2e/tests/api-product-list.spec.ts
@@ -70,15 +70,18 @@ test.describe('APIProduct List Page - Display and Filters', () => {
     await navigateToAPIProducts(page);
     await waitForPermissionsLoaded(page);
 
-    // Wait for Published status labels (green)
-    const publishedLabels = await page
-      .locator('.pf-v6-c-label.pf-m-green:has-text("Published")')
-      .all();
-    expect(publishedLabels).toHaveLength(3);
+    // Wait for table to load
+    await expect(page.locator('tbody tr[data-key]').first()).toBeVisible({ timeout: 15_000 });
 
-    // Wait for Draft status label (orange)
-    const draftLabels = await page.locator('.pf-v6-c-label.pf-m-orange:has-text("Draft")').all();
-    expect(draftLabels).toHaveLength(3);
+    // Verify Published status labels (green)
+    const publishedCount = await page
+      .locator('.pf-v6-c-label.pf-m-green:has-text("Published")')
+      .count();
+    expect(publishedCount).toBeGreaterThanOrEqual(3);
+
+    // Verify Draft status labels (orange)
+    const draftCount = await page.locator('.pf-v6-c-label.pf-m-orange:has-text("Draft")').count();
+    expect(draftCount).toBeGreaterThanOrEqual(1);
   });
 
   test('displays PlanPolicy links correctly', async ({ page }) => {


### PR DESCRIPTION
## Problem
The `displays correct status labels` test was hardcoding exact label counts `(toHaveLength(3))`, which broke every time a new API product fixture was added. This same failure is also affecting other PR.

## Root Cause
The test counts all Published/Draft labels on the page. When any PR adds a new fixture, the count changes and the assertion fails.

## Fix

- Added a table load wait `(toBeVisible)` before counting to prevent race conditions.
- Switched to `toBeGreaterThanOrEqual(3)` for Published and `toBeGreaterThanOrEqual(1)` for Draft so the test won't break when new fixtures are added.
- The minimum thresholds match the known core fixtures (toystore-api, gamestore-api, payment-api for Published; draft-api for Draft).

Fixes #421 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved stability of product list status checks by waiting for the table to be visible before assertions.
  * Replaced strict collection assertions with direct label counts and minimum-count checks for "Published" and "Draft".
  * Refined assertion methods for more reliable verification of status labels.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/422)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->