### PR TITLE
fix: remove unused parameters from handleCancel utility

### DIFF
--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -265,7 +265,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
   };
 
   const handleCancelResource = () => {
-    handleCancel(selectedNamespace, dnsPolicy, navigate);
+    handleCancel(navigate);
   };
   const formValidation = () => {
     if (

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -209,7 +209,7 @@ const KuadrantTLSCreatePage: React.FC = () => {
 
   //Cancel
   const handleCancelResource = () => {
-    handleCancel(selectedNamespace, tlsPolicy, navigate);
+    handleCancel(navigate);
   };
 
   if (

--- a/src/utils/cancel.tsx
+++ b/src/utils/cancel.tsx
@@ -1,5 +1,5 @@
 import { NavigateFunction } from 'react-router-dom-v5-compat';
 
-export function handleCancel(namespace: string, data, navigate: NavigateFunction) {
+export function handleCancel(navigate: NavigateFunction) {
   navigate(-1);
 }


### PR DESCRIPTION

handleCancel in src/utils/cancel.tsx accepted two parameters namespace and data that were never used inside the function. Traced through git history - these were leftover from when cancel navigated to /kuadrant/all-namespaces/policies. When the behavior was changed to navigate(-1) in commit f9ae3d9, the unused parameters were never removed, leaving a misleading function signature.

Fixes #441

Type of change

- [x] fix Bug fix

Changes made

1. Removed unused namespace and data parameters from handleCancel in src/utils/cancel.tsx
2. Updated caller in KuadrantDNSPolicyCreatePage.tsx
3. Updated caller in KuadrantTLSCreatePage.tsx

Checklist
 

- [x] All user-facing strings use t() and added to locales/en/plugin__kuadrant-console-plugin.json
- [x]  CSS classes are prefixed with kuadrant- (no global selectors)
- [x]  Commit(s) include Signed-off-by (git commit -s)