### PR TITLE
docs: fix localhost link and add sandbox note

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In another terminal window, run:
 
 This will run the OpenShift console in a container connected to the cluster
 you've logged into. The plugin HTTP server runs on port 9001 with CORS enabled.
-Navigate to <http://localhost:9000/example> to see the running plugin.
+Navigate to <http://localhost:9000> and click "Kuadrant" in the left sidebar menu to see the running plugin.
 
 ### Option 2: oinc (no cluster required)
 
@@ -71,7 +71,7 @@ OC_PASS=<password>
 
 2. `(Ctrl+Shift+P) => Remote Containers: Open Folder in Container...`
 3. `yarn run start`
-4. Navigate to <http://localhost:9000/example>
+4. Navigate to <http://localhost:9000> and click "Kuadrant" in the left sidebar menu
 
 ## Docker image
 
@@ -196,3 +196,4 @@ Openshift console is configured to share modules with its dynamic plugins (conso
 ## Troubleshooting
 
 For troubleshooting common issues, please see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
+


### PR DESCRIPTION
What

Fixes README instructions for local plugin access and adds a troubleshooting note for Sandbox users.

Changes

1. Removed broken `/example` localhost route from README
2. Updated instructions to access the plugin through the **Kuadrant** left sidebar menu
3. Added troubleshooting note for Red Hat/OpenShift Sandbox users to select a specific project instead of **All Projects**

Verification

1. Verified `/example` route is not registered in `console-extensions.json`
2. Confirmed plugin navigation is exposed through the left sidebar
3. Validated README formatting and ensured only `README.md` was changed

Fixes #428.....


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated getting started instructions: open the base console (http://localhost:9000) and access the Kuadrant plugin via the left-hand sidebar rather than a separate example route.
  * Added troubleshooting guidance for Red Hat / OpenShift Sandbox: if Kuadrant pages fail when the top selector is set to “All Projects”, select a specific project/namespace first.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/432?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->