### PR TITLE
fix: correct broken workflow link in RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,7 +33,7 @@ git push upstream vX.Y.Z
 - [Create a new GitHub release](https://github.com/Kuadrant/kuadrant-console-plugin/releases) from the tag you just pushed.
 - Use auto-generated release notes.
 
-This triggers the `Build and Push Versioned Multi-arch Image (Release)` [GitHub workflow](https://github.com/Kuadrant/kuadrant-console-plugin/blob/da4dc0582c442be725a534ff2790811d9cf7ecd7/.github/workflows/release-build.yaml#L51), which:
+This triggers the `Build and Push Versioned Multi-arch Image (Release)` [GitHub workflow](https://github.com/Kuadrant/kuadrant-console-plugin/blob/main/.github/workflows/release-build.yaml#L51), which:
 - Builds the `kuadrant-console-plugin` image.
 - Pushes the versioned image to [Quay.io](https://quay.io/repository/kuadrant/console-plugin?tab=tags).
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -33,7 +33,7 @@ git push upstream vX.Y.Z
 - [Create a new GitHub release](https://github.com/Kuadrant/kuadrant-console-plugin/releases) from the tag you just pushed.
 - Use auto-generated release notes.
 
-This triggers the `Build and Push Versioned Multi-arch Image (Release)` [GitHub workflow](https://github.com/Kuadrant/kuadrant-console-plugin/blob/da4dc0582c442be725a534ff2790811d9cf7ecd7/.github/workflows/build.yaml#L51), which:
+This triggers the `Build and Push Versioned Multi-arch Image (Release)` [GitHub workflow](https://github.com/Kuadrant/kuadrant-console-plugin/blob/da4dc0582c442be725a534ff2790811d9cf7ecd7/.github/workflows/release-build.yaml#L51), which:
 - Builds the `kuadrant-console-plugin` image.
 - Pushes the versioned image to [Quay.io](https://quay.io/repository/kuadrant/console-plugin?tab=tags).
 


### PR DESCRIPTION
Fixes #444

Updated broken link from `build.yaml` to `release-build.yaml` in `RELEASE.md` because `build.yaml` does not exist in the repository.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release documentation to reference a revised build workflow for the versioned multi‑architecture image build/push process.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->