### PR TITLE
fix: correct typo in Header component declaration

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ naming conflicts. For example, the plugin template uses the
 with this namespace as follows:
 
 ```tsx
-conster Header: React.FC = () => {
+const Header: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   return <h1>{t('Hello, World!')}</h1>;
 };


### PR DESCRIPTION
## Description
Fixes a typo in the `Header` component declaration by replacing `conster` with `const`.

### Changes
- Replaced invalid keyword `conster` with `const`
- Fixed syntax error preventing compilation

## Related Issue
Fixes #461 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Corrected a syntax error in a code example to ensure documentation examples are valid and properly usable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/462)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->