### PR TITLE
replace yarn oinc scripts with make targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: oinc oinc-teardown
+
+oinc:
+	./start-local.sh
+
+oinc-teardown:
+	./scripts/teardown.sh

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ Navigate to <http://localhost:9000> and click "Kuadrant" in the left sidebar men
 Prerequisites: [oinc](https://github.com/jasonmadigan/oinc), [kubectl](https://kubernetes.io/docs/tasks/tools/), Docker or podman, Node.js.
 
 ```bash
-yarn oinc          # create cluster + start plugin dev server with hot reload
-yarn oinc:teardown # tear it all down
+make oinc          # create cluster + start plugin dev server with hot reload
+make oinc-teardown # tear it all down
 ```
 
-Console runs at http://localhost:9000, plugin at http://localhost:9001. If the cluster already exists, `yarn oinc` skips setup and just starts the plugin server.
+Console runs at http://localhost:9000, plugin at http://localhost:9001. If the cluster already exists, `make oinc` skips setup and just starts the plugin server.
 
 ### Option 3: Docker + VSCode Remote Container
 

--- a/package.json
+++ b/package.json
@@ -14,8 +14,6 @@
     "build-dev": "yarn clean && yarn webpack",
     "start": "yarn webpack serve --progress",
     "start-console": "./start-console.sh",
-    "oinc": "./start-local.sh",
-    "oinc:teardown": "./scripts/teardown.sh",
     "i18n": "./i18n-scripts/build-i18n.sh && node ./i18n-scripts/set-english-defaults.js",
     "lint": "yarn eslint src --fix && stylelint 'src/**/*.css' --allow-empty-input --fix",
     "test:e2e": "npx playwright test --config=e2e/playwright.config.ts",

--- a/start-local.sh
+++ b/start-local.sh
@@ -8,8 +8,8 @@ set -euo pipefail
 # prerequisites: oinc, kubectl, node
 #
 # usage:
-#   yarn oinc          # setup cluster + start plugin with hot reload
-#   yarn oinc:teardown # tear it all down
+#   make oinc          # setup cluster + start plugin with hot reload
+#   make oinc-teardown # tear it all down
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
@@ -26,7 +26,7 @@ cleanup() {
   log "shutting down plugin dev server..."
   kill "$PLUGIN_PID" 2>/dev/null || true
   wait "$PLUGIN_PID" 2>/dev/null || true
-  log "cluster is still running. tear down with: yarn oinc:teardown"
+  log "cluster is still running. tear down with: make oinc-teardown"
 }
 
 if kubectl get nodes &>/dev/null 2>&1; then


### PR DESCRIPTION
> corepack enable? in this economy? nah. make `oinc` just work, no prerequisites arc required

replaces `yarn oinc` / `yarn oinc:teardown` with `make oinc` / `make oinc-teardown`.

calls the shell scripts directly, so contributors don't need [corepack](https://yarnpkg.com/corepack) set up for yarn 4 just to run oinc.

- adds Makefile with oinc and oinc-teardown targets
- updates README references
- removes oinc scripts from package.json

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup instructions to use `make oinc` and `make oinc-teardown` for local development.
* **Bug Fixes**
  * Aligned the local run and teardown commands across the project so the documented workflow matches the available commands.
* **Chores**
  * Simplified command entry points by moving the local setup and teardown actions into Make targets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->