### PR TITLE
Remove oauth_token response header from nginx config

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -90,8 +90,6 @@ data:
         ssl_certificate     /var/serving-cert/tls.crt;
         ssl_certificate_key /var/serving-cert/tls.key;
 
-        add_header oauth_token "$http_Authorization";
-
         location / {
           root                /usr/share/nginx/html;
         }


### PR DESCRIPTION
## Summary
- Remove `add_header oauth_token "$http_Authorization"` from `install.yaml` nginx config
- This directive reflected the incoming Authorization header back in every HTTP response, which serves no purpose

The Helm chart (`charts/openshift-console-plugin/templates/configmap.yaml`) already omits this directive. This aligns the raw YAML manifest with the Helm chart.

**Note:** The same directive also exists in the kuadrant-operator's nginx configmap at [`internal/openshift/consoleplugin/nginx_configmap.go:33`](https://github.com/Kuadrant/kuadrant-operator/blob/main/internal/openshift/consoleplugin/nginx_configmap.go#L33) — a separate PR will be opened there.

## Test plan
- [ ] Verify plugin static assets still load correctly after removal
- [ ] Confirm no response header `oauth_token` is present in browser DevTools

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an automatic response header that was being added to authentication responses, resolving header management behaviour in the system.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/493?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->