### PR TITLE
docs: fix CRD API groups for devportal resources in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,10 @@ The plugin manages these Custom Resource Definitions (CRDs):
 
 ### API Management Resources
 7. **PlanPolicy** (`extensions.kuadrant.io/v1alpha1`) - Rate limiting plans with tiers
-8. **APIProduct** (`extensions.kuadrant.io/v1alpha1`) - Published API catalog entries
-9. **APIKeyRequest** (`extensions.kuadrant.io/v1alpha1`) - Consumer requests for API access
+8. **APIProduct** (`devportal.kuadrant.io/v1alpha1`) - Published API catalog entries
+9. **APIKeyRequest** (`devportal.kuadrant.io/v1alpha1`) - Consumer requests for API access
+10. **APIKey** (`devportal.kuadrant.io/v1alpha1`) - API key credentials for consumers
+11. **APIKeyApproval** (`devportal.kuadrant.io/v1alpha1`) - Approval records for API key requests
 
 ## Common Patterns
 


### PR DESCRIPTION
Fixes #443

- Corrected API group for APIProduct and APIKeyRequest from `extensions.kuadrant.io/v1alpha1` to `devportal.kuadrant.io/v1alpha1`
- Added missing APIKey entry under `devportal.kuadrant.io/v1alpha1`
- Added missing APIKeyApproval entry under `devportal.kuadrant.io/v1alpha1` (as noted by @eguzki)
- PlanPolicy remains correctly listed under `extensions.kuadrant.io/v1alpha1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API Management Resources documentation to reflect changes in API definitions and newly supported Custom Resource Definitions for enhanced resource management capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->