### PR TITLE
feat: add automated GVK sync check with kuadrant-operator

### DIFF
--- a/.github/workflows/gvk-sync.yaml
+++ b/.github/workflows/gvk-sync.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       # kubectl (with `kubectl kustomize`) and yq are pre-installed on the
       # ubuntu-latest runner image; the script fails fast if either is missing.
@@ -35,7 +35,7 @@ jobs:
 
       - name: Open pull request on drift
         if: steps.gvk.outputs.drift == 'true'
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6.1.0
         with:
           add-paths: src/utils/resources.ts
           branch: chore/sync-gvks

--- a/.github/workflows/gvk-sync.yaml
+++ b/.github/workflows/gvk-sync.yaml
@@ -1,0 +1,49 @@
+name: GVK Sync Check
+
+# Keeps the GroupVersionKinds in src/utils/resources.ts in sync with the CRDs
+# shipped by the kuadrant-operator. Runs weekly; opens a PR when drift is found.
+# See issue #74.
+
+on:
+  schedule:
+    - cron: '0 6 * * 1' # every Monday at 06:00 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  gvk-sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      # kubectl (with `kubectl kustomize`) and yq are pre-installed on the
+      # ubuntu-latest runner image; the script fails fast if either is missing.
+      - name: Check and fix GVK drift
+        id: gvk
+        env:
+          KUADRANT_OPERATOR_REF: main
+          GVK_REPORT: ${{ runner.temp }}/gvk-drift-report.md
+        run: |
+          chmod +x scripts/check-gvks.sh
+          ./scripts/check-gvks.sh --fix
+          if [[ -f "${GVK_REPORT}" ]]; then echo "drift=true" >> "${GITHUB_OUTPUT}"; fi
+
+      - name: Open pull request on drift
+        if: steps.gvk.outputs.drift == 'true'
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: src/utils/resources.ts
+          branch: chore/sync-gvks
+          delete-branch: true
+          commit-message: 'chore: sync GVKs with kuadrant-operator'
+          title: 'chore: sync GVKs with kuadrant-operator'
+          body-path: ${{ runner.temp }}/gvk-drift-report.md
+          labels: |
+            enhancement
+            automated
+          signoff: true

--- a/scripts/check-gvks.sh
+++ b/scripts/check-gvks.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Compare the GroupVersionKinds hardcoded in src/utils/resources.ts against the
+# CRDs shipped by the kuadrant-operator, and optionally update resources.ts when
+# they drift.
+#
+# The upstream source of truth is the kuadrant-operator `config/manifests`
+# kustomize target, which aggregates the kuadrant.io, extensions.kuadrant.io and
+# devportal.kuadrant.io CRDs the console plugin cares about (see issue #74).
+#
+# Usage:
+#   scripts/check-gvks.sh          # report drift, exit 1 if any (CI gate / local)
+#   scripts/check-gvks.sh --fix    # rewrite resources.ts to match upstream, exit 0
+#
+# Environment:
+#   KUADRANT_OPERATOR_REF   git ref to build from (default: main)
+#   GVK_REPORT              if set, a markdown drift report is written to this path
+#
+# Requirements: kubectl (provides `kubectl kustomize`) and yq (mikefarah v4).
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+RESOURCES_FILE="${REPO_ROOT}/src/utils/resources.ts"
+
+REF="${KUADRANT_OPERATOR_REF:-main}"
+KUSTOMIZE_TARGET="github.com/Kuadrant/kuadrant-operator/config/manifests?ref=${REF}"
+
+# Safety floor: refuse to act if the upstream build returns fewer CRDs than this.
+# Protects against an upstream layout change silently wiping every GVK.
+MIN_EXPECTED_CRDS=8
+
+FIX=false
+[[ "${1:-}" == "--fix" ]] && FIX=true
+
+log() { echo "==> $*"; }
+err() { echo "error: $*" >&2; exit 1; }
+
+command -v kubectl >/dev/null 2>&1 || err "'kubectl' not found (needed for 'kubectl kustomize')"
+command -v yq >/dev/null 2>&1 || err "'yq' (mikefarah v4) not found"
+[[ -f "${RESOURCES_FILE}" ]] || err "resources file not found: ${RESOURCES_FILE}"
+
+# --- 1. Upstream GVKs from the kuadrant-operator -----------------------------
+# Emit "Kind group version" per CRD, using each CRD's storage (canonical) version.
+log "Building upstream CRDs from ${KUSTOMIZE_TARGET}"
+upstream_raw="$(kubectl kustomize "${KUSTOMIZE_TARGET}" \
+  | yq '. | select(.kind == "CustomResourceDefinition")
+            | [.spec.names.kind, .spec.group, (.spec.versions[] | select(.storage == true) | .name)]
+            | join(" ")')"
+
+upstream_count="$(grep -c . <<<"${upstream_raw}" || true)"
+if (( upstream_count < MIN_EXPECTED_CRDS )); then
+  err "only ${upstream_count} upstream CRDs found (expected >= ${MIN_EXPECTED_CRDS}); aborting to avoid a destructive update"
+fi
+log "Found ${upstream_count} upstream Kuadrant CRDs"
+
+declare -A UP_GROUP UP_VERSION
+while read -r kind group version; do
+  [[ -z "${kind}" ]] && continue
+  UP_GROUP["${kind}"]="${group}"
+  UP_VERSION["${kind}"]="${version}"
+done <<<"${upstream_raw}"
+
+# --- 2. Local GVKs declared in resources.ts ----------------------------------
+# Matches lines like: gvk: { group: 'kuadrant.io', version: 'v1', kind: 'AuthPolicy' },
+local_raw="$(sed -nE "s/.*gvk: \{ group: '([^']*)', version: '([^']*)', kind: '([^']*)' \}.*/\3 \1 \2/p" "${RESOURCES_FILE}")"
+
+# --- 3. Diff (keyed by GVK, scoped to kinds the plugin declares) --------------
+drift=false
+report=""
+while read -r kind group version; do
+  [[ -z "${kind}" ]] && continue
+  # Only compare kinds the operator actually ships (skips Gateway API, Istio,
+  # ConfigMap, ConsolePlugin and any dependency CRD not in config/manifests).
+  [[ -n "${UP_GROUP[${kind}]:-}" ]] || continue
+
+  up_group="${UP_GROUP[${kind}]}"
+  up_version="${UP_VERSION[${kind}]}"
+  if [[ "${group}" != "${up_group}" || "${version}" != "${up_version}" ]]; then
+    drift=true
+    line="${kind}: ${group}/${version} (plugin) -> ${up_group}/${up_version} (operator)"
+    echo "DRIFT  ${line}"
+    report+="- \`${kind}\`: \`${group}/${version}\` -> \`${up_group}/${up_version}\`"$'\n'
+
+    if [[ "${FIX}" == true ]]; then
+      sed -i -E "s|(gvk: \{ group: ')[^']*(', version: ')[^']*(', kind: '${kind}' \})|\1${up_group}\2${up_version}\3|" "${RESOURCES_FILE}"
+    fi
+  else
+    echo "OK     ${kind}: ${group}/${version}"
+  fi
+done <<<"${local_raw}"
+
+# --- 4. Outcome --------------------------------------------------------------
+if [[ -n "${GVK_REPORT:-}" && -n "${report}" ]]; then
+  {
+    echo "Automated GVK drift detected against \`kuadrant-operator\` (ref: \`${REF}\`)."
+    echo
+    echo "${report}"
+  } > "${GVK_REPORT}"
+fi
+
+if [[ "${drift}" == false ]]; then
+  log "GVKs are in sync with kuadrant-operator (${REF})"
+  exit 0
+fi
+
+if [[ "${FIX}" == true ]]; then
+  log "Updated ${RESOURCES_FILE#"${REPO_ROOT}"/} to match upstream"
+  exit 0
+fi
+
+log "GVK drift detected (run with --fix to update resources.ts)"
+exit 1

--- a/scripts/check-gvks.sh
+++ b/scripts/check-gvks.sh
@@ -62,7 +62,9 @@ done <<<"${upstream_raw}"
 
 # --- 2. Local GVKs declared in resources.ts ----------------------------------
 # Matches lines like: gvk: { group: 'kuadrant.io', version: 'v1', kind: 'AuthPolicy' },
-local_raw="$(sed -nE "s/.*gvk: \{ group: '([^']*)', version: '([^']*)', kind: '([^']*)' \}.*/\3 \1 \2/p" "${RESOURCES_FILE}")"
+# Tolerant of arbitrary spacing and single or double quotes, so reformatting
+# resources.ts (e.g. via Prettier) does not silently break drift detection.
+local_raw="$(sed -nE 's/.*gvk:[[:space:]]*\{[[:space:]]*group:[[:space:]]*["'\'']([^"'\'']*)["'\''][[:space:]]*,[[:space:]]*version:[[:space:]]*["'\'']([^"'\'']*)["'\''][[:space:]]*,[[:space:]]*kind:[[:space:]]*["'\'']([^"'\'']*)["'\''].*/\3 \1 \2/p' "${RESOURCES_FILE}")"
 
 # --- 3. Diff (keyed by GVK, scoped to kinds the plugin declares) --------------
 drift=false

--- a/scripts/check-gvks.sh
+++ b/scripts/check-gvks.sh
@@ -82,7 +82,10 @@ while read -r kind group version; do
     report+="- \`${kind}\`: \`${group}/${version}\` -> \`${up_group}/${up_version}\`"$'\n'
 
     if [[ "${FIX}" == true ]]; then
-      sed -i -E "s|(gvk: \{ group: ')[^']*(', version: ')[^']*(', kind: '${kind}' \})|\1${up_group}\2${up_version}\3|" "${RESOURCES_FILE}"
+      # Avoid `sed -i` (GNU and BSD/macOS syntax differ); write via a temp file.
+      tmp="$(mktemp)"
+      sed -E "s|(gvk: \{ group: ')[^']*(', version: ')[^']*(', kind: '${kind}' \})|\1${up_group}\2${up_version}\3|" "${RESOURCES_FILE}" > "${tmp}"
+      mv "${tmp}" "${RESOURCES_FILE}"
     fi
   else
     echo "OK     ${kind}: ${group}/${version}"


### PR DESCRIPTION
Adds a weekly GitHub Action that keeps the GroupVersionKinds in src/utils/resources.ts in sync with the CRDs shipped by the kuadrant-operator.

scripts/check-gvks.sh builds the operator's config/manifests kustomize target (which aggregates the kuadrant.io, extensions.kuadrant.io and devportal.kuadrant.io CRDs the plugin uses), extracts each CRD's group and storage version with yq, and diffs them against the GVKs declared in resources.ts. Only kinds the plugin already declares are compared, so Gateway API and Istio types are skipped. A safety floor aborts the run if the upstream build returns an unexpectedly small CRD set.

The .github/workflows/gvk-sync.yaml workflow runs the script weekly (and on demand), and on drift opens a PR updating resources.ts via peter-evans/create-pull-request.

Closes #74




## Type of change

- [ ] `[fix]` Bug fix
- [x] `[feat]` New feature
- [ ] `[refactor]` Refactor (no functional changes)
- [ ] `[test]` Test updates
- [ ] `[chore]` Dependency / config update

## Test plan

- [ ] `yarn lint` passes (no changes after running)
- [ ] `yarn build` passes
- [ ] `yarn i18n` passes (no changes after running — commit updated locale files if needed)
- [ ] Tested manually in OpenShift Console
- [ ] Tested in both light and dark themes
- [ ] Tested in all-namespaces and single namespace mode

## Screenshots

<!-- For UI changes, add before/after screenshots -->

| Before | After |
|--------|-------|
|        |       |

## Checklist

- [ ] All user-facing strings use `t()` and are added to `locales/en/plugin__kuadrant-console-plugin.json`
- [ ] CSS classes are prefixed with `kuadrant-` — no bare `.pf-*` or `.co-*` selectors, no hex colors
- [x] No `console.log` statements left in
- [x] Commits include `Signed-off-by` line (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Added an automated weekly Kubernetes GroupVersionKind sync check against upstream sources, with manual triggering support.
  * Generates a drift report and flags when schema changes are detected.
  * Automatically opens an update pull request (with labels and sign-off) and can apply drift fixes to the maintained definition list.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->