### PR TITLE
Remove ppc64le and s390x from release build workflow

### DIFF
--- a/.github/workflows/release-build.yaml
+++ b/.github/workflows/release-build.yaml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: [amd64, arm64, s390x, ppc64le]
+        arch: [amd64, arm64]
 
     steps:
       - name: Checkout Code
@@ -60,8 +60,6 @@ jobs:
           buildah manifest create ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}
           buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-amd64
           buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-arm64
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-s390x
-          buildah manifest add ${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }} docker://${{ env.REGISTRY }}/${{ env.IMAGE_BASE_NAME }}:${{ github.event.release.name }}-ppc64le
 
       - name: Push Multi-Arch Release Manifest
         run: |


### PR DESCRIPTION
## Summary

Remove ppc64le and s390x from the release-build matrix. Keep release builds to the proven amd64+arm64 architectures that have shipped in every prior release.

- ppc64le fails under QEMU emulation (OpenSSL/TLS bug with `cdn-ubi.redhat.com`)
- s390x built successfully for v0.4.0 but has never shipped in any prior release

The multi-stage Dockerfile fix in #504 will re-enable additional architectures once validated on OpenShift.

## Context

- **Neither ppc64le nor s390x has ever shipped** in any console-plugin release (v0.1.0 through v0.3.7 were all amd64+arm64 only)
- Both remain in the `dev-build.yaml` workflow for CI validation
- The v0.4.0 amd64 and arm64 images already built successfully

## After merging

Create the v0.4.0 multi-arch manifest from the 2 existing images:

```bash
buildah manifest create quay.io/kuadrant/console-plugin:v0.4.0
buildah manifest add quay.io/kuadrant/console-plugin:v0.4.0 docker://quay.io/kuadrant/console-plugin:v0.4.0-amd64
buildah manifest add quay.io/kuadrant/console-plugin:v0.4.0 docker://quay.io/kuadrant/console-plugin:v0.4.0-arm64
buildah manifest push --all quay.io/kuadrant/console-plugin:v0.4.0 docker://quay.io/kuadrant/console-plugin:v0.4.0
```

Or delete the v0.4.0 release and re-publish to trigger the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)