### PR TITLE
[fix] Remove unreachable error-modal scaffolding from YAML-only policy pages

### DIFF
--- a/src/components/KuadrantAuthPolicyCreatePage.tsx
+++ b/src/components/KuadrantAuthPolicyCreatePage.tsx
@@ -1,13 +1,5 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
-import {
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-  ModalBody,
-  ModalFooter,
-} from '@patternfly/react-core';
 import { useTranslation } from 'react-i18next';
 import { ResourceYAMLEditor, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 import { resourceGVKMapping } from '../utils/resources';
@@ -61,9 +53,6 @@ const KuadrantAuthPolicyCreatePage: React.FC = () => {
     },
   };
 
-  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
-  const [errorModalMsg] = React.useState('');
-
   return (
     <>
       <Helmet>
@@ -71,22 +60,6 @@ const KuadrantAuthPolicyCreatePage: React.FC = () => {
       </Helmet>
 
       <ResourceYAMLEditor initialResource={yamlResource} header="Create AuthPolicy" create={true} />
-
-      <Modal
-        isOpen={isErrorModalOpen}
-        onClose={() => setIsErrorModalOpen(false)}
-        variant={ModalVariant.medium}
-        title={t('Error creating AuthPolicy')}
-      >
-        <ModalBody>
-          <b>{errorModalMsg}</b>
-        </ModalBody>
-        <ModalFooter>
-          <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            {t('OK')}
-          </Button>
-        </ModalFooter>
-      </Modal>
     </>
   );
 };

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
-import {
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-  ModalBody,
-  ModalFooter,
-} from '@patternfly/react-core';
-
 import { useTranslation } from 'react-i18next';
 import './kuadrant.css';
 import { ResourceYAMLEditor, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
@@ -17,8 +8,6 @@ import { resourceGVKMapping } from '../utils/resources';
 const KuadrantOIDCPolicyCreatePage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [selectedNamespace] = useActiveNamespace();
-  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
-  const [errorModalMsg] = React.useState('');
 
   const oidcPolicy = {
     apiVersion:
@@ -48,21 +37,6 @@ const KuadrantOIDCPolicyCreatePage: React.FC = () => {
       </Helmet>
 
       <ResourceYAMLEditor initialResource={oidcPolicy} header="Create OIDC Policy" create />
-      <Modal
-        isOpen={isErrorModalOpen}
-        onClose={() => setIsErrorModalOpen(false)}
-        variant={ModalVariant.medium}
-        title={t('Error creating OIDC Policy')}
-      >
-        <ModalBody>
-          <b>{errorModalMsg}</b>
-        </ModalBody>
-        <ModalFooter>
-          <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            {t('OK')}
-          </Button>
-        </ModalFooter>
-      </Modal>
     </>
   );
 };

--- a/src/components/KuadrantPlanPolicyCreatePage.tsx
+++ b/src/components/KuadrantPlanPolicyCreatePage.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
-import {
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-  ModalBody,
-  ModalFooter,
-} from '@patternfly/react-core';
-
 import { useTranslation } from 'react-i18next';
 import './kuadrant.css';
 import { ResourceYAMLEditor, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
@@ -17,8 +8,6 @@ import { resourceGVKMapping } from '../utils/resources';
 const KuadrantPlanPolicyCreatePage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [selectedNamespace] = useActiveNamespace();
-  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
-  const [errorModalMsg] = React.useState('');
 
   const planPolicy = {
     apiVersion:
@@ -53,21 +42,6 @@ const KuadrantPlanPolicyCreatePage: React.FC = () => {
       </Helmet>
 
       <ResourceYAMLEditor initialResource={planPolicy} header="Create Plan Policy" create />
-      <Modal
-        isOpen={isErrorModalOpen}
-        onClose={() => setIsErrorModalOpen(false)}
-        variant={ModalVariant.medium}
-        title={t('Error creating Plan Policy')}
-      >
-        <ModalBody>
-          <b>{errorModalMsg}</b>
-        </ModalBody>
-        <ModalFooter>
-          <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            {t('OK')}
-          </Button>
-        </ModalFooter>
-      </Modal>
     </>
   );
 };

--- a/src/components/KuadrantRateLimitPolicyCreatePage.tsx
+++ b/src/components/KuadrantRateLimitPolicyCreatePage.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
-import {
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-  ModalBody,
-  ModalFooter,
-} from '@patternfly/react-core';
-
 import { useTranslation } from 'react-i18next';
 import './kuadrant.css';
 import { ResourceYAMLEditor, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
@@ -17,8 +8,6 @@ import { resourceGVKMapping } from '../utils/resources';
 const KuadrantRateLimitPolicyCreatePage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [selectedNamespace] = useActiveNamespace();
-  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
-  const [errorModalMsg] = React.useState('');
 
   const rateLimitPolicy = {
     apiVersion:
@@ -65,21 +54,6 @@ const KuadrantRateLimitPolicyCreatePage: React.FC = () => {
         header="Create RateLimit Policy"
         create
       />
-      <Modal
-        isOpen={isErrorModalOpen}
-        onClose={() => setIsErrorModalOpen(false)}
-        variant={ModalVariant.medium}
-        title={t('Error creating Rate Limit Policy')}
-      >
-        <ModalBody>
-          <b>{errorModalMsg}</b>
-        </ModalBody>
-        <ModalFooter>
-          <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            {t('OK')}
-          </Button>
-        </ModalFooter>
-      </Modal>
     </>
   );
 };

--- a/src/components/KuadrantTokenRateLimitPolicyCreatePage.tsx
+++ b/src/components/KuadrantTokenRateLimitPolicyCreatePage.tsx
@@ -1,14 +1,5 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
-import {
-  Button,
-  ButtonVariant,
-  Modal,
-  ModalVariant,
-  ModalBody,
-  ModalFooter,
-} from '@patternfly/react-core';
-
 import { useTranslation } from 'react-i18next';
 import './kuadrant.css';
 import { ResourceYAMLEditor, useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
@@ -17,8 +8,6 @@ import { resourceGVKMapping } from '../utils/resources';
 const KuadrantTokenRateLimitPolicyCreatePage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [selectedNamespace] = useActiveNamespace();
-  const [isErrorModalOpen, setIsErrorModalOpen] = React.useState(false);
-  const [errorModalMsg] = React.useState('');
 
   const tokenRateLimitPolicy = {
     apiVersion:
@@ -60,21 +49,6 @@ const KuadrantTokenRateLimitPolicyCreatePage: React.FC = () => {
         header="Create TokenRateLimit Policy"
         create
       />
-      <Modal
-        isOpen={isErrorModalOpen}
-        onClose={() => setIsErrorModalOpen(false)}
-        variant={ModalVariant.medium}
-        title={t('Error creating Token Rate Limit Policy')}
-      >
-        <ModalBody>
-          <b>{errorModalMsg}</b>
-        </ModalBody>
-        <ModalFooter>
-          <Button key="ok" variant={ButtonVariant.link} onClick={() => setIsErrorModalOpen(false)}>
-            {t('OK')}
-          </Button>
-        </ModalFooter>
-      </Modal>
     </>
   );
 };


### PR DESCRIPTION
## Summary
- Remove unreachable `<Modal>` blocks from the 5 YAML-only policy create pages (Auth, RateLimit, TokenRateLimit, OIDC, Plan)
- Remove the `useState` declarations for `isErrorModalOpen` / `errorModalMsg` (the latter had no setter destructured, the former was never set to `true`, so the modal could never render)
- Remove the now-unused `@patternfly/react-core` imports the dead block was keeping alive (`Button`, `ButtonVariant`, `Modal`, `ModalVariant`, `ModalBody`, `ModalFooter`)

131 lines deleted, 0 added. No behaviour change — these pages currently render only `<ResourceYAMLEditor>`, which has its own save/error handling.

These pages are slated to be rewritten with real Form + YAML views under #378 (the LFX mentorship epic). This cleanup just removes scaffolding that has no render path today.

Refs #445.

## Test plan
- [x] `yarn lint` clean
- [ ] Visually confirm `/k8s/ns/:ns/<policy>/~new` still renders the YAML editor for AuthPolicy, RateLimitPolicy, TokenRateLimitPolicy, OIDCPolicy, PlanPolicy — leaving for reviewer / will follow up once I have a console environment up

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified the create pages for AuthPolicy, PlanPolicy, RateLimitPolicy, and TokenRateLimitPolicy.
  * Removed the extra error pop-up handling from these screens, leaving a cleaner create flow focused on the YAML editor and page title.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->