### PR TITLE
docs: remove stale config/crd reference from CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,6 @@ kuadrant-console-plugin/
 ├── charts/                # Helm chart for deployment
 ├── locales/               # i18n translation files
 ├── config/
-│   ├── crd/              # Custom Resource Definitions
 │   └── rbac/             # RBAC role definitions
 ├── e2e/                   # End-to-end Playwright tests
 ├── docs/                  # Documentation and images


### PR DESCRIPTION
## Description

CLAUDE.md's project-structure section listed a `config/crd/` directory that does not exist in this repository (`config/` only contains `rbac/`). It was a leftover from the console-plugin-template. GroupVersionKinds live in `src/utils/resources.ts`, and upstream CRDs are sourced from the kuadrant-operator rather than vendored here, so the reference was misleading.

Related to #74 (discovered while investigating automated GVK checks).

## Type of change

- [ ] `[fix]` Bug fix
- [ ] `[feat]` New feature
- [ ] `[refactor]` Refactor (no functional changes)
- [ ] `[test]` Test updates
- [x] `[chore]` Dependency / config update

## Changes made

- Removed the non-existent `config/crd/` entry from the project-structure tree in CLAUDE.md.

## Test plan

Documentation-only change; no code or build impact.

- [ ] `yarn lint` passes (no changes after running)
- [ ] `yarn build` passes
- [ ] `yarn i18n` passes (no changes after running — commit updated locale files if needed)
- [ ] Tested manually in OpenShift Console
- [ ] Tested in both light and dark themes
- [ ] Tested in all-namespaces and single namespace mode

## Screenshots

N/A — documentation-only change.

## Checklist

- [ ] All user-facing strings use `t()` and are added to `locales/en/plugin__kuadrant-console-plugin.json` — N/A
- [ ] CSS classes are prefixed with `kuadrant-` — N/A
- [x] No `console.log` statements left in
- [ ] Commits include `Signed-off-by` line (`git commit -s`)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected project structure documentation in the console plugin guide by updating the directory listing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->