### PR TITLE
feat(apiproduct): show public URL in API Product overview tab

### DIFF
--- a/locales/en/plugin__kuadrant-console-plugin.json
+++ b/locales/en/plugin__kuadrant-console-plugin.json
@@ -20,6 +20,7 @@
   "Add API and Associate route": "Add API and Associate route",
   "Add Limit": "Add Limit",
   "Additional operators and tools to support Kuadrant.": "Additional operators and tools to support Kuadrant.",
+  "Address": "Address",
   "All API key requests have been reviewed": "All API key requests have been reviewed",
   "All API Products": "All API Products",
   "All dependencies for the policy are successfully resolved.": "All dependencies for the policy are successfully resolved.",

--- a/src/components/apiproduct/APIProductOverviewTab.tsx
+++ b/src/components/apiproduct/APIProductOverviewTab.tsx
@@ -14,6 +14,7 @@ import {
   Title,
   Button,
   Divider,
+  ClipboardCopy,
 } from '@patternfly/react-core';
 import { PencilAltIcon } from '@patternfly/react-icons';
 import {
@@ -21,6 +22,7 @@ import {
   useActiveNamespace,
   useAccessReview,
   Timestamp,
+  K8sResourceCommon,
 } from '@openshift-console/dynamic-plugin-sdk';
 import { APIProduct, PlanSpec } from './types';
 import { RESOURCES } from '../../utils/resources';
@@ -36,6 +38,14 @@ import '../kuadrant.css';
 
 type ContactField = 'team' | 'email' | 'slack' | 'url';
 type DocumentationField = 'openAPISpecURL' | 'docsURL';
+
+// Minimal shape of the HTTPRoute the APIProduct targets - we only read the
+// hostnames to derive the product's public address.
+interface LinkedHTTPRoute extends K8sResourceCommon {
+  spec?: {
+    hostnames?: string[];
+  };
+}
 
 const APIProductOverviewTab: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
@@ -73,6 +83,38 @@ const APIProductOverviewTab: React.FC = () => {
         }
       : null,
   );
+
+  // The APIProduct's public address is derived from the HTTPRoute it targets:
+  // its first hostname becomes the public URL. The APIProduct itself carries no
+  // address field, so we resolve it from the linked route's spec.hostnames.
+  const targetRef = apiProduct?.spec?.targetRef;
+
+  // Cache the targetRef so a transient watch reconnection (where spec is briefly
+  // absent) doesn't drop the linked route, matching APIProductPoliciesTab.
+  const [cachedTargetRef, setCachedTargetRef] = React.useState<typeof targetRef>(undefined);
+  React.useEffect(() => {
+    if (targetRef) {
+      setCachedTargetRef(targetRef);
+    }
+  }, [targetRef]);
+  const targetRefToUse = targetRef || cachedTargetRef;
+
+  const [httpRoute] = useK8sWatchResource<LinkedHTTPRoute>(
+    targetRefToUse && targetRefToUse.kind === 'HTTPRoute'
+      ? {
+          groupVersionKind: RESOURCES.HTTPRoute.gvk,
+          namespace: targetRefToUse.namespace || activeNamespace,
+          name: targetRefToUse.name,
+          isList: false,
+        }
+      : null,
+  );
+
+  // Use the first non-empty hostname as the public address.
+  const publicUrl = React.useMemo(() => {
+    const hostname = httpRoute?.spec?.hostnames?.find((h) => h.trim().length > 0);
+    return hostname ? `https://${hostname}` : undefined;
+  }, [httpRoute]);
 
   // Check if API Product has API Key authentication configured
   const hasApiKeyAuth = React.useMemo(() => {
@@ -232,6 +274,24 @@ const APIProductOverviewTab: React.FC = () => {
           <DescriptionListTerm>{t('Display Name')}</DescriptionListTerm>
           <DescriptionListDescription>
             {apiProduct.spec.displayName || apiProduct.metadata.name}
+          </DescriptionListDescription>
+        </DescriptionListGroup>
+
+        <DescriptionListGroup>
+          <DescriptionListTerm>{t('Address')}</DescriptionListTerm>
+          <DescriptionListDescription>
+            {publicUrl ? (
+              <ClipboardCopy
+                isReadOnly
+                hoverTip={t('Copy')}
+                clickTip={t('Copied')}
+                variant="inline-compact"
+              >
+                {publicUrl}
+              </ClipboardCopy>
+            ) : (
+              <span style={{ color: 'var(--pf-v6-global--Color--200)' }}>{t('Not set')}</span>
+            )}
           </DescriptionListDescription>
         </DescriptionListGroup>
 


### PR DESCRIPTION
## Description

Adds an **Address** field to the API Product overview tab so users can see and copy the product's public URL directly from the overview, instead of navigating to the underlying route.

Fixes #534

Opening as a **draft** because the source of the public URL is a design choice I'd like to confirm with @eguzki (see *Open question* below). The implementation here is complete and working for the UI-derivation approach; if a controller-populated status field is preferred, the change to swap the source is small.

## Type of change

- [x] `[feat]` New feature

## Changes made

- Derive the public URL from the HTTPRoute referenced by `spec.targetRef`: its first non-empty `spec.hostnames` entry becomes `https://<hostname>`. The APIProduct itself carries no address field (confirmed against `types.ts` and the CRD), so resolving it from the linked route is the only source available without controller changes.
- Reuse the **cached-targetRef + `useK8sWatchResource`** pattern already in `APIProductPoliciesTab.tsx`, so a transient watch reconnection (where `spec` is briefly absent) doesn't drop the linked route.
- Reuse the **`ClipboardCopy`** pattern from `APIKeyRevealModal.tsx` for copy-to-clipboard.
- When no route hostname is resolvable, the field renders **"Not set"**, matching the other optional overview fields.

## Open question for reviewers

Where should the public URL come from?
1. **Derived in the UI from the linked HTTPRoute's hostname** (what this PR does — works today, no controller dependency), or
2. **A resolved address on `APIProduct.status`** populated by the controller (like `APIKey.status.apiHostname`), if one is planned.

If (2) is the intended direction, I'll point the field at that status field instead — the rest of the UI stays the same.

## Test plan

- [x] `yarn lint` passes (no changes after running)
- [x] `yarn i18n` passes (committed the generated `Address` key)
- [x] `yarn tsc --noEmit` reports no errors in `src/`
- [ ] Tested manually in OpenShift Console (will verify once an APIProduct + HTTPRoute fixture is up)
- [ ] Tested in both light and dark themes

## Checklist

- [x] All user-facing strings use `t()` and are added to the locale file
- [x] No bare `.pf-*`/`.co-*` selectors or hex colors (reuses existing `--pf-v6-global--Color--200` for the empty state)
- [x] No `console.log` statements left in
- [x] Commit includes `Signed-off-by`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
