### PR TITLE
fix: wrap hardcoded 'Error Code' string in t() for i18n

### DIFF
--- a/locales/en/plugin__kuadrant-console-plugin.json
+++ b/locales/en/plugin__kuadrant-console-plugin.json
@@ -152,6 +152,7 @@
   "Enter use case": "Enter use case",
   "Error": "Error",
   "Error approving API keys": "Error approving API keys",
+  "Error Code": "Error Code",
   "Error Codes": "Error Codes",
   "Error creating {{policyType}}": "Error creating {{policyType}}",
   "Error creating AuthPolicy": "Error creating AuthPolicy",

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -609,7 +609,7 @@ const KuadrantOverviewPage: React.FC = () => {
     return (
       <Popover
         className="custom-rounded-popover"
-        headerContent={`Error Code`}
+        headerContent={t('Error Code')}
         bodyContent={
           <>
             <Content component={ContentVariants.p}>


### PR DESCRIPTION
Description
The Error Code popover header in KuadrantOverviewPage was using a raw string instead of t(), so it wouldn't be translated in non-English locales. This fixes it and adds the missing key to the locale file.

Fixes #438

Type of change
 - [X] [fix] Bug fix
 
 Changes made
- Wrapped Error Code string in t() in KuadrantOverviewPage.tsx
- Added "Error Code" key to locales/en/plugin__kuadrant-console-plugin.json

Checklist

- [x]  All user-facing strings use t() and added to locales/en/plugin__kuadrant-console-plugin.json
- [x]  CSS classes are prefixed with kuadrant- (no global selectors)
- [x]  Commit(s) include Signed-off-by (git commit -s)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Updated error code label management to use centralised string handling, improving application consistency and maintainability across the interface.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/437)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->