### PR TITLE
Fix stale RBAC state in useAccessReviews hook

### DIFF
--- a/src/utils/resourceRBAC.tsx
+++ b/src/utils/resourceRBAC.tsx
@@ -15,6 +15,8 @@ function useAccessReviews(resource: Resource[]) {
 
   useEffect(() => {
     const checkRBAC = async () => {
+      setLoading(true);
+
       const results = await Promise.all(
         resource.flatMap(({ group, kind, namespace }) =>
           verbs.map(async (verb) => {
@@ -24,20 +26,26 @@ function useAccessReviews(resource: Resource[]) {
               verb,
               ...(namespace ? { namespace } : {}),
             });
-            return { key: `${kind}-${verb}`, isAllowed: result.status?.allowed };
+
+            return {
+              key: `${kind}-${verb}`,
+              isAllowed: result.status?.allowed,
+            };
           }),
         ),
       );
+
       const RBACMap = results.reduce((acc, { key, isAllowed }) => {
         acc[key] = isAllowed;
         return acc;
       }, {} as Record<string, boolean>);
+
       setUserRBAC(RBACMap);
       setLoading(false);
     };
 
     checkRBAC();
-  }, []);
+  }, [resource]);
 
   return { userRBAC, loading };
 }


### PR DESCRIPTION
## Description

This PR fixes stale RBAC permission data in the `useAccessReviews` hook located at:

```txt
src/utils/resourceRBAC.tsx
```

Previously, the hook executed RBAC access checks only once on component mount because the `useEffect` dependency array was empty:

```ts
useEffect(() => {
  checkRBAC();
}, []);
```

As a result, when the `resource` prop changed, the hook did not re-run access reviews and continued returning outdated RBAC permissions.

This PR updates the dependency array to include `resource`, ensuring RBAC checks are refreshed whenever the resource list changes.

---

## Changes Made

- Added `resource` to the `useEffect` dependency array
- Added `setLoading(true)` before re-fetching RBAC data
- Kept the implementation minimal and consistent with the existing code style

---

## Before

```ts
useEffect(() => {
  const checkRBAC = async () => {
    ...
  };

  checkRBAC();
}, []);
```

---

## After

```ts
useEffect(() => {
  const checkRBAC = async () => {
    setLoading(true);

    ...
  };

  checkRBAC();
}, [resource]);
```

---

## Impact

This fix ensures:
- RBAC permissions stay in sync with updated resources
- UI actions reflect the latest access state
- stale RBAC data is no longer returned after resource changes

---

## Testing

Tested by:
1. Rendering the hook with an initial resource
2. Updating the `resource` prop dynamically
3. Verifying that RBAC checks are triggered again
4. Confirming updated permissions are reflected in `userRBAC`

---

## Related Issue

Fixes #451

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed role-based access control (RBAC) checks to properly display loading state during permission verification.
  * Improved RBAC checks to update dynamically when resources change, ensuring permissions are accurately reflected in real time.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/452)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->