### PR TITLE
fix:Replace deprecated pf-v5- classes with pf-v6- in ResourceList

### DIFF
--- a/src/components/ResourceList.tsx
+++ b/src/components/ResourceList.tsx
@@ -198,7 +198,7 @@ const ResourceList: React.FC<ResourceListProps> = ({
     {
       title: '', // No title for the kebab column
       id: 'kebab',
-      props: { className: 'pf-v5-c-table__action' },
+      props: { className: 'pf-v6-c-table__action' },
     },
   ];
 
@@ -363,14 +363,14 @@ const ResourceList: React.FC<ResourceListProps> = ({
                 </ToolbarItem>
 
                 <ToolbarItem>
-                  <InputGroup className="pf-v5-c-input-group co-filter-group">
+                  <InputGroup className="pf-v6-c-input-group co-filter-group">
                     <TextInput
                       type="text"
                       placeholder={t('Search by {{filterValue}}...', {
                         filterValue: filterSelected.toLowerCase(),
                       })}
                       onChange={(_event, value) => handleFilterChange(value)}
-                      className="pf-v5-c-form-control co-text-filter-with-icon"
+                      className="pf-v6-c-form-control co-text-filter-with-icon"
                       aria-label="Resource search"
                     />
                   </InputGroup>


### PR DESCRIPTION
Fixes three leftover `pf-v5-` class references in ResourceList.tsx that were missed during the PatternFly 6 migration.

Changes:
- `pf-v5-c-table__action` to `pf-v6-c-table__action` (line 201)
- `pf-v5-c-input-group` to `pf-v6-c-input-group` (line 366)
- `pf-v5-c-form-control` to `pf-v6-c-form-control` (line 373)

Confirmed safe to migrate by @rhaicl on Slack.

Tested manually in OpenShift Console. Filter bar and kebab menu render correctly in dark theme.