### PR TITLE
fix: add pagination page clamping safeguard to APIKeyApprovalTable

### DIFF
--- a/src/components/apikey/APIKeyApprovalTable.tsx
+++ b/src/components/apikey/APIKeyApprovalTable.tsx
@@ -99,6 +99,13 @@ const APIKeyApprovalTable: React.FC<APIKeyApprovalTableProps> = ({
     return sortedRequests.slice(startIdx, endIdx);
   }, [sortedRequests, page, perPage]);
 
+  React.useEffect(() => {
+    const lastPage = Math.max(1, Math.ceil(sortedRequests.length / perPage));
+    if (page > lastPage) {
+      setPage(lastPage);
+    }
+  }, [page, perPage, sortedRequests.length]);
+
   const onSetPage = (
     _event: React.MouseEvent | React.KeyboardEvent | MouseEvent,
     newPage: number,


### PR DESCRIPTION
## Summary

Add a pagination clamping safeguard to `APIKeyApprovalTable` to prevent invalid-page empty states when the underlying request list shrinks dynamically.

## Changes Made

* Added page clamping logic to ensure the current page never exceeds the last valid page.
* Automatically adjusts pagination state when the request dataset size changes.
* Preserved existing pagination behavior and per-page reset logic.
* Kept the implementation aligned with the pagination safeguard pattern already used in other list views.

## Problem Solved

Previously, if a user was on a later page and the backing request list shrank (e.g. due to approvals, deletions, or live updates), the table could enter an invalid pagination state and render an empty view until the user manually navigated back to a valid page. Discussed on #480. 

This change ensures the pagination state remains valid automatically.

# Testing

Verified:

* Pagination continues to work normally.
* Current page clamps correctly when dataset size shrinks.
* No empty invalid-page states occur after dynamic data updates.
* Existing per-page behavior remains unchanged.

# Related

Issue: #495 