### PR TITLE
test: complete APIProduct edit/delete E2E tests

### DIFF
--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect, Page } from '@playwright/test';
-import { TEST_NAMESPACE, dismissConsoleTour } from './helpers';
+import { TEST_NAMESPACE, dismissConsoleTour, ensureDeleteProductFixture } from './helpers';
 
 // SPA navigation using pushState - preserves redux state
 async function spaNavigate(page: Page, path: string): Promise<void> {
@@ -373,7 +373,6 @@ test.describe('APIProduct CRUD Operations', () => {
     // Placeholder: navigate to edit page for a test APIProduct
     const testProductName = 'test-edit-product';
     await spaNavigate(page, `/kuadrant/apiproducts/ns/${TEST_NAMESPACE}/${testProductName}/edit`);
-    await page.waitForLoadState('networkidle');
 
     // Skip test if APIProduct doesn't exist (check for edit header)
     const editHeader = page.locator('text=Edit API Product');
@@ -404,72 +403,102 @@ test.describe('APIProduct CRUD Operations', () => {
     await expect(descriptionInput).toBeEnabled();
 
     // Modify fields
-    await displayNameInput.fill('Updated Product Name');
+    const updatedDisplayName = `Updated Product ${Date.now()}`;
+    await displayNameInput.fill(updatedDisplayName);
     await versionInput.fill('v2.0.0');
+    await descriptionInput.fill('Updated description for testing');
 
     // Save button should show "Save" instead of "Create"
     const saveButton = page.locator('button:has-text("Save")');
     await expect(saveButton).toBeVisible();
-  });
+    await expect(saveButton).toBeEnabled();
 
-  // Skipping since due to the new columns in the list and the resolution of the test screen, the kebab menu is hidden
-  test.skip('should delete APIProduct with confirmation', async ({ page }) => {
-    // This test assumes an APIProduct exists
-    // For a real e2e test, you would create one first
+    // Click Save
+    await saveButton.click();
 
-    const testProductName = 'test-delete-product';
-
-    // Navigate to APIProducts list
-    await navigateToAPIProducts(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
-
-    // Find the product row (this assumes it exists)
-    const row = page.locator(`tr:has-text("${testProductName}")`);
-
-    // Skip test if product doesn't exist
-    const exists = await row
-      .waitFor({ state: 'visible', timeout: 5000 })
-      .then(() => true)
-      .catch(() => false);
-    if (!exists) {
-      test.skip();
-      return;
-    }
-
-    // Click kebab menu
-    const kebab = row.locator('[aria-label="kebab dropdown toggle"]');
-    await kebab.click();
-
-    // Click Delete
-    const deleteItem = page.locator('[role="menuitem"]:has-text("Delete")');
-    await deleteItem.click();
-
-    // Verify modal appears
-    await expect(page.getByRole('heading', { name: 'Delete API Product' })).toBeVisible({
+    // Wait for redirect to list page - verify heading is visible
+    await expect(page.getByRole('heading', { name: 'API Products', exact: true })).toBeVisible({
       timeout: 10000,
     });
 
-    // Verify warning message
-    await expect(page.locator('text=Warning: This action cannot be undone')).toBeVisible();
+    // Navigate back to edit page to verify changes persisted
+    await spaNavigate(page, `/kuadrant/apiproducts/ns/${TEST_NAMESPACE}/${testProductName}/edit`);
+    await expect(editHeader).toBeVisible();
 
-    // Try clicking delete without entering name - should be disabled
-    const deleteButton = page.locator('button:has-text("Delete API Product")');
-    await expect(deleteButton).toBeDisabled();
+    // Verify changes persisted
+    await expect(displayNameInput).toHaveValue(updatedDisplayName);
+    await expect(versionInput).toHaveValue('v2.0.0');
+    await expect(descriptionInput).toHaveValue('Updated description for testing');
+  });
 
-    // Type wrong name - should still be disabled
-    const confirmInput = page.locator('#confirm-delete');
-    await confirmInput.fill('wrong-name');
-    await expect(deleteButton).toBeDisabled();
+  test('should delete APIProduct with confirmation', async ({ page }) => {
+    const testProductName = 'test-delete-product';
 
-    // Type correct name - should enable
-    await confirmInput.fill(testProductName);
-    await expect(deleteButton).toBeEnabled();
+    // Ensure fixture exists before running test (applies e2e/manifests/test-apiproduct-fixtures.yaml)
+    // This makes the test repeatable - it recreates the product if it was deleted in a previous run
+    await ensureDeleteProductFixture();
 
-    // Confirm deletion
-    await deleteButton.click();
+    // Navigate to APIProducts list
+    await navigateToAPIProducts(page, TEST_NAMESPACE);
 
-    // Wait for deletion to complete (modal closes and row disappears)
-    await expect(row).not.toBeVisible({ timeout: 10000 });
+    // Wait for table to load
+    await page.waitForSelector('table', { timeout: 10000 });
+
+    // Find the product row
+    const row = page.locator(`tr:has-text("${testProductName}")`);
+
+    // Verify product exists
+    await expect(row).toBeVisible({ timeout: 10000 });
+
+    // Navigate to K8s resource details page via product name link
+    // (kebab menu column exists on list page but may be off-screen at test viewport width)
+    const productLink = row.locator(`a[data-test="${testProductName}"]`);
+    await expect(productLink).toBeVisible();
+    await productLink.click();
+
+    // Find Actions dropdown button on K8s resource details page
+    const actionsButton = page.locator('button:has-text("Actions")').first();
+    await expect(actionsButton).toBeVisible({ timeout: 10000 });
+    await actionsButton.click();
+
+    // Click "Delete APIProduct" from dropdown
+    const deleteItem = page.locator('[role="menuitem"]:has-text("Delete APIProduct")');
+    await expect(deleteItem).toBeVisible({ timeout: 5000 });
+    await deleteItem.click();
+
+    // K8s delete modal should appear - look for visible delete button in modal
+    // Use >> to pierce shadow DOM if needed
+    const deleteButton = page
+      .locator('button')
+      .filter({ hasText: 'Delete' })
+      .and(
+        page.locator('[role="dialog"] button, .pf-v6-c-modal-box button, .pf-c-modal-box button'),
+      );
+
+    // If that doesn't work, just find any visible Delete button
+    const fallbackButton = page.locator('button:has-text("Delete")').first();
+
+    // Try primary selector first
+    const buttonToClick = (await deleteButton.count()) > 0 ? deleteButton.first() : fallbackButton;
+
+    await expect(buttonToClick).toBeVisible({ timeout: 10000 });
+
+    // May need to check a confirmation checkbox first
+    const checkbox = page.locator('[role="dialog"] input[type="checkbox"]').first();
+    if ((await checkbox.count()) > 0 && (await checkbox.isVisible())) {
+      await checkbox.check();
+    }
+
+    await expect(buttonToClick).toBeEnabled({ timeout: 5000 });
+    await buttonToClick.click();
+
+    // Verify product removed from list (navigate to list if not there already)
+    if (!page.url().includes('/apiproducts/ns/')) {
+      await navigateToAPIProducts(page, TEST_NAMESPACE);
+    }
+
+    // Verify row no longer exists
+    await expect(row).not.toBeVisible({ timeout: 5000 });
   });
 
   test('should display validation messages for required fields', async ({ page }) => {

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -147,4 +147,18 @@ export async function waitForPermissionsLoaded(page: Page): Promise<void> {
   await expect(loading).toBeHidden({ timeout: 30_000 });
 }
 
+// Apply test-delete-product fixture via kubectl
+// Used by delete test to ensure product exists for each run
+export async function ensureDeleteProductFixture(): Promise<void> {
+  const { execFileSync } = await import('child_process');
+  const path = await import('path');
+  const fixturesPath = path.join(__dirname, '../manifests/test-apiproduct-fixtures.yaml');
+
+  try {
+    execFileSync('kubectl', ['apply', '-f', fixturesPath], { stdio: 'ignore' });
+  } catch (error) {
+    console.warn('Failed to apply test-delete-product fixture:', error);
+  }
+}
+
 export { TEST_NAMESPACE };


### PR DESCRIPTION
## Overview

This PR completes E2E tests for APIProduct edit and delete flows.

Closes #484

### Changes

**Edit Test (`tests/apiproduct-crud.spec.ts:368`)**
- Completes the existing edit test by adding save operation and persistence verification
- Clicks Save button after editing fields
- Navigates back to edit page and verifies changes persisted (display name, version, description)
- Removed check for success alert (app redirects without showing alert)

**Delete Test (`tests/apiproduct-crud.spec.ts:435`)**
- Enables previously skipped delete test
- Uses K8s resource details page Actions dropdown instead of list page kebab menu (kebab column hidden at test viewport width)
- Implements full delete flow: navigate to details → Actions → Delete → confirm → verify removal
- Adds automatic fixture recreation via `ensureDeleteProductFixture()` helper to ensure test repeatability

**Test Helper (`tests/helpers.ts:152`)**
- Adds `ensureDeleteProductFixture()` function that applies test fixtures via kubectl before each delete test run
- Makes delete test fully repeatable without manual setup between runs

### Notes

Delete test path changed from list page kebab menu to details page Actions dropdown because the kebab column exists but is hidden off-screen at Playwright's default viewport width (1280px). The details page Actions dropdown is always accessible.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Enhanced APIProduct edit test to verify updated fields persist after saving and revisiting
  * Re-enabled and improved APIProduct deletion test with a robust confirmation flow and visibility check
  * Added test helper to ensure deletion tests have required fixtures available before running
<!-- end of auto-generated comment: release notes by coderabbit.ai -->