### PR TITLE
Disable Save/Create button while k8sCreate/k8sUpdate is in flight

### DIFF
--- a/src/components/KuadrantCreateUpdate.tsx
+++ b/src/components/KuadrantCreateUpdate.tsx
@@ -29,11 +29,13 @@ const KuadrantCreateUpdate: React.FC<GenericPolicyForm> = ({
 }) => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [errorAlertMsg, setErrorAlertMsg] = React.useState('');
+  const [isSaving, setIsSaving] = React.useState(false);
   const update = updateProp ?? !!resource.metadata.creationTimestamp;
 
   const handleCreateUpdate = async () => {
-    if (!validation) return; // Early return if form is not valid
+    if (!validation || isSaving) return; // Early return if form is not valid or save is already in flight
     setErrorAlertMsg('');
+    setIsSaving(true);
 
     try {
       if (update) {
@@ -68,6 +70,8 @@ const KuadrantCreateUpdate: React.FC<GenericPolicyForm> = ({
         console.error(`Cannot create ${policyType}:`, error);
       }
       setErrorAlertMsg(message);
+      // Only reset isSaving on error — the success path navigates away and unmounts this component
+      setIsSaving(false);
     }
   };
   return (
@@ -87,7 +91,11 @@ const KuadrantCreateUpdate: React.FC<GenericPolicyForm> = ({
           </Alert>
         </AlertGroup>
       )}
-      <Button onClick={handleCreateUpdate} isDisabled={!validation}>
+      <Button
+        onClick={handleCreateUpdate}
+        isDisabled={!validation || isSaving}
+        isLoading={isSaving}
+      >
         {update ? t(`Save`) : t(`Create`)}
       </Button>
     </>


### PR DESCRIPTION
The Save/Create button in DNSPolicy, TLSPolicy and APIProduct forms stays clickable while the underlying k8sCreate or k8sUpdate request is in flight, with no spinner. On slow connections, users can click again before the first request resolves, firing a duplicate request and getting a confusing 409 error after the resource was actually saved.

fixes : #423 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Prevented duplicate form submissions by blocking further submits while a save is in progress.
  * Added a visual loading indicator to show in-progress save operations.
  * Updated submit button behaviour to disable during invalid form states and active saves.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->