### PR TITLE
fix: do not emit empty loadBalancing block on every DNSPolicy

### DIFF
--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -208,7 +208,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
         setProviderRefs([providerRef]);
         setLoadBalancing({
           geo: dnsPolicyUpdate.spec?.loadBalancing?.geo || '',
-          weight: dnsPolicyUpdate.spec?.loadBalancing?.weight ?? null,
+          weight: dnsPolicyUpdate.spec?.loadBalancing?.weight ?? 120,
           defaultGeo:
             dnsPolicyUpdate.spec?.loadBalancing?.defaultGeo !== undefined
               ? dnsPolicyUpdate.spec.loadBalancing?.defaultGeo
@@ -244,7 +244,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
 
       setLoadBalancing({
         geo: parsedYaml.spec?.loadBalancing?.geo || '',
-        weight: parsedYaml.spec?.loadBalancing?.weight ?? null,
+        weight: parsedYaml.spec?.loadBalancing?.weight ?? 120,
         defaultGeo:
           parsedYaml.spec?.loadBalancing?.defaultGeo !== undefined
             ? parsedYaml.spec.loadBalancing?.defaultGeo

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -35,6 +35,9 @@ import KuadrantCreateUpdate from './KuadrantCreateUpdate';
 import { handleCancel } from '../utils/cancel';
 import { resourceGVKMapping } from '../utils/resources';
 
+// Default weight applied to weighted load-balancing endpoints (matches the CRD default).
+const DEFAULT_LOAD_BALANCING_WEIGHT = 120;
+
 const KuadrantDNSPolicyCreatePage: React.FC = () => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [createView, setCreateView] = React.useState<'form' | 'yaml'>('form');
@@ -46,7 +49,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
   });
   const [loadBalancing, setLoadBalancing] = React.useState<LoadBalancing>({
     geo: '',
-    weight: 120,
+    weight: DEFAULT_LOAD_BALANCING_WEIGHT,
     defaultGeo: '',
   });
   const [healthCheck, setHealthCheck] = React.useState<HealthCheck>({
@@ -208,7 +211,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
         setProviderRefs([providerRef]);
         setLoadBalancing({
           geo: dnsPolicyUpdate.spec?.loadBalancing?.geo || '',
-          weight: dnsPolicyUpdate.spec?.loadBalancing?.weight ?? 120,
+          weight: dnsPolicyUpdate.spec?.loadBalancing?.weight ?? DEFAULT_LOAD_BALANCING_WEIGHT,
           defaultGeo:
             dnsPolicyUpdate.spec?.loadBalancing?.defaultGeo !== undefined
               ? dnsPolicyUpdate.spec.loadBalancing?.defaultGeo
@@ -244,7 +247,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
 
       setLoadBalancing({
         geo: parsedYaml.spec?.loadBalancing?.geo || '',
-        weight: parsedYaml.spec?.loadBalancing?.weight ?? 120,
+        weight: parsedYaml.spec?.loadBalancing?.weight ?? DEFAULT_LOAD_BALANCING_WEIGHT,
         defaultGeo:
           parsedYaml.spec?.loadBalancing?.defaultGeo !== undefined
             ? parsedYaml.spec.loadBalancing?.defaultGeo

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -76,8 +76,10 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
       healthCheck.port ||
       healthCheck.protocol !== '';
 
-    const hasLoadBalancing =
-      loadBalancing.geo || loadBalancing.defaultGeo !== '' || loadBalancing.weight != null;
+    // Load balancing requires a geo value (see formValidation). Gate on geo rather than
+    // weight/defaultGeo: weight defaults to 120 and would otherwise always emit an
+    // incomplete loadBalancing block even when the user never opened the section.
+    const hasLoadBalancing = Boolean(loadBalancing.geo);
 
     return {
       apiVersion:


### PR DESCRIPTION
hasLoadBalancing was computed from `loadBalancing.weight != null`, but weight defaults to 120, so the condition was always true. As a result every DNSPolicy created via the form serialized a `spec.loadBalancing` block (with just `weight: 120` and no geo) even when the user never opened the Load Balancing section.

Gate on `loadBalancing.geo` instead, which is the field the form validation already requires for load balancing and which is populated both when the user fills the section and when an existing policy is loaded for editing.
 
## Type of change

- [x] `[fix]` Bug fix
- [ ] `[feat]` New feature
- [ ] `[refactor]` Refactor (no functional changes)
- [ ] `[test]` Test updates
- [ ] `[chore]` Dependency / config update


## Test plan

- [ ] `yarn lint` passes (no changes after running)
- [ ] `yarn build` passes
- [ ] `yarn i18n` passes (no changes after running — commit updated locale files if needed)
- [ ] Tested manually in OpenShift Console
- [ ] Tested in both light and dark themes
- [ ] Tested in all-namespaces and single namespace mode


## Checklist

- [ ] All user-facing strings use `t()` and are added to `locales/en/plugin__kuadrant-console-plugin.json`
- [ ] CSS classes are prefixed with `kuadrant-` — no bare `.pf-*` or `.co-*` selectors, no hex colors
- [ ] No `console.log` statements left in
- [ ] Commits include `Signed-off-by` line (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary

* **Bug Fixes**
  * Improved DNS Policy creation so incomplete load balancing settings are no longer saved when the geographical distribution isn’t configured.
  * Load balancing defaults are now applied consistently when creating or reloading a policy, and the load balancing section is only generated when the geo option is set to avoid partial/invalid configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->