### PR TITLE
[ci] Add build validation workflow for PRs

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,36 @@
+name: Build Check
+
+on:
+  pull_request:
+    branches:
+      - '**'
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+concurrency:
+  group: build-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Run production build
+        run: yarn build


### PR DESCRIPTION
Closes #491

Adds a "Build Check" GitHub Actions workflow that runs `yarn build` on every PR,catching webpack/TypeScript build failures before merge instead of after they land on `main`.

- Triggers on `pull_request` (all branches), `merge_group`, and `workflow_dispatch`
- Mirrors the existing lint/i18n workflows; uses the newer `@v4` actions + Node 22 + Corepack like `e2e.yaml`
- Adds a `concurrency` group (cancels superseded builds) and a 15-min timeout

<img width="1008" height="322" alt="image" src="https://github.com/user-attachments/assets/4d3462a7-b766-4dcf-878f-67e8f1924ed7" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated build verification process implemented to validate code changes across pull requests and merges, ensuring consistent build integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/501?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->