### PR TITLE
Removed the duplicate tab definitions from console-extensions.json

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -371,36 +371,6 @@
     }
   },
   {
-    "type": "console.tab/horizontalNav",
-    "properties": {
-      "model": {
-        "group": "devportal.kuadrant.io",
-        "version": "v1alpha1",
-        "kind": "APIProduct"
-      },
-      "page": {
-        "name": "Definition",
-        "href": "definition"
-      },
-      "component": { "$codeRef": "APIProductDefinitionTab" }
-    }
-  },
-  {
-    "type": "console.tab/horizontalNav",
-    "properties": {
-      "model": {
-        "group": "devportal.kuadrant.io",
-        "version": "v1alpha1",
-        "kind": "APIProduct"
-      },
-      "page": {
-        "name": "Policies",
-        "href": "policies"
-      },
-      "component": { "$codeRef": "APIProductPoliciesTab" }
-    }
-  },
-  {
     "type": "console.navigation/href",
     "properties": {
       "id": "kuadrant-policy-topology-admin",


### PR DESCRIPTION
### What 

Removed the duplicate tab definitions from console-extensions.json

<img width="685" height="188" alt="Screenshot 2026-05-19 at 12-03-25 gamestore-admin · API Product · Details · OKD" src="https://github.com/user-attachments/assets/65c74145-bfaa-4391-8f56-f44769c99ca2" />


:nerd_face: 