### PR TITLE
Fixed the DNSPolicy creation form to properly handle 0

### DIFF
--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -46,7 +46,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
   });
   const [loadBalancing, setLoadBalancing] = React.useState<LoadBalancing>({
     geo: '',
-    weight: null,
+    weight: 120,
     defaultGeo: '',
   });
   const [healthCheck, setHealthCheck] = React.useState<HealthCheck>({

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -77,7 +77,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
       healthCheck.protocol !== '';
 
     const hasLoadBalancing =
-      loadBalancing.geo || loadBalancing.defaultGeo !== '' || loadBalancing.weight;
+      loadBalancing.geo || loadBalancing.defaultGeo !== '' || loadBalancing.weight != null;
 
     return {
       apiVersion:
@@ -99,7 +99,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
         ...(hasLoadBalancing
           ? {
               loadBalancing: {
-                ...(loadBalancing?.weight ? { weight: loadBalancing.weight } : {}),
+                ...(loadBalancing?.weight != null ? { weight: loadBalancing.weight } : {}),
                 ...(loadBalancing?.geo ? { geo: loadBalancing.geo } : {}),
                 ...(loadBalancing.defaultGeo !== ''
                   ? { defaultGeo: loadBalancing.defaultGeo }
@@ -206,7 +206,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
         setProviderRefs([providerRef]);
         setLoadBalancing({
           geo: dnsPolicyUpdate.spec?.loadBalancing?.geo || '',
-          weight: dnsPolicyUpdate.spec?.loadBalancing?.weight || 0,
+          weight: dnsPolicyUpdate.spec?.loadBalancing?.weight ?? null,
           defaultGeo:
             dnsPolicyUpdate.spec?.loadBalancing?.defaultGeo !== undefined
               ? dnsPolicyUpdate.spec.loadBalancing?.defaultGeo
@@ -242,7 +242,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
 
       setLoadBalancing({
         geo: parsedYaml.spec?.loadBalancing?.geo || '',
-        weight: parsedYaml.spec?.loadBalancing?.weight || '',
+        weight: parsedYaml.spec?.loadBalancing?.weight ?? null,
         defaultGeo:
           parsedYaml.spec?.loadBalancing?.defaultGeo !== undefined
             ? parsedYaml.spec.loadBalancing?.defaultGeo
@@ -273,7 +273,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
       selectedGateway.name &&
       providerRefs.length > 0 &&
       (!loadBalancingExpanded ||
-        (loadBalancing.geo && loadBalancing.weight && loadBalancing.defaultGeo !== '')) &&
+        (loadBalancing.geo && loadBalancing.weight != null && loadBalancing.defaultGeo !== '')) &&
       (!healthExpanded ||
         (healthCheck.endpoint &&
           healthCheck.failureThreshold > 0 &&

--- a/src/components/dnspolicy/LoadBalancingField.tsx
+++ b/src/components/dnspolicy/LoadBalancingField.tsx
@@ -44,7 +44,7 @@ const LoadBalancingField: React.FC<LoadBalancingProps> = ({
           }}
           isRequired
           type="number"
-          placeholder="0"
+          placeholder="120"
           isDisabled={formDisabled}
         />
         <FormHelperText>

--- a/src/components/dnspolicy/LoadBalancingField.tsx
+++ b/src/components/dnspolicy/LoadBalancingField.tsx
@@ -34,13 +34,14 @@ const LoadBalancingField: React.FC<LoadBalancingProps> = ({
       >
         <TextInput
           id="weight"
-          value={loadBalancing.weight}
-          onChange={(event) =>
+          value={loadBalancing.weight ?? ''}
+          onChange={(event) => {
+            const value = event.currentTarget.value;
             onChange({
               ...loadBalancing,
-              weight: Number(event.currentTarget.value),
-            })
-          }
+              weight: value === '' ? null : Number(value),
+            });
+          }}
           isRequired
           type="number"
           placeholder="0"

--- a/src/components/dnspolicy/types.ts
+++ b/src/components/dnspolicy/types.ts
@@ -1,6 +1,6 @@
 export interface LoadBalancing {
   geo: string;
-  weight: number;
+  weight: number | null;
   defaultGeo: boolean | '';
 }
 


### PR DESCRIPTION
## What

Fixed the DNSPolicy creation form to properly handle 0 as a valid Load Balancing Weight value

Closes https://github.com/Kuadrant/kuadrant-console-plugin/issues/395

## Verification Steps

### ✅ Prerequisites
- Deploy the plugin to an OpenShift cluster with Kuadrant installed
  -  `yarn oinc`
  -  `make -C kuadrant-dev-setup demo-install` (demo resources will be created)

###  Test Form Validation with Weight=0
**Objective:** Verify that the form validates correctly when weight is 0.
#### Steps:
1. Navigate to DNSPolicy creation page
2. Fill in required fields
3. Expand "Load Balancing" section
4. Fill in:
  - Weight: `0`
  - Geo: `EU`
  - Default Geo: Enabled
5. Switch to the YAML view (toggle at the top)
✅ The YAML should contain:
```yaml
spec:
  loadBalancing:
    weight: 0
    geo: EU
    defaultGeo: true  # or false
```
6. Click the "Create" button (or observe if it's enabled)

#### Expected Result:
✅ Form should validate successfully
✅ Create button should be enabled
✅ Policy should be created without errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Improved handling of empty load balancing weight values in DNS Policy creation form.
* Updated weight field placeholder to `120` for better guidance.
* Enhanced form validation to properly detect when load balancing configuration is incomplete, ensuring clearer error states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->