### PR TITLE
ReadmeFix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Based on https://github.com/openshift/console-plugin-template
 ## Screenshots
 
 ![Overview](docs/images/overview.gif)
+
 ## Running
 
 - Target a running OCP with `oc login`
@@ -36,7 +37,7 @@ In another terminal window, run:
 
 This will run the OpenShift console in a container connected to the cluster
 you've logged into. The plugin HTTP server runs on port 9001 with CORS enabled.
-Navigate to <http://localhost:9000/example> to see the running plugin.
+Navigate to [http://localhost:9000/example](http://localhost:9000/example) to see the running plugin.
 
 ### Option 2: oinc (no cluster required)
 
@@ -71,7 +72,7 @@ OC_PASS=<password>
 
 2. `(Ctrl+Shift+P) => Remote Containers: Open Folder in Container...`
 3. `yarn run start`
-4. Navigate to <http://localhost:9000/example>
+4. Navigate to [http://localhost:9000/example](http://localhost:9000/example)
 
 ## Docker image
 
@@ -120,7 +121,7 @@ naming conflicts. For example, the plugin template uses the
 with this namespace as follows:
 
 ```tsx
-conster Header: React.FC = () => {
+const Header: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   return <h1>{t('Hello, World!')}</h1>;
 };
@@ -176,13 +177,14 @@ Update `settings.json` (File > Preferences > Settings):
 ```json
 "editor.formatOnSave": true
 ```
+
 ## Version matrix
 
 | kuadrant-console-plugin version | PatternFly version | Openshift console version | Dynamic Plugin SDK |
-|---------------------------------|--------------------|---------------------------|--------------------|
-|         v0.0.3 - v0.0.18        |          5         |          v4.17.x          |       v1.6.0       |
-|                TBD              |          5         |          v4.18.x          |       v1.8.0       |
-|                TBD              |          6         |          v4.19.x          |         TBD        |
+| ------------------------------- | ------------------ | ------------------------- | ------------------ |
+| v0.0.3 - v0.0.18                | 5                  | v4.17.x                   | v1.6.0             |
+| TBD                             | 5                  | v4.18.x                   | v1.8.0             |
+| TBD                             | 6                  | v4.19.x                   | TBD                |
 
 Openshift console is configured to share modules with its dynamic plugins (console plugins). For more information on versions and changes to the shared modules, please see the shared modules [documentation](https://www.npmjs.com/package/@openshift-console/dynamic-plugin-sdk?activeTab=readme)
 


### PR DESCRIPTION
# Fixed `conster` typo in README

## Summary
This PR fixes a minor typo in the `README.md` file within the **i18n** section. 

## Changes
- Updated the React component code example on line 123 to use `const` instead of the incorrect `conster`.

## Rationale
This typo was a leftover from the original `console-plugin-template`. Correcting it ensures that users following the documentation can copy-paste the example without encountering syntax errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved README formatting with proper Markdown links for navigation
  * Fixed typo in code example
  * Enhanced version matrix table formatting for better readability

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/429)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->