### PR TITLE
fix: correct broken doc links and cert-manager catalog URL

### DIFF
--- a/downstream.js
+++ b/downstream.js
@@ -22,13 +22,13 @@ const replacements = {
       // Direct string replacements for links.ts
       // Order matters: specific URLs first to prevent partial matches
       'https://docs.kuadrant.io/latest/kuadrant-operator/doc/user-guides/full-walkthrough/secure-protect-connect/':
-        `https://docs.redhat.com/en/documentation/red_hat_connectivity_link/${version}/html/configuring_and_deploying_gateway_policies/index`,
+        `https://docs.redhat.com/en/documentation/red_hat_connectivity_link/${version}/html/deploying_red_hat_connectivity_link/rhcl-config-deploy-gateway-policies`,
       'https://docs.kuadrant.io/latest/kuadrant-operator/doc/observability/examples/':
         `https://docs.redhat.com/en/documentation/red_hat_connectivity_link/${version}/html/observability/index`,
       'https://docs.kuadrant.io':
         `https://docs.redhat.com/en/documentation/red_hat_connectivity_link/${version}/`,
       'https://github.com/Kuadrant/kuadrant-operator/releases':
-        `https://docs.redhat.com/en/documentation/red_hat_connectivity_link/${version}/html/whats_new/rhcl-release-notes`,
+        `https://docs.redhat.com/en/documentation/red_hat_connectivity_link/${version}/html/release_notes/index`,
       'Kuadrant': 'Connectivity Link',
     },
   },

--- a/src/constants/links.ts
+++ b/src/constants/links.ts
@@ -17,7 +17,7 @@ export const INTERNAL_LINKS = {
     }?keyword=cert-manager&details-item=openshift-cert-manager-operator-redhat-operators-openshift-marketplace`;
     const linkLatest = `/catalog/ns/${
       namespace === '#ALL_NS#' ? 'default' : namespace
-    }?selectedId=openshift-cert-manager-operator-redhat-operators-openshift-marketplace`;
+    }?catalogType=operator&selectedId=openshift-cert-manager-operator-redhat-operators-openshift-marketplace`;
 
     // Determine link based on cluster version 4.20+ vs 4.19 and lower
     return major > 4 || (major === 4 && minor >= 20) ? linkLatest : link419;


### PR DESCRIPTION
- Fix downstream doc URL replacements to handle each link explicitly (observability, gateway policies, release notes, docs landing page) instead of a naive domain substitution that corrupted URL paths
- Update release notes path to release_notes/index
- Update gateway policies path to deploying_red_hat_connectivity_link/ rhcl-config-deploy-gateway-policies
- Use 'latest' version slug which resolves to current RHCL version
- Add OCP version detection for cert-manager link: use /catalog/ with catalogType=operator on OCP 4.20+ (Software Catalog), fall back to /operatorhub/ on OCP 4.19



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated gateway policies documentation link to point to the latest deployment guide.
  * Kuadrant releases link now directs to current release notes.
  * Cert Manager Operator link now adapts intelligently based on your cluster version for appropriate guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->