### PR TITLE
fix: replace undefined 'history' with 'navigate' in useMemo deps for DNS/TLS policy action hooks

### DIFF
--- a/src/components/dnspolicy/useDNSPolicyActions.tsx
+++ b/src/components/dnspolicy/useDNSPolicyActions.tsx
@@ -83,7 +83,7 @@ const useDNSPolicyActions = (obj: K8sResourceCommon): ExtensionHookResult<Action
     ];
 
     return actionsList;
-  }, [history, obj, dnsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
+  }, [navigate, obj, dnsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
 
   return [actions, true, undefined];
 };

--- a/src/components/tlspolicy/useTLSPolicyActions.tsx
+++ b/src/components/tlspolicy/useTLSPolicyActions.tsx
@@ -83,7 +83,7 @@ const useTLSPolicyActions = (obj: K8sResourceCommon): ExtensionHookResult<Action
     ];
 
     return actionsList;
-  }, [history, obj, tlsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
+  }, [navigate, obj, tlsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
 
   return [actions, true, undefined];
 };


### PR DESCRIPTION

Fixes #433

The useMemo dependency arrays in useDNSPolicyActions and useTLSPolicyActions referenced history ,a variable that does not exist in scope. This is a leftover from the React Router v5 → v6 migration where useHistory() was replaced with useNavigate() and the variable renamed from history to navigate, but the useMemo dependency array was never updated.

Since history is always undefined, React treats it as permanently stable and never recomputes the memoized actions ,meaning the navigate function captured inside the memo can become stale, causing the Edit action on DNS/TLS policies to navigate incorrectly or silently fail.

Changes

- src/components/dnspolicy/useDNSPolicyActions.tsx - replace history with navigate in useMemo deps
- src/components/tlspolicy/useTLSPolicyActions.tsx - replace history with navigate in useMemo deps


- }, [history, obj, dnsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
+ }, [navigate, obj, dnsPolicyModel, launchAnnotationsModal, launchDeleteModal, launchLabelsModal]);
Test plan

- [X]  Open a DNSPolicy in the OpenShift Console and verify the Edit action navigates correctly to the form edit page
- [X]  Open a TLSPolicy and verify the same
- [X]  Verify no regression in Edit labels, Edit annotations, and Delete actions for both policy types
