### PR TITLE
fix typos in README.md and CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -93,7 +93,7 @@ const canRead = accessReviews[0];
 
 ### 5. Configuration
 
-The plugin supports configurable Topology andPrometheus metrics for gateway traffic monitoring. This allows the console to work with different Gateway API implementations (OpenShift 4.19+, OSSM, etc.).
+The plugin supports configurable Topology and Prometheus metrics for gateway traffic monitoring. This allows the console to work with different Gateway API implementations (OpenShift 4.19+, OSSM, etc.).
 
 **Configuration is managed through:**
 - `src/utils/configLoader.ts` - Configuration schema and defaults

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ naming conflicts. For example, the plugin template uses the
 with this namespace as follows:
 
 ```tsx
-conster Header: React.FC = () => {
+const Header: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   return <h1>{t('Hello, World!')}</h1>;
 };


### PR DESCRIPTION
### Description
This PR addresses two minor documentation typos identified in the codebase guide (`CLAUDE.md`) and the project introduction (`README.md`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Documentation**
  * Corrected spacing in the configuration metrics documentation to properly render “Topology and Prometheus”.
  * Fixed a typo in the internationalisation example code snippet so the React component declaration displays correctly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/467?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
@eguzki @R-Lawton please review it