### PR TITLE
feat: add Gateway Traffic Performance panels to overview page

### DIFF
--- a/locales/en/plugin__kuadrant-console-plugin.json
+++ b/locales/en/plugin__kuadrant-console-plugin.json
@@ -201,6 +201,8 @@
   "Gateway API Target Reference": "Gateway API Target Reference",
   "Gateway: Reference to a Kubernetes resource that the policy attaches to. To create an additional gateway go to": "Gateway: Reference to a Kubernetes resource that the policy attaches to. To create an additional gateway go to",
   "Gateways": "Gateways",
+  "Gateways - Errors req/s": "Gateways - Errors req/s",
+  "Gateways - Total req/s": "Gateways - Total req/s",
   "Gateways - Traffic Analysis": "Gateways - Traffic Analysis",
   "Geo value to apply to geo endpoints": "Geo value to apply to geo endpoints",
   "Geography Label (e.g. 'EU')": "Geography Label (e.g. 'EU')",

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -56,6 +56,7 @@ import {
   TableData,
   NamespaceBar,
   checkAccess,
+  QueryBrowser,
 } from '@openshift-console/dynamic-plugin-sdk';
 import './kuadrant.css';
 import ResourceList from './ResourceList';
@@ -1008,6 +1009,57 @@ const KuadrantOverviewPage: React.FC = () => {
                 </Card>
               </GridItem>
             )}
+
+            <GridItem>
+              <Flex>
+                <FlexItem flex={{ default: 'flex_1' }}>
+                  <Card>
+                    <CardTitle>
+                      <Title headingLevel="h2">{t('Gateways - Total req/s')}</Title>
+                    </CardTitle>
+                    <CardBody className="pf-u-p-10">
+                      <QueryBrowser
+                        defaultTimespan={30 * 60 * 1000}
+                        pollInterval={30 * 1000}
+                        formatSeriesTitle={(labels) =>
+                          labels.source_workload_namespace + '/' + labels.source_workload
+                        }
+                        units={'req/s'}
+                        showLegend={false}
+                        queries={[
+                          'topk(10, sum(rate(istio_requests_total{}[5m])) by (source_workload, source_workload_namespace))',
+                        ]}
+                      />
+                    </CardBody>
+                  </Card>
+                </FlexItem>
+                <FlexItem flex={{ default: 'flex_1' }}>
+                  <Card>
+                    <CardTitle>
+                      <Title headingLevel="h2">{t('Gateways - Errors req/s')}</Title>
+                    </CardTitle>
+                    <CardBody className="pf-u-p-10">
+                      <QueryBrowser
+                        defaultTimespan={30 * 60 * 1000}
+                        pollInterval={30 * 1000}
+                        formatSeriesTitle={(labels) =>
+                          labels.response_code +
+                          ' - ' +
+                          labels.source_workload_namespace +
+                          '/' +
+                          labels.source_workload
+                        }
+                        units={'req/s'}
+                        showLegend={false}
+                        queries={[
+                          'topk(10, sum(rate(istio_requests_total{response_code!~"2(.*)|3(.*)"}[5m])) by (response_code, source_workload, source_workload_namespace))',
+                        ]}
+                      />
+                    </CardBody>
+                  </Card>
+                </FlexItem>
+              </Flex>
+            </GridItem>
 
             {policyRBACNill ? (
               <GridItem lg={6}>


### PR DESCRIPTION
## Summary

Add QueryBrowser time-series chart panels to the Kuadrant Overview page for visualizing gateway traffic performance. Two new charts display request rates and error rates over time, complementing the existing traffic analysis table.

## Changes Made

### Modified Files

#### `KuadrantOverviewPage.tsx`

### Added QueryBrowser import

- Added `QueryBrowser` to the existing `@openshift-console/dynamic-plugin-sdk` import

### Added new GridItem with two-column layout

#### Card 1: `Gateways - Total req/s`

- `QueryBrowser` chart with 30-minute default timespan
- 30-second poll interval
- Series title formatted as `namespace/workload`
- Query:

```promql
topk(
  10,
  sum(rate(istio_requests_total{}[5m]))
    by (source_workload, source_workload_namespace)
)
```

- Units: `req/s`

#### Card 2: `Gateways - Errors req/s`

- `QueryBrowser` chart with 30-minute default timespan
- 30-second poll interval
- Series title formatted as `response_code - namespace/workload`
- Query:

```promql
topk(
  10,
  sum(rate(istio_requests_total{response_code!~"2(.*)|3(.*)"}[5m]))
    by (response_code, source_workload, source_workload_namespace)
)
```

- Units: `req/s`

### Layout Placement

- Placed immediately after the `Gateways - Traffic Analysis` `GridItem` (`ResourceList` table)
- Uses `Flex` layout with two equal-width `FlexItems` for responsive side-by-side display

## Screenshots
[
<img width="1920" height="1080" alt="Screenshot From 2026-05-28 00-56-38" src="https://github.com/user-attachments/assets/9fe966fd-f208-4456-85f3-cbf71f6ff495" />
<img width="1920" height="1080" alt="Screenshot From 2026-05-28 00-56-28" src="https://github.com/user-attachments/assets/3741eee1-6bb5-4220-84e7-788935d8385b" />
<img width="1920" height="1080" alt="Screenshot From 2026-05-28 00-56-22" src="https://github.com/user-attachments/assets/adcc5e6f-94a2-4f79-823f-a07df3b89cfe" />


## Related Issues

Resolves: #220

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added two new Gateways traffic-analysis cards: one displays total requests per second, and another shows error requests per second. Both cards feature 30-minute default time windows with real-time polling to provide continuous monitoring insights.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/500?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->