### PR TITLE
Adds a GitHub PR template to guide contributors through the submission process.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,42 @@
+## Description
+
+<!-- Clear description of what this PR does and why -->
+
+Fixes # (issue)
+
+## Type of change
+
+- [ ] `[fix]` Bug fix
+- [ ] `[feat]` New feature
+- [ ] `[refactor]` Refactor (no functional changes)
+- [ ] `[test]` Test updates
+- [ ] `[chore]` Dependency / config update
+
+## Changes made
+
+-
+-
+
+## Test plan
+
+- [ ] `yarn lint` passes (no changes after running)
+- [ ] `yarn build` passes
+- [ ] `yarn i18n` passes (no changes after running — commit updated locale files if needed)
+- [ ] Tested manually in OpenShift Console
+- [ ] Tested in both light and dark themes
+- [ ] Tested in all-namespaces and single namespace mode
+
+## Screenshots
+
+<!-- For UI changes, add before/after screenshots -->
+
+| Before | After |
+|--------|-------|
+|        |       |
+
+## Checklist
+
+- [ ] All user-facing strings use `t()` and are added to `locales/en/plugin__kuadrant-console-plugin.json`
+- [ ] CSS classes are prefixed with `kuadrant-` — no bare `.pf-*` or `.co-*` selectors, no hex colours
+- [ ] No `console.log` statements left in
+- [ ] Commits include `Signed-off-by` line (`git commit -s`)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 <!-- Clear description of what this PR does and why -->
 
-Fixes # (issue)
+Fixes #
 
 ## Type of change
 
@@ -37,6 +37,6 @@ Fixes # (issue)
 ## Checklist
 
 - [ ] All user-facing strings use `t()` and are added to `locales/en/plugin__kuadrant-console-plugin.json`
-- [ ] CSS classes are prefixed with `kuadrant-` — no bare `.pf-*` or `.co-*` selectors, no hex colours
+- [ ] CSS classes are prefixed with `kuadrant-` — no bare `.pf-*` or `.co-*` selectors, no hex colors
 - [ ] No `console.log` statements left in
 - [ ] Commits include `Signed-off-by` line (`git commit -s`)


### PR DESCRIPTION
Fixes #435

The template includes:
- Type of change labels matching the project's commit conventions (`[fix]`, `[feat]`, `[refactor]`, etc.)
- CI-specific checklist items: `yarn lint`, `yarn build`, and `yarn i18n` all run in CI and must pass with no diff
- Reminder to commit updated locale files when i18n changes are made
- CSS scoping requirement (no bare `.pf-*` / `.co-*` selectors, no hex colours) from project style rules
- `t()` i18n reminder for all user-facing strings
- `Signed-off-by` reminder to avoid DCO check failures

No functional changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Standardised the pull request template with clear sections for PR description, change classification, test plans and optional screenshots. Added checklist items to enforce i18n usage, CSS naming conventions, removal of debug logs, and commit signing. Aims to improve contribution consistency, review quality and project-wide style adherence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->