### PR TITLE
test: add APIProduct details tabs e2e tests

### DIFF
--- a/e2e/tests/apiproduct-details-tabs.spec.ts
+++ b/e2e/tests/apiproduct-details-tabs.spec.ts
@@ -1,0 +1,368 @@
+import { test, expect, Page } from '@playwright/test';
+import { TEST_NAMESPACE, dismissConsoleTour, spaNavigate } from './helpers';
+
+// Test custom tabs in APIProduct details page: Definition, Target, Policies
+
+// Navigate to APIProduct detail page (Details tab is default)
+async function navigateToAPIProductDetails(
+  page: Page,
+  namespace: string,
+  productName: string,
+): Promise<void> {
+  await spaNavigate(
+    page,
+    `/k8s/ns/${namespace}/devportal.kuadrant.io~v1alpha1~APIProduct/${productName}`,
+  );
+}
+
+// Navigate to a specific tab of the APIProduct detail page
+async function navigateToAPIProductTab(
+  page: Page,
+  namespace: string,
+  productName: string,
+  tab: string,
+): Promise<void> {
+  await spaNavigate(
+    page,
+    `/k8s/ns/${namespace}/devportal.kuadrant.io~v1alpha1~APIProduct/${productName}/${tab}`,
+  );
+}
+
+test.describe('APIProduct Details Page - Custom Tabs', () => {
+  // Use test-list-product-2 which has openAPISpecURL configured
+  const API_PRODUCT_NAME = 'test-list-product-2';
+
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('load');
+    await dismissConsoleTour(page);
+  });
+
+  test('should display custom plugin tabs on APIProduct detail page', async ({ page }) => {
+    // Navigate to APIProduct detail page
+    await navigateToAPIProductDetails(page, TEST_NAMESPACE, API_PRODUCT_NAME);
+
+    // Verify custom plugin tabs are visible
+    // Custom tabs: Definition, Target, Policies
+    const tabs = page.locator('[role="tablist"] button, [role="tablist"] a').first();
+    await expect(tabs).toBeVisible({ timeout: 15_000 });
+
+    // Check for each custom tab
+    await expect(
+      page.locator(
+        '[role="tablist"] button:has-text("Definition"), [role="tablist"] a:has-text("Definition")',
+      ),
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        '[role="tablist"] button:has-text("Target"), [role="tablist"] a:has-text("Target")',
+      ),
+    ).toBeVisible();
+    await expect(
+      page.locator(
+        '[role="tablist"] button:has-text("Policies"), [role="tablist"] a:has-text("Policies")',
+      ),
+    ).toBeVisible();
+  });
+
+  test('should display Definition tab empty state when no spec available', async ({ page }) => {
+    const { execSync } = await import('child_process');
+    const testNs = `test-tabs-${Date.now()}`;
+    const httpRouteName = 'test-route-no-spec';
+    const apiProductName = 'test-product-no-spec';
+
+    try {
+      // Create dedicated namespace
+      execSync(`kubectl create namespace ${testNs}`, { stdio: 'pipe' });
+
+      // Create HTTPRoute
+      const httpRoute = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${httpRouteName}
+  namespace: ${testNs}
+spec:
+  parentRefs:
+    - name: test-gateway
+      namespace: ${TEST_NAMESPACE}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /test
+      backendRefs:
+        - name: test-backend
+          port: 8080
+`;
+      execSync(`echo '${httpRoute}' | kubectl apply -f -`, { stdio: 'pipe' });
+
+      // Create APIProduct WITHOUT openAPISpecURL (no spec for controller to sync)
+      const apiProduct = `
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIProduct
+metadata:
+  name: ${apiProductName}
+  namespace: ${testNs}
+spec:
+  displayName: Test No Spec
+  version: v1.0.0
+  publishStatus: Published
+  approvalMode: manual
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ${httpRouteName}
+`;
+      execSync(`echo '${apiProduct}' | kubectl apply -f -`, { stdio: 'pipe' });
+
+      // Navigate to Definition tab
+      await navigateToAPIProductTab(page, testNs, apiProductName, 'definition');
+
+      // Verify empty state is shown
+      const emptyStateText = page.getByText('No OpenAPI specification available');
+      await expect(emptyStateText).toBeVisible({ timeout: 10_000 });
+    } finally {
+      // Cleanup: delete namespace (removes all resources)
+      try {
+        execSync(`kubectl delete namespace ${testNs} --ignore-not-found`, { stdio: 'pipe' });
+      } catch (error) {
+        console.log('Cleanup error (non-fatal):', error);
+      }
+    }
+  });
+
+  test('should display Definition tab with OpenAPI spec (Swagger UI)', async ({ page }) => {
+    // Use toystore-api which has a valid openAPISpecURL that the controller syncs
+    const TOYSTORE_API = 'toystore-api';
+
+    // Navigate to Definition tab
+    await navigateToAPIProductTab(page, TEST_NAMESPACE, TOYSTORE_API, 'definition');
+
+    // Verify Swagger UI renders (wait for it to load)
+    const swaggerContainer = page.locator('.swagger-ui');
+    await expect(swaggerContainer).toBeVisible({ timeout: 15_000 });
+
+    // Verify it contains the Petstore API info
+    await expect(page.getByText('Pet Store API', { exact: false })).toBeVisible({
+      timeout: 10_000,
+    });
+  });
+
+  test('should display Policies tab empty state when no policies attached', async ({ page }) => {
+    const { execSync } = await import('child_process');
+    const testNs = `test-tabs-${Date.now()}`;
+    const httpRouteName = 'test-route-no-policies';
+    const apiProductName = 'test-product-no-policies';
+
+    try {
+      // Create dedicated namespace
+      execSync(`kubectl create namespace ${testNs}`, { stdio: 'pipe' });
+
+      // Create HTTPRoute
+      const httpRoute = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${httpRouteName}
+  namespace: ${testNs}
+spec:
+  parentRefs:
+    - name: test-gateway
+      namespace: ${TEST_NAMESPACE}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /test
+      backendRefs:
+        - name: test-backend
+          port: 8080
+`;
+      execSync(`echo '${httpRoute}' | kubectl apply -f -`, { stdio: 'pipe' });
+
+      // Create APIProduct
+      const apiProduct = `
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIProduct
+metadata:
+  name: ${apiProductName}
+  namespace: ${testNs}
+spec:
+  displayName: Test No Policies
+  version: v1.0.0
+  publishStatus: Published
+  approvalMode: manual
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ${httpRouteName}
+`;
+      execSync(`echo '${apiProduct}' | kubectl apply -f -`, { stdio: 'pipe' });
+
+      // Navigate to Policies tab
+      await navigateToAPIProductTab(page, testNs, apiProductName, 'policies');
+
+      // Verify empty state is shown
+      const emptyState = page.locator('text=No policies found');
+      await expect(emptyState).toBeVisible({ timeout: 10_000 });
+    } finally {
+      // Cleanup: delete namespace (removes all resources)
+      try {
+        execSync(`kubectl delete namespace ${testNs} --ignore-not-found`, { stdio: 'pipe' });
+      } catch (error) {
+        console.log('Cleanup error (non-fatal):', error);
+      }
+    }
+  });
+
+  test('should display Policies tab with actual policies when they exist', async ({ page }) => {
+    const { execSync } = await import('child_process');
+    const testNs = `test-tabs-${Date.now()}`;
+    const httpRouteName = 'test-route-with-policies';
+    const apiProductName = 'test-product-with-policies';
+    const authPolicyName = 'test-auth';
+
+    try {
+      // Create dedicated namespace
+      execSync(`kubectl create namespace ${testNs}`, { stdio: 'pipe' });
+
+      // Create HTTPRoute
+      const httpRoute = `
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: ${httpRouteName}
+  namespace: ${testNs}
+spec:
+  parentRefs:
+    - name: test-gateway
+      namespace: ${TEST_NAMESPACE}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /test
+      backendRefs:
+        - name: test-backend
+          port: 8080
+`;
+      execSync(`echo '${httpRoute}' | kubectl apply -f -`, { stdio: 'pipe' });
+
+      // Create AuthPolicy targeting the HTTPRoute
+      const authPolicy = `
+apiVersion: kuadrant.io/v1
+kind: AuthPolicy
+metadata:
+  name: ${authPolicyName}
+  namespace: ${testNs}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ${httpRouteName}
+  rules:
+    authentication:
+      "api-key":
+        apiKey:
+          selector:
+            matchLabels:
+              authorino.kuadrant.io/managed-by: authorino
+          allNamespaces: true
+        credentials:
+          customHeader:
+            name: "X-API-Key"
+`;
+      execSync(`echo '${authPolicy}' | kubectl apply -f -`, { stdio: 'pipe' });
+
+      // Create APIProduct
+      const apiProduct = `
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIProduct
+metadata:
+  name: ${apiProductName}
+  namespace: ${testNs}
+spec:
+  displayName: Test With Policies
+  version: v1.0.0
+  publishStatus: Published
+  approvalMode: manual
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: ${httpRouteName}
+`;
+      execSync(`echo '${apiProduct}' | kubectl apply -f -`, { stdio: 'pipe' });
+
+      // Navigate to Policies tab
+      await navigateToAPIProductTab(page, testNs, apiProductName, 'policies');
+
+      // Verify policy appears
+      await expect(page.locator(`text=${authPolicyName}`)).toBeVisible({
+        timeout: 10_000,
+      });
+
+      // Verify policy type is shown
+      await expect(page.getByText('AuthPolicy').first()).toBeVisible({ timeout: 10_000 });
+    } finally {
+      // Cleanup: delete namespace (removes all resources)
+      try {
+        execSync(`kubectl delete namespace ${testNs} --ignore-not-found`, { stdio: 'pipe' });
+      } catch (error) {
+        console.log('Cleanup error (non-fatal):', error);
+      }
+    }
+  });
+
+  test('should display Target tab with HTTPRoute targetRef', async ({ page }) => {
+    await navigateToAPIProductTab(page, TEST_NAMESPACE, API_PRODUCT_NAME, 'targetref');
+
+    // Verify HTTPRoute targetRef is displayed
+    await expect(page.locator('text=test-httproute').first()).toBeVisible({ timeout: 10_000 });
+
+    // Verify HTTPRoute resource type is mentioned
+    const httpRouteText = page.getByText('HTTPRoute').first();
+    await expect(httpRouteText).toBeVisible({ timeout: 10_000 });
+  });
+
+  test('should navigate between custom tabs successfully', async ({ page }) => {
+    await navigateToAPIProductDetails(page, TEST_NAMESPACE, API_PRODUCT_NAME);
+
+    // Click on Definition tab
+    const definitionTab = page.locator(
+      '[role="tablist"] button:has-text("Definition"), [role="tablist"] a:has-text("Definition")',
+    );
+    await definitionTab.click();
+    await page.waitForURL('**/definition');
+
+    // Verify URL changed to /definition
+    expect(page.url()).toContain('/definition');
+
+    // Click on Target tab
+    const targetTab = page.locator(
+      '[role="tablist"] button:has-text("Target"), [role="tablist"] a:has-text("Target")',
+    );
+    await targetTab.click();
+    await page.waitForURL('**/targetref');
+
+    // Verify URL changed to /targetref
+    expect(page.url()).toContain('/targetref');
+
+    // Click on Policies tab
+    const policiesTab = page.locator(
+      '[role="tablist"] button:has-text("Policies"), [role="tablist"] a:has-text("Policies")',
+    );
+    await policiesTab.click();
+    await page.waitForURL('**/policies');
+
+    // Verify URL changed to /policies
+    expect(page.url()).toContain('/policies');
+
+    // Navigate back to Definition tab to verify bidirectional navigation
+    await definitionTab.click();
+    await page.waitForURL('**/definition');
+
+    // Verify we're back on Definition tab
+    expect(page.url()).toContain('/definition');
+  });
+});

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -94,7 +94,7 @@ async function waitForKuadrantPlugin(page: Page): Promise<void> {
 
 // SPA navigation using pushState - preserves redux state (including impersonation)
 // page.goto() causes a full reload which destroys impersonation state
-async function spaNavigate(page: Page, path: string): Promise<void> {
+export async function spaNavigate(page: Page, path: string): Promise<void> {
   // Wait for plugin to be ready before navigating to plugin routes
   await waitForKuadrantPlugin(page);
 


### PR DESCRIPTION
## Summary

Adds e2e tests for APIProduct detail page custom tabs (Definition, Target, Policies).

Closes #477 

## Changes

**New test file:** `e2e/tests/apiproduct-details-tabs.spec.ts` (7 tests)
- Display custom plugin tabs (Definition, Target, Policies visible)
- Definition tab empty state (no OpenAPI spec)
- Definition tab with OpenAPI spec (Swagger UI renders)
- Policies tab empty state (no policies attached)
- Policies tab populated (creates temp policies, verifies table)
- Target tab (HTTPRoute targetRef displayed)
- Navigate between tabs (URL changes, bidirectional nav)

**Modified:** `e2e/tests/helpers.ts`
- Exported `spaNavigate` helper for reuse

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for API Product Details custom tabs (Definition, Target, Policies): empty states, embedded API definition rendering, target details, policy listing and type labels, and bidirectional tab navigation.
  * Made the SPA navigation helper available across the test suite to ensure consistent route-driven checks and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->