### PR TITLE
Backport patch-safe fixes for v0.3.7

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,6 +91,60 @@ const accessReviews = useAccessReviews(resourceAttributes);
 const canRead = accessReviews[0];
 ```
 
+### 5. Metrics Configuration
+
+The plugin supports configurable Prometheus metrics for gateway traffic monitoring. This allows the console to work with different Gateway API implementations (OpenShift 4.19+, OSSM, etc.).
+
+**Configuration is managed through:**
+- `src/utils/topology/configLoader.ts` - Configuration schema and defaults
+- `src/utils/metricsQueries.ts` - Query builder utilities
+- Environment variables in deployment manifests
+
+**Default Configuration (OpenShift 4.19+):**
+```yaml
+METRICS_METRIC_NAME: istio_request_duration_milliseconds_count
+METRICS_QUERY_FUNCTION: rate
+METRICS_TIME_WINDOW: 2m
+METRICS_WORKLOAD_SUFFIX: "" # no suffix
+METRICS_SUCCESS_CODE_PATTERN: "2(.*)|3(.*)"
+```
+
+**OSSM Compatibility Configuration:**
+```yaml
+METRICS_METRIC_NAME: istio_requests_total
+METRICS_QUERY_FUNCTION: increase
+METRICS_TIME_WINDOW: 24h
+METRICS_WORKLOAD_SUFFIX: "-istio"
+METRICS_SUCCESS_CODE_PATTERN: "2(.*)|3(.*)"
+```
+
+**Query Builders:**
+The `metricsQueries.ts` utility provides DRY query construction:
+- `buildTotalRequestsQuery(config)` - Total requests across all gateways
+- `buildErrorRequestsQuery(config)` - Error requests (non-2xx/3xx)
+- `buildErrorsByCodeQuery(config)` - Errors grouped by response code
+- `buildGatewayKey(namespace, name, suffix)` - Gateway metric lookup key
+
+**Usage in Components:**
+```typescript
+import { fetchConfig, MetricsConfig } from '../utils/topology/configLoader';
+import { buildTotalRequestsQuery } from '../utils/metricsQueries';
+
+const [config, setConfig] = React.useState<KuadrantConfig | null>(null);
+React.useEffect(() => {
+  fetchConfig().then(setConfig).catch(console.error);
+}, []);
+
+const metricsConfig: MetricsConfig = config?.METRICS || {
+  // fallback defaults
+};
+
+const [totalRequestsRes] = usePrometheusPoll({
+  endpoint: PrometheusEndpoint.QUERY,
+  query: buildTotalRequestsQuery(metricsConfig),
+});
+```
+
 ## Key Components
 
 - **KuadrantOverviewPage**: Main dashboard with gateway health status

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,58 +91,20 @@ const accessReviews = useAccessReviews(resourceAttributes);
 const canRead = accessReviews[0];
 ```
 
-### 5. Metrics Configuration
+### 5. Configuration
 
-The plugin supports configurable Prometheus metrics for gateway traffic monitoring. This allows the console to work with different Gateway API implementations (OpenShift 4.19+, OSSM, etc.).
+The plugin supports configurable Topology andPrometheus metrics for gateway traffic monitoring. This allows the console to work with different Gateway API implementations (OpenShift 4.19+, OSSM, etc.).
 
 **Configuration is managed through:**
-- `src/utils/topology/configLoader.ts` - Configuration schema and defaults
-- `src/utils/metricsQueries.ts` - Query builder utilities
+- `src/utils/configLoader.ts` - Configuration schema and defaults
+- `src/utils/metricsQueries.ts` - Query utilities
 - Environment variables in deployment manifests
 
-**Default Configuration (OpenShift 4.19+):**
+**Example ENV Configuration:**
 ```yaml
-METRICS_METRIC_NAME: istio_request_duration_milliseconds_count
-METRICS_QUERY_FUNCTION: rate
-METRICS_TIME_WINDOW: 2m
-METRICS_WORKLOAD_SUFFIX: "" # no suffix
-METRICS_SUCCESS_CODE_PATTERN: "2(.*)|3(.*)"
-```
-
-**OSSM Compatibility Configuration:**
-```yaml
-METRICS_METRIC_NAME: istio_requests_total
-METRICS_QUERY_FUNCTION: increase
-METRICS_TIME_WINDOW: 24h
-METRICS_WORKLOAD_SUFFIX: "-istio"
-METRICS_SUCCESS_CODE_PATTERN: "2(.*)|3(.*)"
-```
-
-**Query Builders:**
-The `metricsQueries.ts` utility provides DRY query construction:
-- `buildTotalRequestsQuery(config)` - Total requests across all gateways
-- `buildErrorRequestsQuery(config)` - Error requests (non-2xx/3xx)
-- `buildErrorsByCodeQuery(config)` - Errors grouped by response code
-- `buildGatewayKey(namespace, name, suffix)` - Gateway metric lookup key
-
-**Usage in Components:**
-```typescript
-import { fetchConfig, MetricsConfig } from '../utils/topology/configLoader';
-import { buildTotalRequestsQuery } from '../utils/metricsQueries';
-
-const [config, setConfig] = React.useState<KuadrantConfig | null>(null);
-React.useEffect(() => {
-  fetchConfig().then(setConfig).catch(console.error);
-}, []);
-
-const metricsConfig: MetricsConfig = config?.METRICS || {
-  // fallback defaults
-};
-
-const [totalRequestsRes] = usePrometheusPoll({
-  endpoint: PrometheusEndpoint.QUERY,
-  query: buildTotalRequestsQuery(metricsConfig),
-});
+TOPOLOGY_CONFIGMAP_NAME: "topology"
+TOPOLOGY_CONFIGMAP_NAMESPACE: "kuadrant-system"
+METRICS_WORKLOAD_SUFFIX: "-openshift-default"
 ```
 
 ## Key Components

--- a/charts/openshift-console-plugin/templates/deployment.yaml
+++ b/charts/openshift-console-plugin/templates/deployment.yaml
@@ -23,6 +23,21 @@ spec:
             - containerPort: {{ .Values.plugin.port }}
               protocol: TCP
           imagePullPolicy: {{ .Values.plugin.imagePullPolicy }}
+          env:
+            - name: TOPOLOGY_CONFIGMAP_NAME
+              value: {{ .Values.plugin.topologyConfigMapName | default "topology" | quote }}
+            - name: TOPOLOGY_CONFIGMAP_NAMESPACE
+              value: {{ .Values.plugin.topologyConfigMapNamespace | default "kuadrant-system" | quote }}
+            - name: METRICS_METRIC_NAME
+              value: {{ .Values.plugin.metrics.metricName | quote }}
+            - name: METRICS_QUERY_FUNCTION
+              value: {{ .Values.plugin.metrics.queryFunction | quote }}
+            - name: METRICS_TIME_WINDOW
+              value: {{ .Values.plugin.metrics.timeWindow | quote }}
+            - name: METRICS_WORKLOAD_SUFFIX
+              value: {{ .Values.plugin.metrics.workloadSuffix | quote }}
+            - name: METRICS_SUCCESS_CODE_PATTERN
+              value: {{ .Values.plugin.metrics.successCodePattern | quote }}
           {{- if and (.Values.plugin.securityContext.enabled) (.Values.plugin.containerSecurityContext) }}
           securityContext: {{ tpl (toYaml (omit .Values.plugin.containerSecurityContext "enabled")) $ | nindent 12 }}
           {{- end }}

--- a/charts/openshift-console-plugin/templates/deployment.yaml
+++ b/charts/openshift-console-plugin/templates/deployment.yaml
@@ -28,16 +28,8 @@ spec:
               value: {{ .Values.plugin.topologyConfigMapName | default "topology" | quote }}
             - name: TOPOLOGY_CONFIGMAP_NAMESPACE
               value: {{ .Values.plugin.topologyConfigMapNamespace | default "kuadrant-system" | quote }}
-            - name: METRICS_METRIC_NAME
-              value: {{ .Values.plugin.metrics.metricName | quote }}
-            - name: METRICS_QUERY_FUNCTION
-              value: {{ .Values.plugin.metrics.queryFunction | quote }}
-            - name: METRICS_TIME_WINDOW
-              value: {{ .Values.plugin.metrics.timeWindow | quote }}
             - name: METRICS_WORKLOAD_SUFFIX
-              value: {{ .Values.plugin.metrics.workloadSuffix | quote }}
-            - name: METRICS_SUCCESS_CODE_PATTERN
-              value: {{ .Values.plugin.metrics.successCodePattern | quote }}
+              value: {{ .Values.plugin.metricsWorkloadSuffix | default "-openshift-default" | quote }}
           {{- if and (.Values.plugin.securityContext.enabled) (.Values.plugin.containerSecurityContext) }}
           securityContext: {{ tpl (toYaml (omit .Values.plugin.containerSecurityContext "enabled")) $ | nindent 12 }}
           {{- end }}

--- a/charts/openshift-console-plugin/values.yaml
+++ b/charts/openshift-console-plugin/values.yaml
@@ -33,6 +33,14 @@ plugin:
     create: true
     annotations: {}
     name: ""
+  topologyConfigMapName: "topology"
+  topologyConfigMapNamespace: "kuadrant-system"
+  metrics:
+    metricName: "istio_request_duration_milliseconds_count"
+    queryFunction: "rate"
+    timeWindow: "2m"
+    workloadSuffix: ""
+    successCodePattern: "2(.*)|3(.*)"
   jobs:
     patchConsoles:
       enabled: true

--- a/charts/openshift-console-plugin/values.yaml
+++ b/charts/openshift-console-plugin/values.yaml
@@ -35,12 +35,7 @@ plugin:
     name: ""
   topologyConfigMapName: "topology"
   topologyConfigMapNamespace: "kuadrant-system"
-  metrics:
-    metricName: "istio_request_duration_milliseconds_count"
-    queryFunction: "rate"
-    timeWindow: "2m"
-    workloadSuffix: ""
-    successCodePattern: "2(.*)|3(.*)"
+  metricsWorkloadSuffix: "-openshift-default"
   jobs:
     patchConsoles:
       enabled: true

--- a/e2e/tests/rbac.spec.ts
+++ b/e2e/tests/rbac.spec.ts
@@ -356,4 +356,67 @@ test.describe('RBAC - test-admin persona', () => {
     ).not.toBeVisible({ timeout: 15_000 });
     await expect(page.locator('text=Topology View')).toBeVisible({ timeout: 15_000 });
   });
+
+  test('namespace picker changes to namespace-scoped view', async ({ page }) => {
+    await navigateToOverview(page);
+    await waitForPermissionsLoaded(page);
+
+    // verify we're on cluster-wide view
+    await expect(page).toHaveURL('/kuadrant/overview', { timeout: 15_000 });
+
+    // find the namespace dropdown button using various selectors
+    const namespaceButtonSelectors = [
+      'button[data-test="namespace-dropdown-toggle"]',
+      'button[data-test="namespace-bar-dropdown"]',
+      '[data-test-id="namespace-bar-dropdown"] button',
+      '.co-namespace-selector button',
+      '.co-namespace-bar button',
+    ];
+
+    const namespaceButton = await (async () => {
+      for (const selector of namespaceButtonSelectors) {
+        const element = page.locator(selector).first();
+        if ((await element.count()) > 0 && (await element.isVisible())) {
+          return element;
+        }
+      }
+      throw new Error('Could not locate namespace picker button');
+    })();
+
+    // click to open dropdown
+    await namespaceButton.click();
+    await page.waitForTimeout(1000);
+
+    // select kuadrant-system namespace
+    const namespaceOptionSelectors = [
+      'li:has-text("kuadrant-system")',
+      'button:has-text("kuadrant-system")',
+      'a:has-text("kuadrant-system")',
+      '[role="option"]:has-text("kuadrant-system")',
+    ];
+
+    const namespaceOption = await (async () => {
+      for (const selector of namespaceOptionSelectors) {
+        const element = page.locator(selector).first();
+        if ((await element.count()) > 0 && (await element.isVisible())) {
+          return element;
+        }
+      }
+      throw new Error('Could not locate kuadrant-system namespace option');
+    })();
+
+    await namespaceOption.click();
+    await page.waitForTimeout(2000);
+
+    // verify URL changed to namespace-scoped view
+    await expect(page).toHaveURL('/kuadrant/ns/kuadrant-system/overview', {
+      timeout: 15_000,
+    });
+
+    // verify URL doesn't revert back to cluster-wide view
+    await page.waitForTimeout(2000);
+    await expect(page).toHaveURL('/kuadrant/ns/kuadrant-system/overview', {
+      timeout: 5_000,
+    });
+  });
 });

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -5,13 +5,7 @@ cat <<EOF > /tmp/config.js
 window.kuadrant_config = {
   TOPOLOGY_CONFIGMAP_NAME: '${TOPOLOGY_CONFIGMAP_NAME:-topology}',
   TOPOLOGY_CONFIGMAP_NAMESPACE: '${TOPOLOGY_CONFIGMAP_NAMESPACE:-kuadrant-system}',
-  METRICS: {
-    metricName: '${METRICS_METRIC_NAME:-istio_request_duration_milliseconds_count}',
-    queryFunction: '${METRICS_QUERY_FUNCTION:-rate}',
-    timeWindow: '${METRICS_TIME_WINDOW:-2m}',
-    workloadSuffix: '${METRICS_WORKLOAD_SUFFIX:-}',
-    successCodePattern: '${METRICS_SUCCESS_CODE_PATTERN:-2(.*)|3(.*)}',
-  }
+  METRICS_WORKLOAD_SUFFIX: '-openshift-default'
 };
 EOF
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,10 +1,17 @@
 #!/bin/bash
 
-# Inject topology ConfigMap location
+# Inject topology ConfigMap location and metrics configuration
 cat <<EOF > /tmp/config.js
 window.kuadrant_config = {
-  TOPOLOGY_CONFIGMAP_NAME: '${TOPOLOGY_CONFIGMAP_NAME}',
-  TOPOLOGY_CONFIGMAP_NAMESPACE: '${TOPOLOGY_CONFIGMAP_NAMESPACE}'
+  TOPOLOGY_CONFIGMAP_NAME: '${TOPOLOGY_CONFIGMAP_NAME:-topology}',
+  TOPOLOGY_CONFIGMAP_NAMESPACE: '${TOPOLOGY_CONFIGMAP_NAMESPACE:-kuadrant-system}',
+  METRICS: {
+    metricName: '${METRICS_METRIC_NAME:-istio_request_duration_milliseconds_count}',
+    queryFunction: '${METRICS_QUERY_FUNCTION:-rate}',
+    timeWindow: '${METRICS_TIME_WINDOW:-2m}',
+    workloadSuffix: '${METRICS_WORKLOAD_SUFFIX:-}',
+    successCodePattern: '${METRICS_SUCCESS_CODE_PATTERN:-2(.*)|3(.*)}',
+  }
 };
 EOF
 

--- a/install.yaml
+++ b/install.yaml
@@ -36,6 +36,16 @@ spec:
             value: topology
           - name: TOPOLOGY_CONFIGMAP_NAMESPACE
             value: kuadrant-system
+          - name: METRICS_METRIC_NAME
+            value: istio_request_duration_milliseconds_count
+          - name: METRICS_QUERY_FUNCTION
+            value: rate
+          - name: METRICS_TIME_WINDOW
+            value: 2m
+          - name: METRICS_WORKLOAD_SUFFIX
+            value: ""
+          - name: METRICS_SUCCESS_CODE_PATTERN
+            value: "2(.*)|3(.*)"
         volumeMounts:
         - name: plugin-serving-cert
           readOnly: true

--- a/install.yaml
+++ b/install.yaml
@@ -36,16 +36,8 @@ spec:
             value: topology
           - name: TOPOLOGY_CONFIGMAP_NAMESPACE
             value: kuadrant-system
-          - name: METRICS_METRIC_NAME
-            value: istio_request_duration_milliseconds_count
-          - name: METRICS_QUERY_FUNCTION
-            value: rate
-          - name: METRICS_TIME_WINDOW
-            value: 2m
           - name: METRICS_WORKLOAD_SUFFIX
-            value: ""
-          - name: METRICS_SUCCESS_CODE_PATTERN
-            value: "2(.*)|3(.*)"
+            value: -openshift-default
         volumeMounts:
         - name: plugin-serving-cert
           readOnly: true

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
   },
   "resolutions": {
     "http-proxy-middleware": "2.0.7",
-    "lodash": "4.17.23",
+    "immutable": "3.8.3",
+    "lodash": "4.18.0",
     "node-forge": "^1.3.2",
     "qs": "6.14.1"
   },

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "upstream-replacements": "node downstream.js --upstream && yarn i18n && yarn lint"
   },
   "resolutions": {
+    "follow-redirects": "^1.16.0",
     "http-proxy-middleware": "2.0.7",
     "immutable": "3.8.3",
     "lodash": "4.18.0",

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -65,13 +65,13 @@ import { useHistory } from 'react-router-dom';
 import useAccessReviews from '../utils/resourceRBAC';
 import { getResourceNameFromKind } from '../utils/getModelFromResource';
 import { KuadrantStatusAlert } from './KuadrantStatusAlert';
-import { fetchConfig, KuadrantConfig, MetricsConfig } from '../utils/topology/configLoader';
 import {
-  buildTotalRequestsQuery,
-  buildErrorRequestsQuery,
-  buildErrorsByCodeQuery,
+  TOTAL_REQUESTS_QUERY,
+  ERROR_REQUEST_QUERY,
+  ERRORS_BY_CODE_QUERY,
   buildGatewayKey,
 } from '../utils/metricsQueries';
+import { fetchConfig, KuadrantConfig } from '../utils/topology/configLoader';
 
 export type MenuToggleElement = HTMLDivElement | HTMLButtonElement;
 
@@ -132,13 +132,7 @@ const KuadrantOverviewPage: React.FC = () => {
     fetchConfig().then(setConfig).catch(console.error);
   }, []);
 
-  const metricsConfig: MetricsConfig = config?.METRICS || {
-    metricName: 'istio_request_duration_milliseconds_count',
-    queryFunction: 'rate',
-    timeWindow: '2m',
-    workloadSuffix: '',
-    successCodePattern: '2(.*)|3(.*)',
-  };
+  const metricsWorkloadSuffix: string = config?.METRICS_WORKLOAD_SUFFIX || '-openshift-default';
 
   const onToggleClick = () => {
     setIsCreateOpen(!isCreateOpen);
@@ -441,16 +435,16 @@ const KuadrantOverviewPage: React.FC = () => {
   // Prometheus queries for gateway traffic
   const [totalRequestsRes, totalRequestsLoaded, totalRequestsError] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY,
-    query: buildTotalRequestsQuery(metricsConfig),
+    query: TOTAL_REQUESTS_QUERY,
   });
   const [totalErrorsRes, totalErrorsLoaded, totalErrorsError] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY,
-    query: buildErrorRequestsQuery(metricsConfig),
+    query: ERROR_REQUEST_QUERY,
   });
   const [totalErrorsByCodeRes, totalErrorsByCodeLoaded, totalErrorsByCodeError] = usePrometheusPoll(
     {
       endpoint: PrometheusEndpoint.QUERY,
-      query: buildErrorsByCodeQuery(metricsConfig),
+      query: ERRORS_BY_CODE_QUERY,
     },
   );
 
@@ -485,41 +479,25 @@ const KuadrantOverviewPage: React.FC = () => {
 
   // Helper functions to pull out metric values in correct format, given a gateway object
   const getTotalRequests = (obj: { metadata: { namespace: string; name: string } }): number => {
-    const key = buildGatewayKey(
-      obj.metadata.namespace,
-      obj.metadata.name,
-      metricsConfig.workloadSuffix,
-    );
+    const key = buildGatewayKey(obj.metadata.namespace, obj.metadata.name, metricsWorkloadSuffix);
     const total = totalRequestsByGateway[key]?.total;
     return Number.isFinite(total) ? Math.round(total) : 0;
   };
   const getSuccessfulRequests = (obj: {
     metadata: { namespace: string; name: string };
   }): number => {
-    const key = buildGatewayKey(
-      obj.metadata.namespace,
-      obj.metadata.name,
-      metricsConfig.workloadSuffix,
-    );
+    const key = buildGatewayKey(obj.metadata.namespace, obj.metadata.name, metricsWorkloadSuffix);
     const success = totalRequestsByGateway[key]?.total - totalRequestsByGateway[key]?.errors;
     return Number.isFinite(success) ? Math.round(success) : 0;
   };
   const getErrorRate = (obj: { metadata: { namespace: string; name: string } }): string => {
-    const key = buildGatewayKey(
-      obj.metadata.namespace,
-      obj.metadata.name,
-      metricsConfig.workloadSuffix,
-    );
+    const key = buildGatewayKey(obj.metadata.namespace, obj.metadata.name, metricsWorkloadSuffix);
     const rate = (totalRequestsByGateway[key]?.errors / totalRequestsByGateway[key]?.total) * 100;
     return Number.isFinite(rate) ? rate.toFixed(1) : '-';
   };
   const getErrorCodes = (obj: { metadata: { namespace: string; name: string } }): Set<string> => {
     const codes = new Set<string>();
-    const key = buildGatewayKey(
-      obj.metadata.namespace,
-      obj.metadata.name,
-      metricsConfig.workloadSuffix,
-    );
+    const key = buildGatewayKey(obj.metadata.namespace, obj.metadata.name, metricsWorkloadSuffix);
     if (totalRequestsByGateway[key]?.codes) {
       Object.entries(totalRequestsByGateway[key].codes).forEach(([key, value]) => {
         if (key.startsWith('4') && value > 0) {
@@ -541,11 +519,7 @@ const KuadrantOverviewPage: React.FC = () => {
     obj: { metadata: { namespace: string; name: string } },
     prefix: string,
   ): Array<[string, Distribution]> => {
-    const key = buildGatewayKey(
-      obj.metadata.namespace,
-      obj.metadata.name,
-      metricsConfig.workloadSuffix,
-    );
+    const key = buildGatewayKey(obj.metadata.namespace, obj.metadata.name, metricsWorkloadSuffix);
     const codes = totalRequestsByGateway[key]?.codes ?? {};
     const filteredCodes = Object.entries(codes).filter(([code]) => code.startsWith(prefix));
 

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -190,7 +190,7 @@ const KuadrantOverviewPage: React.FC = () => {
     if (ns && ns !== activeNamespace) {
       setActiveNamespace(ns);
     }
-  }, [ns, activeNamespace, setActiveNamespace]);
+  }, [ns, setActiveNamespace]);
 
   const handleHideCard = () => {
     setHideCard(true);

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -65,6 +65,13 @@ import { useHistory } from 'react-router-dom';
 import useAccessReviews from '../utils/resourceRBAC';
 import { getResourceNameFromKind } from '../utils/getModelFromResource';
 import { KuadrantStatusAlert } from './KuadrantStatusAlert';
+import { fetchConfig, KuadrantConfig, MetricsConfig } from '../utils/topology/configLoader';
+import {
+  buildTotalRequestsQuery,
+  buildErrorRequestsQuery,
+  buildErrorsByCodeQuery,
+  buildGatewayKey,
+} from '../utils/metricsQueries';
 
 export type MenuToggleElement = HTMLDivElement | HTMLButtonElement;
 
@@ -117,6 +124,22 @@ const KuadrantOverviewPage: React.FC = () => {
   const [hideCard, setHideCard] = React.useState(
     sessionStorage.getItem('hideGettingStarted') === 'true',
   );
+
+  // Load metrics configuration
+  const [config, setConfig] = React.useState<KuadrantConfig | null>(null);
+
+  React.useEffect(() => {
+    fetchConfig().then(setConfig).catch(console.error);
+  }, []);
+
+  const metricsConfig: MetricsConfig = config?.METRICS || {
+    metricName: 'istio_request_duration_milliseconds_count',
+    queryFunction: 'rate',
+    timeWindow: '2m',
+    workloadSuffix: '',
+    successCodePattern: '2(.*)|3(.*)',
+  };
+
   const onToggleClick = () => {
     setIsCreateOpen(!isCreateOpen);
   };
@@ -418,19 +441,16 @@ const KuadrantOverviewPage: React.FC = () => {
   // Prometheus queries for gateway traffic
   const [totalRequestsRes, totalRequestsLoaded, totalRequestsError] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY,
-    query:
-      'sum by (source_workload, source_workload_namespace) (increase(istio_requests_total[24h]))',
+    query: buildTotalRequestsQuery(metricsConfig),
   });
   const [totalErrorsRes, totalErrorsLoaded, totalErrorsError] = usePrometheusPoll({
     endpoint: PrometheusEndpoint.QUERY,
-    query:
-      'sum by (source_workload, source_workload_namespace) (increase(istio_requests_total{response_code!~"2(.*)|3(.*)"}[24h]))',
+    query: buildErrorRequestsQuery(metricsConfig),
   });
   const [totalErrorsByCodeRes, totalErrorsByCodeLoaded, totalErrorsByCodeError] = usePrometheusPoll(
     {
       endpoint: PrometheusEndpoint.QUERY,
-      query:
-        'sum by (response_code, source_workload, source_workload_namespace) (increase(istio_requests_total{response_code!~"2(.*)|3(.*)"}[24h]))',
+      query: buildErrorsByCodeQuery(metricsConfig),
     },
   );
 
@@ -465,25 +485,41 @@ const KuadrantOverviewPage: React.FC = () => {
 
   // Helper functions to pull out metric values in correct format, given a gateway object
   const getTotalRequests = (obj: { metadata: { namespace: string; name: string } }): number => {
-    const key = `${obj.metadata.namespace}/${obj.metadata.name}-istio`;
+    const key = buildGatewayKey(
+      obj.metadata.namespace,
+      obj.metadata.name,
+      metricsConfig.workloadSuffix,
+    );
     const total = totalRequestsByGateway[key]?.total;
     return Number.isFinite(total) ? Math.round(total) : 0;
   };
   const getSuccessfulRequests = (obj: {
     metadata: { namespace: string; name: string };
   }): number => {
-    const key = `${obj.metadata.namespace}/${obj.metadata.name}-istio`;
+    const key = buildGatewayKey(
+      obj.metadata.namespace,
+      obj.metadata.name,
+      metricsConfig.workloadSuffix,
+    );
     const success = totalRequestsByGateway[key]?.total - totalRequestsByGateway[key]?.errors;
     return Number.isFinite(success) ? Math.round(success) : 0;
   };
   const getErrorRate = (obj: { metadata: { namespace: string; name: string } }): string => {
-    const key = `${obj.metadata.namespace}/${obj.metadata.name}-istio`;
+    const key = buildGatewayKey(
+      obj.metadata.namespace,
+      obj.metadata.name,
+      metricsConfig.workloadSuffix,
+    );
     const rate = (totalRequestsByGateway[key]?.errors / totalRequestsByGateway[key]?.total) * 100;
     return Number.isFinite(rate) ? rate.toFixed(1) : '-';
   };
   const getErrorCodes = (obj: { metadata: { namespace: string; name: string } }): Set<string> => {
     const codes = new Set<string>();
-    const key = `${obj.metadata.namespace}/${obj.metadata.name}-istio`;
+    const key = buildGatewayKey(
+      obj.metadata.namespace,
+      obj.metadata.name,
+      metricsConfig.workloadSuffix,
+    );
     if (totalRequestsByGateway[key]?.codes) {
       Object.entries(totalRequestsByGateway[key].codes).forEach(([key, value]) => {
         if (key.startsWith('4') && value > 0) {
@@ -505,7 +541,11 @@ const KuadrantOverviewPage: React.FC = () => {
     obj: { metadata: { namespace: string; name: string } },
     prefix: string,
   ): Array<[string, Distribution]> => {
-    const key = `${obj.metadata.namespace}/${obj.metadata.name}-istio`;
+    const key = buildGatewayKey(
+      obj.metadata.namespace,
+      obj.metadata.name,
+      metricsConfig.workloadSuffix,
+    );
     const codes = totalRequestsByGateway[key]?.codes ?? {};
     const filteredCodes = Object.entries(codes).filter(([code]) => code.startsWith(prefix));
 

--- a/src/components/PolicyTopologyPage.tsx
+++ b/src/components/PolicyTopologyPage.tsx
@@ -15,7 +15,7 @@ import {
 import { useTranslation } from 'react-i18next';
 import './kuadrant.css';
 import NoPermissionsView from './NoPermissionsView';
-import { fetchConfig, TopologyConfig } from '../utils/topology/configLoader';
+import { fetchConfig, KuadrantConfig } from '../utils/topology/configLoader';
 import { useVisualizationController } from '../hooks/topology/useVisualizationController';
 import { useTopologyData } from '../hooks/topology/useTopologyData';
 import { ResourceFilterToolbar } from './topology/ResourceFilterToolbar';
@@ -25,7 +25,7 @@ const PolicyTopologyPage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
 
   // config and state
-  const [config, setConfig] = React.useState<TopologyConfig | null>(null);
+  const [config, setConfig] = React.useState<KuadrantConfig | null>(null);
   const [selectedResourceTypes, setSelectedResourceTypes] = React.useState<string[]>([]);
   const [selectedNamespace, setSelectedNamespace] = React.useState<string | null>(null);
 

--- a/src/utils/metricsQueries.ts
+++ b/src/utils/metricsQueries.ts
@@ -1,0 +1,69 @@
+import { MetricsConfig } from './topology/configLoader';
+
+/**
+ * Builds a Prometheus query for total requests across all gateways.
+ *
+ * @param config - Metrics configuration containing metric name, query function, and time window
+ * @returns Prometheus query string
+ *
+ * @example
+ * // With default config (OpenShift 4.19+):
+ * // sum by (source_workload, source_workload_namespace) (rate(istio_request_duration_milliseconds_count[2m]))
+ *
+ * // With OSSM config:
+ * // sum by (source_workload, source_workload_namespace) (increase(istio_requests_total[24h]))
+ */
+export const buildTotalRequestsQuery = (config: MetricsConfig): string => {
+  return `sum by (source_workload, source_workload_namespace) (${config.queryFunction}(${config.metricName}[${config.timeWindow}]))`;
+};
+
+/**
+ * Builds a Prometheus query for error requests (non-2xx/3xx responses) across all gateways.
+ *
+ * @param config - Metrics configuration containing metric name, query function, time window, and success pattern
+ * @returns Prometheus query string
+ *
+ * @example
+ * // With default config (OpenShift 4.19+):
+ * // sum by (source_workload, source_workload_namespace) (rate(istio_request_duration_milliseconds_count{response_code!~"2(.*)|3(.*)"}[2m]))
+ */
+export const buildErrorRequestsQuery = (config: MetricsConfig): string => {
+  return `sum by (source_workload, source_workload_namespace) (${config.queryFunction}(${config.metricName}{response_code!~"${config.successCodePattern}"}[${config.timeWindow}]))`;
+};
+
+/**
+ * Builds a Prometheus query for error requests grouped by response code.
+ *
+ * @param config - Metrics configuration containing metric name, query function, time window, and success pattern
+ * @returns Prometheus query string
+ *
+ * @example
+ * // With default config (OpenShift 4.19+):
+ * // sum by (response_code, source_workload, source_workload_namespace) (rate(istio_request_duration_milliseconds_count{response_code!~"2(.*)|3(.*)"}[2m]))
+ */
+export const buildErrorsByCodeQuery = (config: MetricsConfig): string => {
+  return `sum by (response_code, source_workload, source_workload_namespace) (${config.queryFunction}(${config.metricName}{response_code!~"${config.successCodePattern}"}[${config.timeWindow}]))`;
+};
+
+/**
+ * Constructs a gateway lookup key for metric data based on namespace, name, and workload suffix.
+ *
+ * @param namespace - Kubernetes namespace of the gateway
+ * @param name - Name of the gateway resource
+ * @param workloadSuffix - Suffix appended to gateway name in metrics (e.g., "-istio" for OSSM)
+ * @returns Lookup key in format "namespace/name<suffix>"
+ *
+ * @example
+ * // OpenShift 4.19+ (no suffix):
+ * buildGatewayKey('kuadrant-system', 'my-gateway', '') // "kuadrant-system/my-gateway"
+ *
+ * // OSSM (with -istio suffix):
+ * buildGatewayKey('kuadrant-system', 'my-gateway', '-istio') // "kuadrant-system/my-gateway-istio"
+ */
+export const buildGatewayKey = (
+  namespace: string,
+  name: string,
+  workloadSuffix: string,
+): string => {
+  return `${namespace}/${name}${workloadSuffix}`;
+};

--- a/src/utils/metricsQueries.ts
+++ b/src/utils/metricsQueries.ts
@@ -1,64 +1,20 @@
-import { MetricsConfig } from './topology/configLoader';
+export const TOTAL_REQUESTS_QUERY = `sum by (source_workload, source_workload_namespace) (increase(istio_requests_total[24h]))`;
 
-/**
- * Builds a Prometheus query for total requests across all gateways.
- *
- * @param config - Metrics configuration containing metric name, query function, and time window
- * @returns Prometheus query string
- *
- * @example
- * // With default config (OpenShift 4.19+):
- * // sum by (source_workload, source_workload_namespace) (rate(istio_request_duration_milliseconds_count[2m]))
- *
- * // With OSSM config:
- * // sum by (source_workload, source_workload_namespace) (increase(istio_requests_total[24h]))
- */
-export const buildTotalRequestsQuery = (config: MetricsConfig): string => {
-  return `sum by (source_workload, source_workload_namespace) (${config.queryFunction}(${config.metricName}[${config.timeWindow}]))`;
-};
+export const ERROR_REQUEST_QUERY = `sum by (source_workload, source_workload_namespace) (increase(istio_requests_total{response_code!~"2(.*)|3(.*)"}[24h]))`;
 
-/**
- * Builds a Prometheus query for error requests (non-2xx/3xx responses) across all gateways.
- *
- * @param config - Metrics configuration containing metric name, query function, time window, and success pattern
- * @returns Prometheus query string
- *
- * @example
- * // With default config (OpenShift 4.19+):
- * // sum by (source_workload, source_workload_namespace) (rate(istio_request_duration_milliseconds_count{response_code!~"2(.*)|3(.*)"}[2m]))
- */
-export const buildErrorRequestsQuery = (config: MetricsConfig): string => {
-  return `sum by (source_workload, source_workload_namespace) (${config.queryFunction}(${config.metricName}{response_code!~"${config.successCodePattern}"}[${config.timeWindow}]))`;
-};
-
-/**
- * Builds a Prometheus query for error requests grouped by response code.
- *
- * @param config - Metrics configuration containing metric name, query function, time window, and success pattern
- * @returns Prometheus query string
- *
- * @example
- * // With default config (OpenShift 4.19+):
- * // sum by (response_code, source_workload, source_workload_namespace) (rate(istio_request_duration_milliseconds_count{response_code!~"2(.*)|3(.*)"}[2m]))
- */
-export const buildErrorsByCodeQuery = (config: MetricsConfig): string => {
-  return `sum by (response_code, source_workload, source_workload_namespace) (${config.queryFunction}(${config.metricName}{response_code!~"${config.successCodePattern}"}[${config.timeWindow}]))`;
-};
+export const ERRORS_BY_CODE_QUERY = `sum by (response_code, source_workload, source_workload_namespace) (increase(istio_requests_total{response_code!~"2(.*)|3(.*)"}[24h]))`;
 
 /**
  * Constructs a gateway lookup key for metric data based on namespace, name, and workload suffix.
  *
  * @param namespace - Kubernetes namespace of the gateway
  * @param name - Name of the gateway resource
- * @param workloadSuffix - Suffix appended to gateway name in metrics (e.g., "-istio" for OSSM)
+ * @param workloadSuffix - Suffix appended to gateway name in metrics (e.g., "-openshift-default" for OSSM 3)
  * @returns Lookup key in format "namespace/name<suffix>"
  *
  * @example
- * // OpenShift 4.19+ (no suffix):
- * buildGatewayKey('kuadrant-system', 'my-gateway', '') // "kuadrant-system/my-gateway"
- *
- * // OSSM (with -istio suffix):
- * buildGatewayKey('kuadrant-system', 'my-gateway', '-istio') // "kuadrant-system/my-gateway-istio"
+ * // OSSM 3 (with -openshift-default suffix):
+ * buildGatewayKey('ingress-gateway', 'my-gateway', '-openshift-default') // "ingress-gateway/my-gateway-openshift-default"
  */
 export const buildGatewayKey = (
   namespace: string,

--- a/src/utils/topology/configLoader.ts
+++ b/src/utils/topology/configLoader.ts
@@ -1,16 +1,32 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export interface TopologyConfig {
+export interface MetricsConfig {
+  metricName: string;
+  queryFunction: string;
+  timeWindow: string;
+  workloadSuffix: string;
+  successCodePattern: string;
+}
+
+export interface KuadrantConfig {
   TOPOLOGY_CONFIGMAP_NAME: string;
   TOPOLOGY_CONFIGMAP_NAMESPACE: string;
+  METRICS?: MetricsConfig;
 }
 
 // fetch the config.js file dynamically at runtime
 // normally served from <cluster-host>/api/plugins/kuadrant-console-plugin/config.js
-export const fetchConfig = async (): Promise<TopologyConfig> => {
-  const defaultConfig: TopologyConfig = {
+export const fetchConfig = async (): Promise<KuadrantConfig> => {
+  const defaultConfig: KuadrantConfig = {
     TOPOLOGY_CONFIGMAP_NAME: 'topology',
     TOPOLOGY_CONFIGMAP_NAMESPACE: 'kuadrant-system',
+    METRICS: {
+      metricName: 'istio_request_duration_milliseconds_count',
+      queryFunction: 'rate',
+      timeWindow: '2m',
+      workloadSuffix: '',
+      successCodePattern: '2(.*)|3(.*)',
+    },
   };
 
   try {

--- a/src/utils/topology/configLoader.ts
+++ b/src/utils/topology/configLoader.ts
@@ -1,20 +1,21 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-
 export interface KuadrantConfig {
   TOPOLOGY_CONFIGMAP_NAME: string;
   TOPOLOGY_CONFIGMAP_NAMESPACE: string;
   METRICS_WORKLOAD_SUFFIX: string;
 }
 
-// fetch the config.js file dynamically at runtime
-// normally served from <cluster-host>/api/plugins/kuadrant-console-plugin/config.js
-export const fetchConfig = async (): Promise<KuadrantConfig> => {
-  const defaultConfig: KuadrantConfig = {
-    TOPOLOGY_CONFIGMAP_NAME: 'topology',
-    TOPOLOGY_CONFIGMAP_NAMESPACE: 'kuadrant-system',
-    METRICS_WORKLOAD_SUFFIX: '-openshift-default',
-  };
+const DEFAULT_CONFIG: KuadrantConfig = {
+  TOPOLOGY_CONFIGMAP_NAME: 'topology',
+  TOPOLOGY_CONFIGMAP_NAMESPACE: 'kuadrant-system',
+  METRICS_WORKLOAD_SUFFIX: '-openshift-default',
+};
 
+// Module-level cache for boot-time configuration
+let configPromise: Promise<KuadrantConfig> | null = null;
+// Fetch the config.js file dynamically at runtime (once, then cached)
+// Normally served from <cluster-host>/api/plugins/kuadrant-console-plugin/config.js
+const loadConfig = async (): Promise<KuadrantConfig> => {
   try {
     const response = await fetch('/api/plugins/kuadrant-console-plugin/config.js');
     if (!response.ok) {
@@ -23,7 +24,7 @@ export const fetchConfig = async (): Promise<KuadrantConfig> => {
       } else {
         throw new Error(`Failed to fetch config.js: ${response.statusText}`);
       }
-      return defaultConfig;
+      return DEFAULT_CONFIG;
     }
 
     const script = await response.text();
@@ -32,9 +33,20 @@ export const fetchConfig = async (): Promise<KuadrantConfig> => {
     configScript.innerHTML = script;
     document.head.appendChild(configScript);
 
-    return (window as any).kuadrant_config || defaultConfig;
+    return (window as any).kuadrant_config || DEFAULT_CONFIG;
   } catch (error) {
     console.error('Error loading config.js:', error);
-    return defaultConfig;
+    return DEFAULT_CONFIG;
   }
+};
+
+/**
+ * Get Kuadrant configuration (singleton - fetched once per session)
+ * Safe to call from multiple components - all callers share the same promise
+ */
+export const fetchConfig = (): Promise<KuadrantConfig> => {
+  if (!configPromise) {
+    configPromise = loadConfig();
+  }
+  return configPromise;
 };

--- a/src/utils/topology/configLoader.ts
+++ b/src/utils/topology/configLoader.ts
@@ -1,17 +1,9 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-export interface MetricsConfig {
-  metricName: string;
-  queryFunction: string;
-  timeWindow: string;
-  workloadSuffix: string;
-  successCodePattern: string;
-}
-
 export interface KuadrantConfig {
   TOPOLOGY_CONFIGMAP_NAME: string;
   TOPOLOGY_CONFIGMAP_NAMESPACE: string;
-  METRICS?: MetricsConfig;
+  METRICS_WORKLOAD_SUFFIX: string;
 }
 
 // fetch the config.js file dynamically at runtime
@@ -20,13 +12,7 @@ export const fetchConfig = async (): Promise<KuadrantConfig> => {
   const defaultConfig: KuadrantConfig = {
     TOPOLOGY_CONFIGMAP_NAME: 'topology',
     TOPOLOGY_CONFIGMAP_NAMESPACE: 'kuadrant-system',
-    METRICS: {
-      metricName: 'istio_request_duration_milliseconds_count',
-      queryFunction: 'rate',
-      timeWindow: '2m',
-      workloadSuffix: '',
-      successCodePattern: '2(.*)|3(.*)',
-    },
+    METRICS_WORKLOAD_SUFFIX: '-openshift-default',
   };
 
   try {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6480,13 +6480,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"follow-redirects@npm:^1.0.0":
-  version: 1.15.6
-  resolution: "follow-redirects@npm:1.15.6"
+"follow-redirects@npm:^1.16.0":
+  version: 1.16.0
+  resolution: "follow-redirects@npm:1.16.0"
   peerDependenciesMeta:
     debug:
       optional: true
-  checksum: 10c0/9ff767f0d7be6aa6870c82ac79cf0368cd73e01bbc00e9eb1c2a16fbb198ec105e3c9b6628bb98e9f3ac66fe29a957b9645bcb9a490bb7aa0d35f908b6b85071
+  checksum: 10c0/a1e2900163e6f1b4d1ed5c221b607f41decbab65534c63fe7e287e40a5d552a6496e7d9d7d976fa4ba77b4c51c11e5e9f683f10b43011ea11e442ff128d0e181
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7564,10 +7564,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"immutable@npm:3.x":
-  version: 3.8.2
-  resolution: "immutable@npm:3.8.2"
-  checksum: 10c0/fb6a2999ad3bda9e51741721e42547076dd492635ee4df9241224055fe953ec843583a700088cc4915f23dc326e5084f4e17f1bbd7388c3e872ef5a242e0ac5e
+"immutable@npm:3.8.3":
+  version: 3.8.3
+  resolution: "immutable@npm:3.8.3"
+  checksum: 10c0/bafa7b8371b7622bc3d128cd9e6bba3a654b968f09a237929629f43ac26f7e974a5879cd38baad0c26f6f0628753968611bf832add7bf0c44d647bf4306a2988
   languageName: node
   linkType: hard
 
@@ -8755,10 +8755,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash@npm:4.17.23":
-  version: 4.17.23
-  resolution: "lodash@npm:4.17.23"
-  checksum: 10c0/1264a90469f5bb95d4739c43eb6277d15b6d9e186df4ac68c3620443160fc669e2f14c11e7d8b2ccf078b81d06147c01a8ccced9aab9f9f63d50dcf8cace6bf6
+"lodash@npm:4.18.0":
+  version: 4.18.0
+  resolution: "lodash@npm:4.18.0"
+  checksum: 10c0/0c5a7c5a4ea1db59ade40ff03cc8bfc7ea79806f5639ff4c7ee581811c8d88248bf1da608199b9d3614d8db133088bd434f3307c3951a96a821044f72a5ba810
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Cherry-picked patch-safe fixes from `main` for the v0.3.7 patch release (Kuadrant 1.4.4).

The `release-0.3` branch was created from `release-v0.3` at the v0.3.6 tag as part of the RFC 0018 migration.

## Bug fix
- **Fix metrics not populating without OSSM** (#306, PR #329) — replaces hardcoded `-istio` suffix with configurable `METRICS_WORKLOAD_SUFFIX`. Metrics dashboard was unusable for non-OSSM users (default from OCP 4.19 onward). Adds runtime config loading for metrics queries.
- **Fix namespace picker race condition** — namespace selections were immediately reverting due to a sync effect dependency loop.

## Security
- **CVE-2026-40895**: upgrade follow-redirects to 1.16.0 (information disclosure on cross-domain redirects)
- **CVE-2026-4800**: bump lodash resolution to 4.18.0
- **CVE-2026-29063**: pin immutable resolution to 3.8.3

## Skipped from metrics fix PR
- `[setup] Fix observability & policy enforcement` (2cc1a8c) — dev setup only (`kuadrant-dev-setup/`), conflicts with release branch, not needed for the fix

## Skipped (not patch-safe)
- Combined filter box, table tooltips (features)
- API product views, API management RBAC (features)
- e2e test improvements (test-only, depend on new features)
- Resource filter badge count fix (depends on topology refactor)

## Test plan
- [x] CI passes on the release-0.3 branch
- [ ] Verify metrics populate on OCP 4.19+ without OSSM
- [ ] Verify namespace picker selections persist after clicking

🤖 Generated with [Claude Code](https://claude.com/claude-code)