### PR TITLE
fix: use configured auth scheme prefix in API key usage examples

### DIFF
--- a/src/components/apikey/UsageExamples.tsx
+++ b/src/components/apikey/UsageExamples.tsx
@@ -42,8 +42,10 @@ const UsageExamples: React.FC<UsageExamplesProps> = ({ apiKey }) => {
 
     const hostname = apiKey.status?.apiHostname || 'api.example.com';
     const placeholderKey = 'YOUR_API_KEY';
+    const authPrefix =
+      apiKey.status?.authScheme?.credentials?.authorizationHeader?.prefix ?? 'Bearer';
 
-    const codeSnippets = generateAuthCodeSnippets(placeholderKey, hostname);
+    const codeSnippets = generateAuthCodeSnippets(placeholderKey, hostname, authPrefix);
     setSnippets(codeSnippets);
   }, [apiKey]);
 

--- a/src/utils/generateAuthCodeSnippets.ts
+++ b/src/utils/generateAuthCodeSnippets.ts
@@ -5,18 +5,24 @@ export interface AuthCodeSnippets {
   go: string;
 }
 
-export const generateAuthCodeSnippets = (apiKey: string, hostname: string): AuthCodeSnippets => {
+export const generateAuthCodeSnippets = (
+  apiKey: string,
+  hostname: string,
+  authPrefix = 'Bearer',
+): AuthCodeSnippets => {
   const url = `https://${hostname}/api/v1/example`;
+  // Some auth schemes use an empty prefix; only prepend one (with a space) when present.
+  const credential = authPrefix ? `${authPrefix} ${apiKey}` : apiKey;
 
   return {
     curl: `curl -X GET "${url}" \\
-  -H "Authorization: Bearer ${apiKey}"`,
+  -H "Authorization: ${credential}"`,
 
     nodejs: `const axios = require('axios');
 
 axios.get('${url}', {
   headers: {
-    'Authorization': 'Bearer ${apiKey}'
+    'Authorization': '${credential}'
   }
 })
 .then(response => {
@@ -30,7 +36,7 @@ axios.get('${url}', {
 
 url = "${url}"
 headers = {
-    "Authorization": f"Bearer ${apiKey}"
+    "Authorization": "${credential}"
 }
 
 response = requests.get(url, headers=headers)
@@ -48,7 +54,7 @@ func main() {
     url := "${url}"
 
     req, _ := http.NewRequest("GET", url, nil)
-    req.Header.Add("Authorization", "Bearer ${apiKey}")
+    req.Header.Add("Authorization", "${credential}")
 
     client := &http.Client{}
     resp, err := client.Do(req)

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -75,6 +75,13 @@ export interface APIKey extends K8sResourceCommon {
     limits?: PlanLimits;
     conditions?: Condition[];
     apiHostname?: string;
+    authScheme?: {
+      credentials?: {
+        authorizationHeader?: {
+          prefix?: string;
+        };
+      };
+    };
   };
 }
 


### PR DESCRIPTION
 ## Description

The **Usage Examples** panel on the API Key details page generated cURL, Node.js, Python, and Go snippets that hardcoded `Authorization: Bearer <key>`, ignoring the auth scheme actually configured by the API product's AuthPolicy. When a product uses a custom credentials prefix (e.g. `APIKEY`), consumers copied the snippet, sent `Bearer ...`, and received a silent `401 Unauthorized` which looks like a credential/config problem rather than a display bug.

This PR reads the real prefix from the APIKey status (`status.authScheme.credentials.authorizationHeader.prefix`) and threads it through the snippet generator, falling back to `Bearer` when the field is absent (so OIDC/JWT products and older controllers are unaffected). No additional API calls are required the value is already present on the APIKey status subresource.

  Fixes #547

  ## Type of change

  - [x] `[fix]` Bug fix
  - [ ] `[feat]` New feature
  - [ ] `[refactor]` Refactor (no functional changes)
  - [ ] `[test]` Test updates
  - [ ] `[chore]` Dependency / config update

  ## Changes made

  - `src/utils/resources.ts` added `authScheme.credentials.authorizationHeader.prefix` to the `APIKey` `status` type.
  - `src/utils/generateAuthCodeSnippets.ts` added an `authPrefix = 'Bearer'` parameter, build the credential string once (handling empty-prefix schemes to
  avoid a stray leading space), and applied it across all four snippets. Also corrected the Python snippet, which used an `f"..."` string with no
  interpolation.
  - `src/components/apikey/UsageExamples.tsx` derive the prefix from the APIKey status (`?? 'Bearer'`) and pass it to `generateAuthCodeSnippets`.

  ## Test plan

  - [x] `yarn lint` passes (no changes after running)
  - [x] `yarn build` passes
  - [x] `yarn i18n` passes (no new user-facing strings snippet bodies are raw code, not translated)
  - [x] Tested manually in OpenShift Console
  - [x] Tested in both light and dark themes
  - [x] Tested in all-namespaces and single namespace mode

## Screenshots

| Before | After |
|---------|---------|
| **Authorization: Bearer YOUR_API_KEY**<br><br><img width="1086" height="565" alt="Before" src="https://github.com/user-attachments/assets/aaccd4df-3348-4c03-b9de-7345b7ab2c23" /> | **Authorization: APIKEY YOUR_API_KEY**<br><br><img width="1095" height="557" alt="After" src="https://github.com/user-attachments/assets/284b8a7d-8574-45a0-9607-44abb2c4ccb3" /> |

  ## Checklist

  - [x] All user-facing strings use `t()` and are added to `locales/en/plugin__kuadrant-console-plugin.json` (no new strings introduced)
  - [x] CSS classes are prefixed with `kuadrant-` no bare `.pf-*` or `.co-*` selectors, no hex colors (no CSS changes)
  - [x] No `console.log` statements left in
  - [x] Commits include `Signed-off-by` line (`git commit -s`)