### PR TITLE
unify build workflows and add quay.expires-after label to container images

### DIFF
--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -52,6 +52,17 @@ jobs:
             # Manual: git sha as fallback
             type=raw,value=${{ github.sha }},enable=${{ github.event_name == 'workflow_dispatch' }}
 
+      - name: Read quay image expiry
+        id: quay-expiry
+        run: |
+          if [[ "${{ github.ref_name }}" == "main" || "${{ github.ref_type }}" == "tag" && "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+            echo "expiry=never" >> $GITHUB_OUTPUT
+            echo "Setting expiry to 'never' for ref ${{ github.ref_name }}"
+          else
+            echo "expiry=3w" >> $GITHUB_OUTPUT
+            echo "Setting expiry to '3w' for ref ${{ github.ref_name }}"
+          fi
+
       - name: Build and Push Image
         if: github.repository_owner == 'kuadrant'
         uses: docker/build-push-action@v5
@@ -62,6 +73,8 @@ jobs:
           push: true
           provenance: false
           tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            QUAY_IMAGE_EXPIRY=${{ steps.quay-expiry.outputs.expiry }}
 
       - name: Print Image URL
         run: |

--- a/.github/workflows/build-push.yaml
+++ b/.github/workflows/build-push.yaml
@@ -54,13 +54,16 @@ jobs:
 
       - name: Read quay image expiry
         id: quay-expiry
+        env:
+          REF_NAME: ${{ github.ref_name }}
+          REF_TYPE: ${{ github.ref_type }}
         run: |
-          if [[ "${{ github.ref_name }}" == "main" || "${{ github.ref_type }}" == "tag" && "${{ github.ref_name }}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ]]; then
+          if [[ "$REF_NAME" == "main" || ( "$REF_TYPE" == "tag" && "$REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-.*)?$ ) ]]; then
             echo "expiry=never" >> $GITHUB_OUTPUT
-            echo "Setting expiry to 'never' for ref ${{ github.ref_name }}"
+            echo "Setting expiry to 'never' for ref $REF_NAME"
           else
             echo "expiry=3w" >> $GITHUB_OUTPUT
-            echo "Setting expiry to '3w' for ref ${{ github.ref_name }}"
+            echo "Setting expiry to '3w' for ref $REF_NAME"
           fi
 
       - name: Build and Push Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,8 @@ RUN mkdir -p /var/cache/nginx /var/log/nginx /run && \
 COPY --from=builder /usr/src/app/dist/ /usr/share/nginx/html/
 COPY entrypoint.sh /usr/share/nginx/html/entrypoint.sh
 
+ARG QUAY_IMAGE_EXPIRY="never"
+LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}
+
 USER 1001
 ENTRYPOINT ["/usr/share/nginx/html/entrypoint.sh"]


### PR DESCRIPTION
### Changes
`.github/workflows/build-push.yaml` (replaces `dev-build.yaml` + `release-build.yaml`)
- Unified single workflow handling all three scenarios:
  - `push` to `main` → tags with git SHA + `latest`
  - `release` published → tags with semver (e.g. `v0.4.0`)
  - `workflow_dispatch` → manual trigger
- Adds a **Read quay image expiry** step that sets `QUAY_IMAGE_EXPIRY`:
  - `never` for `main` branch and release tags (`v*.*.*`)
  - `3w` (3 weeks) for all other refs (e.g. git SHA builds from feature branches)
- Passes `QUAY_IMAGE_EXPIRY` as a build argument to the Docker build step
- Uses `IMG_REGISTRY_USERNAME` / `IMG_REGISTRY_TOKEN` secrets (consistent with `dev-build.yaml`)
- Maintains multi-arch support: `linux/amd64`, `linux/arm64`, `linux/s390x`, `linux/ppc64le`
### `Dockerfile`
- Added `ARG QUAY_IMAGE_EXPIRY="never"` — defaults to `never` for local/manual builds
- Added `LABEL quay.expires-after=${QUAY_IMAGE_EXPIRY}` — Quay.io reads this label and automatically expires the image accordingly
## Expiry Behaviour Summary
| Tag type | `QUAY_IMAGE_EXPIRY` | Expires? |
|---|---|---|
| `main` | `never` | ❌ Never |
| `latest` | `never` | ❌ Never |
| `v0.4.0` (release) | `never` | ❌ Never |
| Git SHA | `3w` | ✅ After 3 weeks |

closes #518 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Image expiry is now set automatically during builds based on the release branch or tag.
  * Builds from `main` and version tags use no expiry; other builds get a shorter expiry period.

* **Changes**
  * Container images now include an expiry label during build, helping downstream image management reflect the intended retention period.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->