### PR TITLE
Apikey approvals enhancements

### DIFF
--- a/src/components/apikey/APIKeyApprovalPage.tsx
+++ b/src/components/apikey/APIKeyApprovalPage.tsx
@@ -18,7 +18,11 @@ import {
   NamespaceBar,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
-import { RESOURCES } from '../../utils/resources';
+import {
+  RESOURCES,
+  OpenshiftUser,
+  SelfSubjectReviewResponse,
+} from '../../utils/resources';
 import { getModelFromResource } from '../../utils/getModelFromResource';
 import { APIKeyRequest, APIKeyApproval } from './types';
 import { getRequestStatus } from './utils';
@@ -60,15 +64,46 @@ const APIKeyApprovalPage: React.FC = () => {
   });
 
   React.useEffect(() => {
-    consoleFetchJSON('/api/kubernetes/apis/user.openshift.io/v1/users/~')
-      .then((user: { metadata: { name: string } }) => {
-        setCurrentUser(user.metadata.name);
-        setUserLoaded(true);
-      })
-      .catch((err: unknown) => {
+    const fetchCurrentUser = async () => {
+      try {
+        // Try OpenShift User API first (OpenShift 4.x)
+        try {
+          const user = (await consoleFetchJSON(
+            '/api/kubernetes/apis/user.openshift.io/v1/users/~',
+          )) as OpenshiftUser;
+          if (user?.metadata?.name) {
+            setCurrentUser(user.metadata.name);
+            setUserLoaded(true);
+            return;
+          }
+        } catch (_openshiftError) {
+          // OpenShift User API not available, fall back to SelfSubjectReview
+        }
+
+        // Fallback: Try Kubernetes SelfSubjectReview (K8s 1.27+, MicroShift)
+        const response = (await consoleFetchJSON.post(
+          '/api/kubernetes/apis/authentication.k8s.io/v1/selfsubjectreviews',
+          {
+            apiVersion: 'authentication.k8s.io/v1',
+            kind: 'SelfSubjectReview',
+          },
+        )) as SelfSubjectReviewResponse;
+
+        const username = response?.status?.userInfo?.username;
+        if (username) {
+          setCurrentUser(username);
+          setUserLoaded(true);
+        } else {
+          throw new Error('Username not found in SelfSubjectReview response');
+        }
+      } catch (err: unknown) {
         console.error('Failed to get current user:', err);
         setUserError(true);
-      });
+        setUserLoaded(true);
+      }
+    };
+
+    fetchCurrentUser();
   }, []);
 
   const requestResource = React.useMemo(

--- a/src/components/apikey/APIKeyApprovalPage.tsx
+++ b/src/components/apikey/APIKeyApprovalPage.tsx
@@ -18,13 +18,10 @@ import {
   NamespaceBar,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
-import {
-  RESOURCES,
-  OpenshiftUser,
-  SelfSubjectReviewResponse,
-} from '../../utils/resources';
+import { RESOURCES, OpenshiftUser, SelfSubjectReviewResponse } from '../../utils/resources';
 import { getModelFromResource } from '../../utils/getModelFromResource';
 import { APIKeyRequest, APIKeyApproval } from './types';
+import { APIProduct } from '../apiproduct/types';
 import { getRequestStatus } from './utils';
 import APIKeyApprovalToolbar, { FilterState } from './APIKeyApprovalToolbar';
 import APIKeyApprovalTable from './APIKeyApprovalTable';
@@ -126,8 +123,7 @@ const APIKeyApprovalPage: React.FC = () => {
     [],
   );
 
-  const [products, productsLoaded] =
-    useK8sWatchResource<{ metadata: { name: string; namespace: string } }[]>(productResource);
+  const [products, productsLoaded] = useK8sWatchResource<APIProduct[]>(productResource);
 
   const productOptions = React.useMemo(() => {
     if (!productsLoaded || !Array.isArray(products)) return [];
@@ -372,6 +368,7 @@ const APIKeyApprovalPage: React.FC = () => {
           onReject={(req) => setRejectionModalRequests([req])}
           canApprove={canApprove}
           canApproveLoading={canApproveLoading}
+          products={products || []}
         />
       </PageSection>
 

--- a/src/components/apikey/APIKeyApprovalTable.tsx
+++ b/src/components/apikey/APIKeyApprovalTable.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Link } from 'react-router-dom-v5-compat';
 import { Table, Thead, Tr, Th, Tbody, Td, SortByDirection } from '@patternfly/react-table';
 import {
   Dropdown,
@@ -7,11 +8,15 @@ import {
   DropdownItem,
   Tooltip,
   Pagination,
+  Label,
 } from '@patternfly/react-core';
 import { Timestamp } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
 import { APIKeyRequest } from './types';
 import { getRequestStatus, truncateUseCase, getStatusSortWeight } from './utils';
+import { APIKeyStatusBadge } from './APIKeyStatusBadge';
+import { APIProduct } from '../apiproduct/types';
+import { formatLimits } from '../../utils/apiKeyUtils';
 import { EllipsisVIcon } from '@patternfly/react-icons';
 
 interface APIKeyApprovalTableProps {
@@ -23,6 +28,7 @@ interface APIKeyApprovalTableProps {
   onReject: (request: APIKeyRequest) => void;
   canApprove?: boolean;
   canApproveLoading?: boolean;
+  products: APIProduct[];
 }
 
 const APIKeyApprovalTable: React.FC<APIKeyApprovalTableProps> = ({
@@ -34,6 +40,7 @@ const APIKeyApprovalTable: React.FC<APIKeyApprovalTableProps> = ({
   onReject,
   canApprove = true,
   canApproveLoading = false,
+  products,
 }) => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [sortBy, setSortBy] = React.useState<{ index?: number; direction?: 'asc' | 'desc' }>({
@@ -43,6 +50,19 @@ const APIKeyApprovalTable: React.FC<APIKeyApprovalTableProps> = ({
   const [openActionMenus, setOpenActionMenus] = React.useState<Set<string>>(new Set());
   const [page, setPage] = React.useState(1);
   const [perPage, setPerPage] = React.useState(20);
+
+  // Helper function to find plan limits from APIProduct
+  const getPlanLimits = (request: APIKeyRequest): string | null => {
+    const product = products.find(
+      (p) =>
+        p.metadata.name === request.spec.apiProductRef.name &&
+        p.metadata.namespace === request.metadata.namespace,
+    );
+    if (!product?.status?.discoveredPlans) return null;
+
+    const plan = product.status.discoveredPlans.find((p) => p.tier === request.spec.planTier);
+    return plan ? formatLimits(plan.limits) : null;
+  };
 
   const toggleActionMenu = (requestName: string) => {
     setOpenActionMenus((prev) => {
@@ -173,8 +193,24 @@ const APIKeyApprovalTable: React.FC<APIKeyApprovalTableProps> = ({
                   }}
                 />
                 <Td dataLabel={t('Requester')}>{request.spec.requestedBy.email}</Td>
-                <Td dataLabel={t('API Product')}>{request.spec.apiProductRef.name}</Td>
-                <Td dataLabel={t('Plan')}>{request.spec.planTier}</Td>
+                <Td dataLabel={t('API Product')}>
+                  <Link
+                    to={`/k8s/ns/${request.metadata.namespace}/devportal.kuadrant.io~v1alpha1~APIProduct/${request.spec.apiProductRef.name}/overview`}
+                  >
+                    {request.spec.apiProductRef.name}
+                  </Link>
+                </Td>
+                <Td dataLabel={t('Plan')}>
+                  {(() => {
+                    const limitsText = getPlanLimits(request);
+                    return (
+                      <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+                        {request.spec.planTier && <Label isCompact>{request.spec.planTier}</Label>}
+                        {limitsText && <span>{limitsText}</span>}
+                      </div>
+                    );
+                  })()}
+                </Td>
                 <Td dataLabel={t('Use Case')}>
                   <Tooltip content={request.spec.useCase}>
                     <span>{truncateUseCase(request.spec.useCase)}</span>
@@ -183,7 +219,9 @@ const APIKeyApprovalTable: React.FC<APIKeyApprovalTableProps> = ({
                 <Td dataLabel={t('Date')}>
                   <Timestamp timestamp={request.metadata?.creationTimestamp || ''} />
                 </Td>
-                <Td dataLabel={t('Status')}>{status}</Td>
+                <Td dataLabel={t('Status')}>
+                  <APIKeyStatusBadge phase={status} />
+                </Td>
                 <Td isActionCell>
                   {isPending && (
                     <Dropdown

--- a/src/components/apikey/MyAPIKeysPage.tsx
+++ b/src/components/apikey/MyAPIKeysPage.tsx
@@ -27,6 +27,7 @@ import {
   DropdownItem,
   Button,
   Tooltip,
+  Label,
 } from '@patternfly/react-core';
 import {
   useK8sWatchResource,
@@ -56,6 +57,8 @@ import APIKeyRevealModal from './APIKeyRevealModal';
 import APIKeyDeleteModal from './APIKeyDeleteModal';
 import RequestAPIKeyModal from './RequestAPIKeyModal';
 import { APIKeyStatusBadge } from './APIKeyStatusBadge';
+import { APIProduct } from '../apiproduct/types';
+import { formatLimits } from '../../utils/apiKeyUtils';
 import '../kuadrant.css';
 import { useKuadrantNamespaceChange } from '../../hooks/useKuadrantNamespaceChange';
 
@@ -67,6 +70,7 @@ const APIKeyRow: React.FC<
     onDelete: (apiKey: APIKey) => void;
     canDelete: boolean;
     canDeleteLoading: boolean;
+    getPlanLimits: (apiKey: APIKey) => string | null;
   }
 > = ({
   obj,
@@ -76,6 +80,7 @@ const APIKeyRow: React.FC<
   onDelete,
   canDelete,
   canDeleteLoading,
+  getPlanLimits,
 }) => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [isKebabOpen, setIsKebabOpen] = React.useState(false);
@@ -103,13 +108,33 @@ const APIKeyRow: React.FC<
         {obj.spec?.requestedBy?.userId || '-'}
       </TableData>
       <TableData id="apiProduct" activeColumnIDs={activeColumnIDs}>
-        {obj.spec?.apiProductRef?.name || '-'}
+        {obj.spec?.apiProductRef?.name ? (
+          <Link
+            to={`/k8s/ns/${
+              obj.spec.apiProductRef.namespace || obj.metadata.namespace
+            }/devportal.kuadrant.io~v1alpha1~APIProduct/${obj.spec.apiProductRef.name}/overview`}
+          >
+            {obj.spec.apiProductRef.name}
+          </Link>
+        ) : (
+          '-'
+        )}
       </TableData>
       <TableData id="status" activeColumnIDs={activeColumnIDs}>
         <APIKeyStatusBadge phase={getAPIKeyPhase(obj)} />
       </TableData>
       <TableData id="tier" activeColumnIDs={activeColumnIDs}>
-        {obj.spec?.planTier || '-'}
+        {(() => {
+          const limitsText = getPlanLimits(obj);
+          return obj.spec?.planTier || limitsText ? (
+            <div style={{ display: 'flex', alignItems: 'center', gap: '8px' }}>
+              {obj.spec?.planTier && <Label isCompact>{obj.spec.planTier}</Label>}
+              {limitsText && <span>{limitsText}</span>}
+            </div>
+          ) : (
+            '-'
+          );
+        })()}
       </TableData>
       <TableData id="apiKey" activeColumnIDs={activeColumnIDs}>
         {getAPIKeyPhase(obj) !== 'Approved' || !obj.spec?.secretRef?.name ? (
@@ -195,6 +220,32 @@ const MyAPIKeysPage: React.FC = () => {
     namespace: activeNamespace === '#ALL_NS#' ? undefined : activeNamespace,
     isList: true,
   });
+
+  // Watch APIProduct resources to get plan limits
+  const [products, productsLoaded] = useK8sWatchResource<APIProduct[]>({
+    groupVersionKind: RESOURCES.APIProduct.gvk,
+    namespace: activeNamespace === '#ALL_NS#' ? undefined : activeNamespace,
+    isList: true,
+  });
+
+  // Helper function to find plan limits from APIProduct
+  const getPlanLimits = React.useCallback(
+    (apiKey: APIKey): string | null => {
+      if (!productsLoaded || !products) return null;
+
+      const product = products.find(
+        (p) =>
+          p.metadata.name === apiKey.spec?.apiProductRef?.name &&
+          (p.metadata.namespace === apiKey.spec?.apiProductRef?.namespace ||
+            p.metadata.namespace === apiKey.metadata.namespace),
+      );
+      if (!product?.status?.discoveredPlans) return null;
+
+      const plan = product.status.discoveredPlans.find((p) => p.tier === apiKey.spec?.planTier);
+      return plan ? formatLimits(plan.limits) : null;
+    },
+    [products, productsLoaded],
+  );
 
   // Smart default redirect: check cluster-wide permissions and redirect namespace-scoped users
   React.useEffect(() => {
@@ -503,9 +554,10 @@ const MyAPIKeysPage: React.FC = () => {
         onDelete={handleDeleteClick}
         canDelete={canDelete}
         canDeleteLoading={canDeleteLoading}
+        getPlanLimits={getPlanLimits}
       />
     ),
-    [activeNamespace, handleDeleteClick, canDelete, canDeleteLoading],
+    [activeNamespace, handleDeleteClick, canDelete, canDeleteLoading, getPlanLimits],
   );
 
   return (


### PR DESCRIPTION
### What

* [fix: add fallback to fetch current user in API key approvals](https://github.com/Kuadrant/kuadrant-console-plugin/pull/492/changes/a01802491b2c458b32dc1caef11a9613f09a0a47)

* [APIKeyApprovals and MyAPIKeys status badges and tier info](https://github.com/Kuadrant/kuadrant-console-plugin/pull/492/changes/870b760f79f4e055fede4cf9daf9ee7b6f9e6bbe)

<img width="2201" height="500" alt="Screenshot 2026-05-27 at 10-10-10 My API Keys" src="https://github.com/user-attachments/assets/e04fa878-6726-495c-a947-5d2785749cb7" />
<img width="2212" height="488" alt="Screenshot 2026-05-27 at 10-09-58 My API Keys" src="https://github.com/user-attachments/assets/322a0e0e-c365-4f3f-b2db-cdca0d53aa6a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * API Product names in tables are now clickable links to product overviews.
  * Plan limits are now displayed alongside plan tier information in API Key tables.
  * API Key status is now displayed as a badge component.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/492?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->