### PR TITLE
fix: replace hardcoded path indexes with URL utility functions in DNS/TLS create pages

### DIFF
--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -33,6 +33,7 @@ import GatewaySelect from './gateway/GatewaySelect';
 import * as yaml from 'js-yaml';
 import KuadrantCreateUpdate from './KuadrantCreateUpdate';
 import { handleCancel } from '../utils/cancel';
+import extractResourceNameFromURL, { extractNamespaceFromURL } from '../utils/nameFromPath';
 import { resourceGVKMapping } from '../utils/resources';
 
 const KuadrantDNSPolicyCreatePage: React.FC = () => {
@@ -59,9 +60,8 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
   const [creationTimestamp, setCreationTimestamp] = React.useState('');
   const [resourceVersion, setResourceVersion] = React.useState('');
   const location = useLocation();
-  const pathSplit = location.pathname.split('/');
-  const nameEdit = pathSplit[6];
-  const namespaceEdit = pathSplit[3];
+  const nameEdit = extractResourceNameFromURL(location.pathname);
+  const namespaceEdit = extractNamespaceFromURL(location.pathname);
   const [formDisabled, setFormDisabled] = React.useState(false);
   const [create, setCreate] = React.useState(true);
   const [loadBalancingExpanded, setLoadBalancingExpanded] = React.useState(false);

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -22,6 +22,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import './kuadrant.css';
 import { handleCancel } from '../utils/cancel';
+import extractResourceNameFromURL, { extractNamespaceFromURL } from '../utils/nameFromPath';
 import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
 import * as yaml from 'js-yaml';
 import { useTranslation } from 'react-i18next';
@@ -52,9 +53,8 @@ const KuadrantTLSCreatePage: React.FC = () => {
   );
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const location = useLocation();
-  const pathSplit = location.pathname.split('/');
-  const nameEdit = pathSplit[6];
-  const namespaceEdit = pathSplit[3];
+  const nameEdit = extractResourceNameFromURL(location.pathname);
+  const namespaceEdit = extractNamespaceFromURL(location.pathname);
   const [formDisabled, setFormDisabled] = React.useState(false);
   const [create, setCreate] = React.useState(true);
   const [creationTimestamp, setCreationTimestamp] = React.useState('');


### PR DESCRIPTION

KuadrantDNSPolicyCreatePage and KuadrantTLSCreatePage were using hardcoded array indexes (pathSplit[3], pathSplit[6]) to extract namespace and name from the URL. This is fragile - if the URL structure changes (as it did in #408), these indexes silently return wrong values with no error. The codebase already has extractResourceNameFromURL and extractNamespaceFromURL utility functions that use regex to correctly locate these segments. This fix replaces the raw index access with those existing utilities.

Fixes #440

Type of change

- [X] - [fix] Bug fix


Changes made

- Replaced pathSplit[6] and pathSplit[3] with extractResourceNameFromURL and extractNamespaceFromURL in KuadrantDNSPolicyCreatePage.tsx
- Replaced pathSplit[6] and pathSplit[3] with extractResourceNameFromURL and extractNamespaceFromURL in KuadrantTLSCreatePage.tsx

Screenshots

- No visual change - this is an internal refactor to use existing URL utility functions.

Checklist

- [x]  All user-facing strings use t() and added to locales/en/plugin__kuadrant-console-plugin.json
- [x]  CSS classes are prefixed with kuadrant- (no global selectors)
- [x]  Commit(s) include Signed-off-by (git commit -s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal URL parsing logic in DNS Policy and TLS Policy creation pages for more consistent and maintainable handling of resource identifiers from URLs.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/439)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->