### PR TITLE
fix: add location config.js to Helm chart nginx config

### DIFF
--- a/charts/openshift-console-plugin/templates/configmap.yaml
+++ b/charts/openshift-console-plugin/templates/configmap.yaml
@@ -19,6 +19,14 @@ data:
         listen              [::]:{{ .Values.plugin.port }} ssl;
         ssl_certificate     /var/cert/tls.crt;
         ssl_certificate_key /var/cert/tls.key;
-        root                /usr/share/nginx/html;
+
+        location / {
+          root                /usr/share/nginx/html;
+        }
+
+        # Serve config.js from /tmp
+        location /config.js {
+          root /tmp;
+        }
       }
     }


### PR DESCRIPTION
## Description

While working on #517, I found that the Helm chart's `nginx.conf` in `charts/openshift-console-plugin/templates/configmap.yaml` is missing the `location /config.js` block.

The `entrypoint.sh` generates a runtime configuration file at `/tmp/config.js` containing values TOPOLOGY_CONFIGMAP_NAME, TOPOLOGY_CONFIGMAP_NAMESPACE and METRICS_WORKLOAD_SUFFIX``. For nginx to serve this file, a dedicated location block pointing to `/tmp` is required.

The `install.yaml` already has this block correctly configured but the Helm chart's configmap was not updated. So, Helm-based deployments silently fall back to hardcoded defaults, ignoring any custom values.

## Type of change

- [x] `[fix]` Bug fix
- [ ] `[feat]` New feature
- [ ] `[refactor]` Refactor (no functional changes)
- [ ] `[test]` Test updates
- [ ] `[chore]` Dependency / config update

## Changes made

- Wrapped the existing `root` directive inside a `location / { }` block, matching `install.yaml` structure
- Added `location /config.js { root /tmp; }` to serve the runtime config generated by `entrypoint.sh`

 **With this fix:** Helm chart nginx config is consistent with `install.yaml` and custom Helm values are correctly served to the UI.





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated web server configuration to explicitly route and serve static files and configuration files for improved request handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-console-plugin/pull/520?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->