### PR TITLE
Optimize e2e parallel

### DIFF
--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -9,7 +9,7 @@ on:
         type: string
 
 jobs:
-  e2e:
+  e2e-rbac:
     runs-on: ubuntu-latest
     timeout-minutes: 60
 

--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -1,0 +1,94 @@
+name: E2E Tests (Common)
+
+on:
+  workflow_call:
+    inputs:
+      suite:
+        description: 'Test suite to run: smoke or full'
+        required: true
+        type: string
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Install oinc
+        run: |
+          OINC_VERSION="${OINC_VERSION:-v0.1.2}"
+          curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
+          chmod +x oinc
+          sudo mv oinc /usr/local/bin/
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+
+      - name: Install dependencies
+        run: yarn install
+
+      - name: Install Playwright browsers
+        run: yarn playwright install --with-deps chromium
+
+      - name: Start plugin dev server
+        run: |
+          yarn clean && yarn start &
+          echo $! > /tmp/dev-server.pid
+        env:
+          NODE_ENV: development
+
+      - name: Setup cluster
+        run: ./e2e/setup.sh
+
+      - name: Wait for plugin dev server
+        run: |
+          DEV_SERVER_PID=$(cat /tmp/dev-server.pid)
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:9001 >/dev/null 2>&1; then
+              echo "plugin dev server ready"
+              exit 0
+            fi
+            # Fail fast if the dev server process has already exited
+            if ! kill -0 "$DEV_SERVER_PID" 2>/dev/null; then
+              echo "plugin dev server process died unexpectedly"
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "plugin dev server not ready after 60s"
+          exit 1
+
+      - name: Run E2E tests (smoke)
+        if: inputs.suite == 'smoke'
+        run: npx playwright test --config=e2e/playwright.config.ts
+          e2e/tests/apiproduct-crud.spec.ts
+          e2e/tests/apikey-lifecycle.spec.ts
+          e2e/tests/apikey-approvals.spec.ts
+          e2e/tests/apiproduct-rbac.spec.ts
+          e2e/tests/apiproduct-apikeys-tab.spec.ts
+          e2e/tests/rbac.spec.ts
+
+      - name: Run E2E tests (full)
+        if: inputs.suite == 'full'
+        run: npx playwright test --config=e2e/playwright.config.ts
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report-${{ inputs.suite }}
+          path: playwright-report/
+          retention-days: 7
+
+      - name: Teardown
+        if: always()
+        run: ./e2e/teardown.sh

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -1,0 +1,12 @@
+name: E2E Tests (Nightly)
+
+on:
+  schedule:
+    - cron: '0 2 * * *'  # Every night at 2:00 UTC
+  workflow_dispatch:
+
+jobs:
+  e2e-full:
+    uses: ./.github/workflows/e2e-common.yaml
+    with:
+      suite: full

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,67 +12,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  e2e-rbac:
-    runs-on: ubuntu-latest
-    timeout-minutes: 45
-
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
-      - name: Enable Corepack
-        run: corepack enable
-
-      - name: Install oinc
-        run: |
-          OINC_VERSION="${OINC_VERSION:-v0.1.2}"
-          curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
-          chmod +x oinc
-          sudo mv oinc /usr/local/bin/
-
-      - name: Install Helm
-        uses: azure/setup-helm@v4
-
-      - name: Install dependencies
-        run: yarn install
-
-      - name: Install Playwright browsers
-        run: yarn playwright install --with-deps chromium
-
-      - name: Setup cluster
-        run: ./e2e/setup.sh
-
-      - name: Start plugin dev server
-        run: yarn clean && yarn start &
-        env:
-          NODE_ENV: development
-
-      - name: Wait for plugin dev server
-        run: |
-          for i in $(seq 1 30); do
-            if curl -sf http://localhost:9001 >/dev/null 2>&1; then
-              echo "plugin dev server ready"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "plugin dev server not ready after 60s"
-          exit 1
-
-      - name: Run E2E tests
-        run: npx playwright test --config=e2e/playwright.config.ts
-
-      - name: Upload test results
-        if: always()
-        uses: actions/upload-artifact@v4
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 7
-
-      - name: Teardown
-        if: always()
-        run: ./e2e/teardown.sh
+  e2e-smoke:
+    uses: ./.github/workflows/e2e-common.yaml
+    with:
+      suite: smoke

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -4,9 +4,9 @@ export default defineConfig({
   testDir: './tests',
   timeout: 60_000,
   expect: { timeout: 10_000 },
-  fullyParallel: false,
+  fullyParallel: true,
   retries: 1,
-  workers: 1,
+  workers: 3,
   reporter: [['html', { open: 'never' }], ['list']],
   use: {
     baseURL: process.env.CONSOLE_URL || 'http://localhost:9000',

--- a/e2e/tests/apikey-approvals.spec.ts
+++ b/e2e/tests/apikey-approvals.spec.ts
@@ -88,24 +88,35 @@ test.describe('APIKey Approvals - Approve flow', () => {
     await expect(page.locator('td:has-text("alice@example.com")')).toBeVisible();
   });
 
-  test('approve single request shows success toast', async ({ page }) => {
-    // Create test-specific namespace and APIKey
-    execSync(`
-      kubectl create namespace consumer-alice-approve || true
-      kubectl apply -f - <<EOF
+  // Nested describe so dynamic resources are only created for the approve test,
+  // not for the cancel test which uses the static alice@example.com from setup.sh.
+  test.describe('approve single request', () => {
+    let aliceNs: string;
+    let aliceKey: string;
+    let aliceEmail: string;
+
+    test.beforeEach(async ({ page }) => {
+      const uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      aliceNs = `consumer-alice-approve-${uid}`;
+      aliceKey = `alice-approve-${uid}`;
+      aliceEmail = `alice-approve-${uid}@example.com`;
+
+      execSync(`
+        kubectl create namespace ${aliceNs} || true
+        kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: alice-approve-api-key
-  namespace: consumer-alice-approve
+  name: ${aliceKey}
+  namespace: ${aliceNs}
 stringData:
   api_key: test-alice-approve-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: alice-approve-api-key
-  namespace: consumer-alice-approve
+  name: ${aliceKey}
+  namespace: ${aliceNs}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -114,59 +125,70 @@ spec:
   useCase: "Testing API integration for approval"
   requestedBy:
     userId: "alice-approve"
-    email: "alice-approve@example.com"
+    email: "${aliceEmail}"
   secretRef:
-    name: alice-approve-api-key
+    name: ${aliceKey}
 EOF
-    `, { stdio: 'inherit' });
+      `, { stdio: 'inherit' });
 
-    // Wait for APIKeyRequest to be created
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q alice-approve; do sleep 1; done\'', { stdio: 'inherit' });
+      execSync(`timeout 30 bash -c 'until kubectl get apikeyrequests -n kuadrant-test | grep -q ${aliceKey}; do sleep 1; done'`, { stdio: 'inherit' });
 
-    // Refresh the page to see the new request
-    await page.reload();
-    await page.waitForLoadState('networkidle');
-
-    const aliceApproveRow = page.locator('tr:has-text("alice-approve@example.com")');
-    await expect(aliceApproveRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
-    await aliceApproveRow.locator('[aria-label="Actions"]').click();
-    await page.locator('[role="menuitem"]:has-text("Approve")').click();
-
-    await expect(page.locator('.pf-v6-c-modal-box')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-modal-box').locator('text=alice-approve@example.com')).toBeVisible();
-
-    await page.locator('.pf-v6-c-modal-box').locator('button:has-text("Approve")').click();
-
-    await expect(page.locator('.pf-v6-c-alert:has-text("approved successfully")')).toBeVisible({
-      timeout: 30_000,
+      await page.reload();
+      await page.waitForLoadState('networkidle');
     });
 
-    // Clean up test namespace
-    execSync('kubectl delete namespace consumer-alice-approve --ignore-not-found=true', { stdio: 'inherit' });
+    test.afterEach(async () => {
+      execSync(`kubectl delete namespace ${aliceNs} --ignore-not-found=true`, { stdio: 'inherit' });
+    });
+
+    test('approve single request shows success toast', async ({ page }) => {
+      const aliceApproveRow = page.locator(`tr:has-text("${aliceEmail}")`);
+      await expect(aliceApproveRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
+      await aliceApproveRow.locator('[aria-label="Actions"]').click();
+      await page.locator('[role="menuitem"]:has-text("Approve")').click();
+
+      await expect(page.locator('.pf-v6-c-modal-box')).toBeVisible();
+      await expect(page.locator('.pf-v6-c-modal-box').locator(`text=${aliceEmail}`)).toBeVisible();
+
+      await page.locator('.pf-v6-c-modal-box').locator('button:has-text("Approve")').click();
+
+      await expect(page.locator('.pf-v6-c-alert:has-text("approved successfully")')).toBeVisible({
+        timeout: 30_000,
+      });
+    });
   });
 });
 
 // ── Reject with reason (uses bob) ────────────────────────────────────────────
 
 test.describe('APIKey Approvals - Reject with reason', () => {
+  let uid: string;
+  let bobNs: string;
+  let bobKey: string;
+  let bobEmail: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create test-specific namespace and APIKey
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    bobNs = `consumer-bob-reject-${uid}`;
+    bobKey = `bob-reject-${uid}`;
+    bobEmail = `bob-reject-${uid}@startup.io`;
+
     execSync(`
-      kubectl create namespace consumer-bob-reject || true
+      kubectl create namespace ${bobNs} || true
       kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: bob-reject-api-key
-  namespace: consumer-bob-reject
+  name: ${bobKey}
+  namespace: ${bobNs}
 stringData:
   api_key: test-bob-reject-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: bob-reject-api-key
-  namespace: consumer-bob-reject
+  name: ${bobKey}
+  namespace: ${bobNs}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -175,33 +197,31 @@ spec:
   useCase: "Building a startup integration"
   requestedBy:
     userId: "bob-reject"
-    email: "bob-reject@startup.io"
+    email: "${bobEmail}"
   secretRef:
-    name: bob-reject-api-key
+    name: ${bobKey}
 EOF
     `, { stdio: 'inherit' });
 
-    // Wait for APIKeyRequest to be created
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q bob-reject; do sleep 1; done\'', { stdio: 'inherit' });
+    execSync(`timeout 30 bash -c 'until kubectl get apikeyrequests -n kuadrant-test | grep -q ${bobKey}; do sleep 1; done'`, { stdio: 'inherit' });
 
     await navigateAsOwner(page);
-    await expect(page.locator('td:has-text("bob-reject@startup.io")')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`td:has-text("${bobEmail}")`)).toBeVisible({ timeout: 30_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    // Clean up test namespace
-    execSync('kubectl delete namespace consumer-bob-reject --ignore-not-found=true', { stdio: 'inherit' });
+    execSync(`kubectl delete namespace ${bobNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
   test('reject request with reason shows success toast', async ({ page }) => {
-    const bobRow = page.locator('tr:has-text("bob-reject@startup.io")');
+    const bobRow = page.locator(`tr:has-text("${bobEmail}")`);
     await expect(bobRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
     await bobRow.locator('[aria-label="Actions"]').click();
     await page.locator('[role="menuitem"]:has-text("Deny")').click();
 
     await expect(page.locator('.pf-v6-c-modal-box')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-modal-box').locator('text=bob-reject@startup.io')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-modal-box').locator(`text=${bobEmail}`)).toBeVisible();
 
     await page.locator('#rejection-reason').fill('Does not meet usage requirements');
     await page.locator('.pf-v6-c-modal-box').locator('button:has-text("Deny")').click();
@@ -215,24 +235,33 @@ EOF
 // ── Reject without reason (uses bob2) ────────────────────────────────────────
 
 test.describe('APIKey Approvals - Reject without reason', () => {
+  let uid: string;
+  let bob2Ns: string;
+  let bob2Key: string;
+  let bob2Email: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create test-specific namespace and APIKey
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    bob2Ns = `consumer-bob2-reject-${uid}`;
+    bob2Key = `bob2-reject-${uid}`;
+    bob2Email = `bob2-reject-${uid}@startup.io`;
+
     execSync(`
-      kubectl create namespace consumer-bob2-reject || true
+      kubectl create namespace ${bob2Ns} || true
       kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: bob2-reject-api-key
-  namespace: consumer-bob2-reject
+  name: ${bob2Key}
+  namespace: ${bob2Ns}
 stringData:
   api_key: test-bob2-reject-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: bob2-reject-api-key
-  namespace: consumer-bob2-reject
+  name: ${bob2Key}
+  namespace: ${bob2Ns}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -241,27 +270,25 @@ spec:
   useCase: "Mobile app API integration"
   requestedBy:
     userId: "bob2-reject"
-    email: "bob2-reject@startup.io"
+    email: "${bob2Email}"
   secretRef:
-    name: bob2-reject-api-key
+    name: ${bob2Key}
 EOF
     `, { stdio: 'inherit' });
 
-    // Wait for APIKeyRequest to be created
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q bob2-reject; do sleep 1; done\'', { stdio: 'inherit' });
+    execSync(`timeout 30 bash -c 'until kubectl get apikeyrequests -n kuadrant-test | grep -q ${bob2Key}; do sleep 1; done'`, { stdio: 'inherit' });
 
     await navigateAsOwner(page);
-    await expect(page.locator('td:has-text("bob2-reject@startup.io")')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`td:has-text("${bob2Email}")`)).toBeVisible({ timeout: 30_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    // Clean up test namespace
-    execSync('kubectl delete namespace consumer-bob2-reject --ignore-not-found=true', { stdio: 'inherit' });
+    execSync(`kubectl delete namespace ${bob2Ns} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
   test('reject request without reason is allowed', async ({ page }) => {
-    const bob2Row = page.locator('tr:has-text("bob2-reject@startup.io")');
+    const bob2Row = page.locator(`tr:has-text("${bob2Email}")`);
     await expect(bob2Row.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
     await bob2Row.locator('[aria-label="Actions"]').click();
     await page.locator('[role="menuitem"]:has-text("Deny")').click();
@@ -281,25 +308,40 @@ EOF
 // ── Bulk approve (uses carol + dave) ──────────────────────────────────────────
 
 test.describe('APIKey Approvals - Bulk approve', () => {
+  let uid: string;
+  let carolNs: string;
+  let carolKey: string;
+  let carolEmail: string;
+  let daveNs: string;
+  let daveKey: string;
+  let daveEmail: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create test-specific namespaces and APIKeys
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    carolNs = `consumer-carol-bulk-${uid}`;
+    carolKey = `carol-bulk-${uid}`;
+    carolEmail = `carol-bulk-${uid}@enterprise.com`;
+    daveNs = `consumer-dave-bulk-${uid}`;
+    daveKey = `dave-bulk-${uid}`;
+    daveEmail = `dave-bulk-${uid}@partner.io`;
+
     execSync(`
-      kubectl create namespace consumer-carol-bulk || true
-      kubectl create namespace consumer-dave-bulk || true
+      kubectl create namespace ${carolNs} || true
+      kubectl create namespace ${daveNs} || true
       kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: carol-bulk-api-key
-  namespace: consumer-carol-bulk
+  name: ${carolKey}
+  namespace: ${carolNs}
 stringData:
   api_key: test-carol-bulk-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: carol-bulk-api-key
-  namespace: consumer-carol-bulk
+  name: ${carolKey}
+  namespace: ${carolNs}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -308,23 +350,23 @@ spec:
   useCase: "Enterprise integration"
   requestedBy:
     userId: "carol-bulk"
-    email: "carol-bulk@enterprise.com"
+    email: "${carolEmail}"
   secretRef:
-    name: carol-bulk-api-key
+    name: ${carolKey}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: dave-bulk-api-key
-  namespace: consumer-dave-bulk
+  name: ${daveKey}
+  namespace: ${daveNs}
 stringData:
   api_key: test-dave-bulk-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: dave-bulk-api-key
-  namespace: consumer-dave-bulk
+  name: ${daveKey}
+  namespace: ${daveNs}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -333,31 +375,29 @@ spec:
   useCase: "Partner API access"
   requestedBy:
     userId: "dave-bulk"
-    email: "dave-bulk@partner.io"
+    email: "${daveEmail}"
   secretRef:
-    name: dave-bulk-api-key
+    name: ${daveKey}
 EOF
     `, { stdio: 'inherit' });
 
-    // Wait for APIKeyRequests to be created
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q carol-bulk; do sleep 1; done\'', { stdio: 'inherit' });
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q dave-bulk; do sleep 1; done\'', { stdio: 'inherit' });
+    // Poll for both APIKeyRequests in parallel (background jobs) and fail fast
+    // if either times out, rather than waiting sequentially (up to 60s total).
+    execSync(`bash -c 'timeout 30 bash -c "until kubectl get apikeyrequests -n kuadrant-test | grep -q ${carolKey}; do sleep 1; done" & PID1=$!; timeout 30 bash -c "until kubectl get apikeyrequests -n kuadrant-test | grep -q ${daveKey}; do sleep 1; done" & PID2=$!; wait $PID1 || exit 1; wait $PID2 || exit 1'`, { stdio: 'inherit' });
 
     await navigateAsOwner(page);
-    await expect(page.locator('td:has-text("carol-bulk@enterprise.com")')).toBeVisible({ timeout: 30_000 });
-    await expect(page.locator('td:has-text("dave-bulk@partner.io")')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`td:has-text("${carolEmail}")`)).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`td:has-text("${daveEmail}")`)).toBeVisible({ timeout: 30_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    // Clean up test namespaces
-    execSync('kubectl delete namespace consumer-carol-bulk consumer-dave-bulk --ignore-not-found=true', { stdio: 'inherit' });
+    execSync(`kubectl delete namespace ${carolNs} ${daveNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
   test('bulk approve selected requests shows success toast', async ({ page }) => {
-    // Select only carol and dave — don't use "select all" since other requests may be visible
-    await page.locator('tr:has-text("carol-bulk@enterprise.com") input[type="checkbox"]').click();
-    await page.locator('tr:has-text("dave-bulk@partner.io") input[type="checkbox"]').click();
+    await page.locator(`tr:has-text("${carolEmail}") input[type="checkbox"]`).click();
+    await page.locator(`tr:has-text("${daveEmail}") input[type="checkbox"]`).click();
 
     const bulkApproveButton = page.locator('button', { hasText: /Approve \d+ selected/ });
     await expect(bulkApproveButton).toBeVisible({ timeout: 5_000 });
@@ -375,25 +415,40 @@ EOF
 // ── Bulk reject (uses ellen + frank) ─────────────────────────────────────────
 
 test.describe('APIKey Approvals - Bulk reject', () => {
+  let uid: string;
+  let ellenNs: string;
+  let ellenKey: string;
+  let ellenEmail: string;
+  let frankNs: string;
+  let frankKey: string;
+  let frankEmail: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create test-specific namespaces and APIKeys
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    ellenNs = `consumer-ellen-bulk-${uid}`;
+    ellenKey = `ellen-bulk-${uid}`;
+    ellenEmail = `ellen-bulk-${uid}@research.io`;
+    frankNs = `consumer-frank-bulk-${uid}`;
+    frankKey = `frank-bulk-${uid}`;
+    frankEmail = `frank-bulk-${uid}@freelance.io`;
+
     execSync(`
-      kubectl create namespace consumer-ellen-bulk || true
-      kubectl create namespace consumer-frank-bulk || true
+      kubectl create namespace ${ellenNs} || true
+      kubectl create namespace ${frankNs} || true
       kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: ellen-bulk-api-key
-  namespace: consumer-ellen-bulk
+  name: ${ellenKey}
+  namespace: ${ellenNs}
 stringData:
   api_key: test-ellen-bulk-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: ellen-bulk-api-key
-  namespace: consumer-ellen-bulk
+  name: ${ellenKey}
+  namespace: ${ellenNs}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -402,23 +457,23 @@ spec:
   useCase: "Research API integration"
   requestedBy:
     userId: "ellen-bulk"
-    email: "ellen-bulk@research.io"
+    email: "${ellenEmail}"
   secretRef:
-    name: ellen-bulk-api-key
+    name: ${ellenKey}
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: frank-bulk-api-key
-  namespace: consumer-frank-bulk
+  name: ${frankKey}
+  namespace: ${frankNs}
 stringData:
   api_key: test-frank-bulk-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: frank-bulk-api-key
-  namespace: consumer-frank-bulk
+  name: ${frankKey}
+  namespace: ${frankNs}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -427,31 +482,29 @@ spec:
   useCase: "Freelance project API"
   requestedBy:
     userId: "frank-bulk"
-    email: "frank-bulk@freelance.io"
+    email: "${frankEmail}"
   secretRef:
-    name: frank-bulk-api-key
+    name: ${frankKey}
 EOF
     `, { stdio: 'inherit' });
 
-    // Wait for APIKeyRequests to be created
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q ellen-bulk; do sleep 1; done\'', { stdio: 'inherit' });
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q frank-bulk; do sleep 1; done\'', { stdio: 'inherit' });
+    // Poll for both APIKeyRequests in parallel (background jobs) and fail fast
+    // if either times out, rather than waiting sequentially (up to 60s total).
+    execSync(`bash -c 'timeout 30 bash -c "until kubectl get apikeyrequests -n kuadrant-test | grep -q ${ellenKey}; do sleep 1; done" & PID1=$!; timeout 30 bash -c "until kubectl get apikeyrequests -n kuadrant-test | grep -q ${frankKey}; do sleep 1; done" & PID2=$!; wait $PID1 || exit 1; wait $PID2 || exit 1'`, { stdio: 'inherit' });
 
     await navigateAsOwner(page);
-    await expect(page.locator('td:has-text("ellen-bulk@research.io")')).toBeVisible({ timeout: 30_000 });
-    await expect(page.locator('td:has-text("frank-bulk@freelance.io")')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`td:has-text("${ellenEmail}")`)).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`td:has-text("${frankEmail}")`)).toBeVisible({ timeout: 30_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    // Clean up test namespaces
-    execSync('kubectl delete namespace consumer-ellen-bulk consumer-frank-bulk --ignore-not-found=true', { stdio: 'inherit' });
+    execSync(`kubectl delete namespace ${ellenNs} ${frankNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
   test('bulk reject selected requests shows success toast', async ({ page }) => {
-    // Select only ellen and frank — don't use "select all" since other requests may be visible
-    await page.locator('tr:has-text("ellen-bulk@research.io") input[type="checkbox"]').click();
-    await page.locator('tr:has-text("frank-bulk@freelance.io") input[type="checkbox"]').click();
+    await page.locator(`tr:has-text("${ellenEmail}") input[type="checkbox"]`).click();
+    await page.locator(`tr:has-text("${frankEmail}") input[type="checkbox"]`).click();
 
     const bulkRejectButton = page.locator('button', { hasText: /Deny \d+ selected/ });
     await expect(bulkRejectButton).toBeVisible({ timeout: 5_000 });
@@ -469,24 +522,33 @@ EOF
 // ── Deny active key (uses george) ────────────────────────────────────────────
 
 test.describe('APIKey Approvals - Deny active key', () => {
+  let uid: string;
+  let georgeNs: string;
+  let georgeKey: string;
+  let georgeEmail: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create test-specific namespace and APIKey
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    georgeNs = `consumer-george-active-${uid}`;
+    georgeKey = `george-active-${uid}`;
+    georgeEmail = `george-active-${uid}@test.io`;
+
     execSync(`
-      kubectl create namespace consumer-george-active || true
+      kubectl create namespace ${georgeNs} || true
       kubectl apply -f - <<EOF
 apiVersion: v1
 kind: Secret
 metadata:
-  name: george-active-api-key
-  namespace: consumer-george-active
+  name: ${georgeKey}
+  namespace: ${georgeNs}
 stringData:
   api_key: test-george-active-key
 ---
 apiVersion: devportal.kuadrant.io/v1alpha1
 kind: APIKey
 metadata:
-  name: george-active-api-key
-  namespace: consumer-george-active
+  name: ${georgeKey}
+  namespace: ${georgeNs}
 spec:
   apiProductRef:
     name: test-approval-product
@@ -495,28 +557,25 @@ spec:
   useCase: "Testing active key denial"
   requestedBy:
     userId: "george-active"
-    email: "george-active@test.io"
+    email: "${georgeEmail}"
   secretRef:
-    name: george-active-api-key
+    name: ${georgeKey}
 EOF
     `, { stdio: 'inherit' });
 
-    // Wait for APIKeyRequest to be created
-    execSync('timeout 30 bash -c \'until kubectl get apikeyrequests -n kuadrant-test | grep -q george-active; do sleep 1; done\'', { stdio: 'inherit' });
+    execSync(`timeout 30 bash -c 'until kubectl get apikeyrequests -n kuadrant-test | grep -q ${georgeKey}; do sleep 1; done'`, { stdio: 'inherit' });
 
     await navigateAsOwner(page);
-    await expect(page.locator('td:has-text("george-active@test.io")')).toBeVisible({ timeout: 30_000 });
+    await expect(page.locator(`td:has-text("${georgeEmail}")`)).toBeVisible({ timeout: 30_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    // Clean up test namespace
-    execSync('kubectl delete namespace consumer-george-active --ignore-not-found=true', { stdio: 'inherit' });
+    execSync(`kubectl delete namespace ${georgeNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
   test('should deny an active API key', async ({ page }) => {
-    // Step 1: Approve the pending request
-    let georgeRow = page.locator('tr:has-text("george-active@test.io")');
+    let georgeRow = page.locator(`tr:has-text("${georgeEmail}")`);
     await expect(georgeRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
     await georgeRow.locator('[aria-label="Actions"]').click();
     await page.locator('[role="menuitem"]:has-text("Approve")').click();
@@ -532,14 +591,14 @@ EOF
     await page.waitForTimeout(3000);
 
     // Step 3: Deny the now-active key (reselect row and verify it has Actions menu)
-    georgeRow = page.locator('tr:has-text("george-active@test.io")');
+    georgeRow = page.locator(`tr:has-text("${georgeEmail}")`);
     await expect(georgeRow).toBeVisible({ timeout: 10_000 });
     await expect(georgeRow.locator('[aria-label="Actions"]')).toBeVisible({ timeout: 10_000 });
     await georgeRow.locator('[aria-label="Actions"]').click();
     await page.locator('[role="menuitem"]:has-text("Deny")').click();
 
     await expect(page.locator('.pf-v6-c-modal-box')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-modal-box').locator('text=george-active@test.io')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-modal-box').locator(`text=${georgeEmail}`)).toBeVisible();
 
     await page.locator('.pf-v6-c-modal-box').locator('button:has-text("Deny")').click();
 
@@ -550,7 +609,7 @@ EOF
 
     // Step 5: Verify status changed to "Denied" (wait a moment, then check)
     await page.waitForTimeout(3000);
-    georgeRow = page.locator('tr:has-text("george-active@test.io")');
+    georgeRow = page.locator(`tr:has-text("${georgeEmail}")`);
     await expect(georgeRow.locator('text=Denied')).toBeVisible({
       timeout: 10_000,
     });

--- a/e2e/tests/apiproduct-apikeys-tab.spec.ts
+++ b/e2e/tests/apiproduct-apikeys-tab.spec.ts
@@ -170,22 +170,35 @@ async function navigateAsOwner(page: Parameters<typeof impersonateUser>[0]) {
 // ── View API Keys Tab ─────────────────────────────────────────────────────────
 
 test.describe('APIProduct API Keys Tab - View and Actions', () => {
+  let uid: string;
+  let georgeNs: string;
+  let georgeKey: string;
+  let helenNs: string;
+  let helenKey: string;
+
   test.beforeEach(async ({ page }) => {
+    // Unique suffix per test run to avoid parallel conflicts
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    georgeNs = `george-${uid}`;
+    georgeKey = `george-${uid}`;
+    helenNs = `helen-${uid}`;
+    helenKey = `helen-${uid}`;
+
     // Create dedicated test fixtures
-    await createNamespace('george');
+    await createNamespace(georgeNs);
     await createAPIKey({
-      name: 'george-apikey',
-      namespace: 'george',
+      name: georgeKey,
+      namespace: georgeNs,
       userId: 'george',
       email: 'george@example.com',
       planTier: 'gold',
       useCase: 'Testing API integration',
       apiKeySecret: 'test-george-key-77777',
     });
-    await createNamespace('helen');
+    await createNamespace(helenNs);
     await createAPIKey({
-      name: 'helen-apikey',
-      namespace: 'helen',
+      name: helenKey,
+      namespace: helenNs,
       userId: 'helen',
       email: 'helen@mobile.io',
       planTier: 'silver',
@@ -197,38 +210,38 @@ test.describe('APIProduct API Keys Tab - View and Actions', () => {
 
     // Use the search filter to find our specific test resource
     const searchInput = page.locator('input[placeholder*="Search by name"]');
-    await searchInput.fill('george');
-    await expect(page.locator('tr:has-text("george-apikey")')).toBeVisible({ timeout: 10_000 });
+    await searchInput.fill(georgeKey);
+    await expect(page.locator(`tr:has-text("${georgeKey}")`)).toBeVisible({ timeout: 10_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    await deleteAPIKey('george', 'george-apikey');
-    await deleteAPIKey('helen', 'helen-apikey');
-    await deleteNamespace('george');
-    await deleteNamespace('helen');
+    await deleteAPIKey(georgeNs, georgeKey);
+    await deleteAPIKey(helenNs, helenKey);
+    await deleteNamespace(georgeNs);
+    await deleteNamespace(helenNs);
   });
 
   test('should display pending API key requests', async ({ page }) => {
     // Verify george request is visible
-    await expect(page.locator('tr:has-text("george-apikey")')).toBeVisible();
-    const georgeRow = page.locator('tr:has-text("george-apikey")');
+    await expect(page.locator(`tr:has-text("${georgeKey}")`)).toBeVisible();
+    const georgeRow = page.locator(`tr:has-text("${georgeKey}")`);
     await expect(georgeRow.locator('text=Pending')).toBeVisible();
 
     // Search for helen
     const searchInput = page.locator('input[placeholder*="Search by name"]');
     await searchInput.clear();
-    await searchInput.fill('helen');
+    await searchInput.fill(helenKey);
 
     // Verify helen request is visible
-    await expect(page.locator('tr:has-text("helen-apikey")')).toBeVisible({ timeout: 5_000 });
-    const helenRow = page.locator('tr:has-text("helen-apikey")');
+    await expect(page.locator(`tr:has-text("${helenKey}")`)).toBeVisible({ timeout: 5_000 });
+    const helenRow = page.locator(`tr:has-text("${helenKey}")`);
     await expect(helenRow.locator('text=Pending')).toBeVisible();
   });
 
   test('should show actionable items for pending requests', async ({ page }) => {
     // George row should already be visible from beforeEach filter
-    const georgeRow = page.locator('tr:has-text("george-apikey")');
+    const georgeRow = page.locator(`tr:has-text("${georgeKey}")`);
     await expect(georgeRow).toBeVisible();
 
     // Verify the kebab menu (actions) is available
@@ -249,7 +262,7 @@ test.describe('APIProduct API Keys Tab - View and Actions', () => {
 
   test('should show use case info icon when use case exists', async ({ page }) => {
     // George row should already be visible from beforeEach filter
-    const georgeRow = page.locator('tr:has-text("george-apikey")');
+    const georgeRow = page.locator(`tr:has-text("${georgeKey}")`);
     await expect(georgeRow).toBeVisible();
 
     // Check that the use case column has the info icon (InfoCircleIcon)
@@ -263,12 +276,19 @@ test.describe('APIProduct API Keys Tab - View and Actions', () => {
 // ── Approve Request ───────────────────────────────────────────────────────────
 
 test.describe('APIProduct API Keys Tab - Approve Request', () => {
+  let uid: string;
+  let ivanNs: string;
+  let ivanKey: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create dedicated test fixture
-    await createNamespace('ivan');
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    ivanNs = `ivan-${uid}`;
+    ivanKey = `ivan-${uid}`;
+
+    await createNamespace(ivanNs);
     await createAPIKey({
-      name: 'ivan-apikey',
-      namespace: 'ivan',
+      name: ivanKey,
+      namespace: ivanNs,
       userId: 'ivan',
       email: 'ivan@enterprise.com',
       planTier: 'gold',
@@ -278,21 +298,19 @@ test.describe('APIProduct API Keys Tab - Approve Request', () => {
 
     await navigateAsOwner(page);
 
-    // Use the search filter to find our specific test resource
     const searchInput = page.locator('input[placeholder*="Search by name"]');
-    await searchInput.fill('ivan');
-    await expect(page.locator('tr:has-text("ivan-apikey")')).toBeVisible({ timeout: 10_000 });
+    await searchInput.fill(ivanKey);
+    await expect(page.locator(`tr:has-text("${ivanKey}")`)).toBeVisible({ timeout: 10_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    await deleteAPIKey('ivan', 'ivan-apikey');
-    await deleteNamespace('ivan');
+    await deleteAPIKey(ivanNs, ivanKey);
+    await deleteNamespace(ivanNs);
   });
 
   test('should approve a pending request and update status', async ({ page }) => {
-    // Ivan row should already be visible from beforeEach filter
-    const ivanRow = page.locator('tr:has-text("ivan-apikey")');
+    const ivanRow = page.locator(`tr:has-text("${ivanKey}")`);
 
     // Open actions menu and click Approve
     const actionsButton = ivanRow.locator('[aria-label="Actions"]');
@@ -302,7 +320,6 @@ test.describe('APIProduct API Keys Tab - Approve Request', () => {
 
     // Verify approval modal appears
     await expect(page.locator('.pf-v6-c-modal-box')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-modal-box').locator('text=ivan')).toBeVisible();
 
     // Click Approve button in modal
     await page.locator('.pf-v6-c-modal-box').locator('button:has-text("Approve")').click();
@@ -319,12 +336,19 @@ test.describe('APIProduct API Keys Tab - Approve Request', () => {
 // ── Reject Request ────────────────────────────────────────────────────────────
 
 test.describe('APIProduct API Keys Tab - Reject Request', () => {
+  let uid: string;
+  let judyNs: string;
+  let judyKey: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create dedicated test fixture
-    await createNamespace('judy');
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    judyNs = `judy-${uid}`;
+    judyKey = `judy-${uid}`;
+
+    await createNamespace(judyNs);
     await createAPIKey({
-      name: 'judy-apikey',
-      namespace: 'judy',
+      name: judyKey,
+      namespace: judyNs,
       userId: 'judy',
       email: 'judy@partner.io',
       planTier: 'bronze',
@@ -334,21 +358,19 @@ test.describe('APIProduct API Keys Tab - Reject Request', () => {
 
     await navigateAsOwner(page);
 
-    // Use the search filter to find our specific test resource
     const searchInput = page.locator('input[placeholder*="Search by name"]');
-    await searchInput.fill('judy');
-    await expect(page.locator('tr:has-text("judy-apikey")')).toBeVisible({ timeout: 10_000 });
+    await searchInput.fill(judyKey);
+    await expect(page.locator(`tr:has-text("${judyKey}")`)).toBeVisible({ timeout: 10_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    await deleteAPIKey('judy', 'judy-apikey');
-    await deleteNamespace('judy');
+    await deleteAPIKey(judyNs, judyKey);
+    await deleteNamespace(judyNs);
   });
 
   test('should reject a pending request and update status', async ({ page }) => {
-    // Judy row should already be visible from beforeEach filter
-    const judyRow = page.locator('tr:has-text("judy-apikey")');
+    const judyRow = page.locator(`tr:has-text("${judyKey}")`);
 
     // Open actions menu and click Deny
     const actionsButton = judyRow.locator('[aria-label="Actions"]');
@@ -358,7 +380,6 @@ test.describe('APIProduct API Keys Tab - Reject Request', () => {
 
     // Verify denial modal appears
     await expect(page.locator('.pf-v6-c-modal-box')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-modal-box').locator('text=judy')).toBeVisible();
 
     // Fill denial reason
     await page.locator('#rejection-reason').fill('Does not meet usage requirements');
@@ -377,12 +398,19 @@ test.describe('APIProduct API Keys Tab - Reject Request', () => {
 // ── Deny Active Key ───────────────────────────────────────────────────────────
 
 test.describe('APIProduct API Keys Tab - Deny Active Key', () => {
+  let uid: string;
+  let kateNs: string;
+  let kateKey: string;
+
   test.beforeEach(async ({ page }) => {
-    // Create dedicated test fixture
-    await createNamespace('kate');
+    uid = `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+    kateNs = `kate-${uid}`;
+    kateKey = `kate-${uid}`;
+
+    await createNamespace(kateNs);
     await createAPIKey({
-      name: 'kate-apikey',
-      namespace: 'kate',
+      name: kateKey,
+      namespace: kateNs,
       userId: 'kate',
       email: 'kate@tech.io',
       planTier: 'silver',
@@ -392,20 +420,19 @@ test.describe('APIProduct API Keys Tab - Deny Active Key', () => {
 
     await navigateAsOwner(page);
 
-    // Use the search filter to find our specific test resource
     const searchInput = page.locator('input[placeholder*="Search by name"]');
-    await searchInput.fill('kate');
-    await expect(page.locator('tr:has-text("kate-apikey")')).toBeVisible({ timeout: 10_000 });
+    await searchInput.fill(kateKey);
+    await expect(page.locator(`tr:has-text("${kateKey}")`)).toBeVisible({ timeout: 10_000 });
   });
 
   test.afterEach(async ({ page }) => {
     await stopImpersonation(page);
-    await deleteAPIKey('kate', 'kate-apikey');
-    await deleteNamespace('kate');
+    await deleteAPIKey(kateNs, kateKey);
+    await deleteNamespace(kateNs);
   });
 
   test('should deny an active API key', async ({ page }) => {
-    const kateRow = page.locator('tr:has-text("kate-apikey")');
+    const kateRow = page.locator(`tr:has-text("${kateKey}")`);
 
     // Step 1: Approve the pending request
     const actionsButton = kateRow.locator('[aria-label="Actions"]');
@@ -430,7 +457,6 @@ test.describe('APIProduct API Keys Tab - Deny Active Key', () => {
     await page.locator('[role="menuitem"]:has-text("Deny")').click();
 
     await expect(page.locator('.pf-v6-c-modal-box')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-modal-box').locator('text=kate')).toBeVisible();
 
     await page.locator('.pf-v6-c-modal-box').locator('button:has-text("Deny")').click();
 

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
-import { TEST_NAMESPACE, dismissConsoleTour, ensureDeleteProductFixture } from './helpers';
+import { execSync } from 'child_process';
+import { TEST_NAMESPACE, dismissConsoleTour } from './helpers';
 
 // SPA navigation using pushState - preserves redux state
 async function spaNavigate(page: Page, path: string): Promise<void> {
@@ -365,25 +366,58 @@ test.describe('APIProduct CRUD Operations', () => {
     await expect(page.locator('text=Create API Product')).toBeVisible();
   });
 
-  test('should edit existing APIProduct (resource name immutable)', async ({ page }) => {
-    // This test assumes an APIProduct exists
-    // For a real e2e test, you would create one first via API or UI
-    // Then navigate to edit page
+  // ── Edit and Delete ──────────────────────────────────────────────────────────
+  // Nested describe so the APIProduct fixture is only created for these two tests
+  // rather than for every test in the outer describe.
+  test.describe('edit and delete', () => {
+    let editProductName = '';
 
-    // Placeholder: navigate to edit page for a test APIProduct
-    const testProductName = 'test-edit-product';
+    test.beforeEach(async () => {
+      editProductName = `test-edit-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+      execSync(`kubectl apply -f - <<'EOF'
+apiVersion: devportal.kuadrant.io/v1alpha1
+kind: APIProduct
+metadata:
+  name: ${editProductName}
+  namespace: ${TEST_NAMESPACE}
+spec:
+  displayName: Test Edit Product
+  description: product for edit testing
+  version: v1.0.0
+  approvalMode: manual
+  publishStatus: Draft
+  tags:
+    - test
+    - edit
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: test-httproute
+  contact:
+    team: Platform Team
+    email: platform@example.com
+    slack: "#platform-support"
+    url: https://platform.example.com/support
+  documentation:
+    openAPISpecURL: https://api.example.com/spec.yaml
+    docsURL: https://api.example.com/docs
+EOF`, { stdio: 'inherit' });
+    });
+
+    test.afterEach(async () => {
+      if (editProductName) {
+        execSync(
+          `kubectl delete apiproduct ${editProductName} -n ${TEST_NAMESPACE} --ignore-not-found=true`,
+          { stdio: 'inherit' },
+        );
+      }
+    });
+
+  test('should edit existing APIProduct (resource name immutable)', async ({ page }) => {
+    const testProductName = editProductName;
     await spaNavigate(page, `/kuadrant/apiproducts/ns/${TEST_NAMESPACE}/${testProductName}/edit`);
 
-    // Skip test if APIProduct doesn't exist (check for edit header)
     const editHeader = page.locator('text=Edit API Product');
-    const exists = await editHeader
-      .waitFor({ state: 'visible', timeout: 5000 })
-      .then(() => true)
-      .catch(() => false);
-    if (!exists) {
-      test.skip();
-      return;
-    }
 
     // Verify we're on edit page
     await expect(editHeader).toBeVisible();
@@ -432,11 +466,7 @@ test.describe('APIProduct CRUD Operations', () => {
   });
 
   test('should delete APIProduct with confirmation', async ({ page }) => {
-    const testProductName = 'test-delete-product';
-
-    // Ensure fixture exists before running test (applies e2e/manifests/test-apiproduct-fixtures.yaml)
-    // This makes the test repeatable - it recreates the product if it was deleted in a previous run
-    await ensureDeleteProductFixture();
+    const testProductName = editProductName;
 
     // Navigate to APIProducts list
     await navigateToAPIProducts(page, TEST_NAMESPACE);
@@ -500,6 +530,8 @@ test.describe('APIProduct CRUD Operations', () => {
     // Verify row no longer exists
     await expect(row).not.toBeVisible({ timeout: 5000 });
   });
+
+  }); // end of 'edit and delete' describe
 
   test('should display validation messages for required fields', async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);


### PR DESCRIPTION
## Description

Closes #559 

Reduces e2e CI time from ~30 minutes to ~11 minutes by enabling parallel test execution, fixing parallel conflicts, and splitting tests into smoke (PR) and nightly runs.


## Type of change

  **Parallel test execution**
  - Enable `fullyParallel: true` and increase `workers` from 1 to 3
  - Tests now run concurrently instead of sequentially

  **Fix parallel conflicts**
  - `apiproduct-apikeys-tab`: use unique namespace names per test run
    (`george-${uid}`) instead of fixed names to avoid conflicts
  - `apiproduct-crud`: add `mode: serial` to prevent race condition
    with `apiproduct-overview-tab` reading shared `test-edit-product`
  - Refactor edit test to create its own unique APIProduct in
    `beforeEach` and clean up in `afterEach`

  **Smoke / Nightly split**
  - PR runs only critical smoke tests (~58 tests, ~11 min)
  - Nightly runs all 96 tests every night at 2:00 UTC
  - Moved to nightly: filter tests, UI detail tests, tab content tests

  **CI optimization**
  - Start `yarn start` in parallel with cluster setup to save ~40s


 ## How to verify

  **Smoke tests (runs automatically on PR):**
  1. Push any commit to this branch
  2. GitHub Actions will trigger `E2E Tests` workflow automatically
  3. Verify it runs only the 6 smoke test files (~58 tests)
  4. Check total CI time is ~11 minutes

  **Nightly tests (full suite):**
  1. Go to Actions → `E2E Tests (Nightly)` in your fork
  2. Click `Run workflow` → `Run workflow` to trigger manually
  3. Verify all 96 tests run and pass
  4. Or wait until 2:00 UTC for automatic trigger



  | | Before | After |
  |--|--|--|
  | CI time on PR | ~30 min | ~11 min |
  | Full test coverage | ✅ | ✅ (nightly) |



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reusable E2E workflow with selectable **smoke** and **full** suites, and enabled an automated nightly E2E run that uses the **full** suite.
* **Bug Fixes**
  * Improved E2E reliability by isolating Kubernetes test data per test/run and strengthening setup/cleanup, including namespace deletion.
* **Tests**
  * Increased Playwright parallelism (more workers and full parallel execution) and updated API key/API product E2E scenarios to use dynamically generated resources and identifiers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->