### PR TITLE
fix(apikey): clear denial reason after a successful rejection

### DIFF
--- a/src/components/apikey/RejectionModal.tsx
+++ b/src/components/apikey/RejectionModal.tsx
@@ -70,7 +70,9 @@ const RejectionModal: React.FC<RejectionModalProps> = ({
 
     try {
       await onReject(requests, reason || undefined);
-      onClose();
+      // Reset transient state on success so the denial reason doesn't
+      // carry over and pre-fill the next rejection in the same session.
+      handleClose();
     } catch (err) {
       setError(err instanceof Error ? err.message : t('Failed to deny API keys'));
     } finally {


### PR DESCRIPTION
## Description

The denial reason entered in the `RejectionModal` carried over and pre-filled the next rejection within the same session. On a successful denial, `handleReject` closed the modal via `onClose()` without resetting the local `reason` state. Because the modal stays mounted and only toggles `isOpen`, the stale reason persisted (it only cleared on a full page refresh, which remounts the component). `Cancel` already resets via `handleClose()` — the success path did not.

Fix: on success, reset the transient state the same way `Cancel` does, so every new rejection starts with an empty reason.

Fixes #573

## Type of change

- [x] `[fix]` Bug fix

## Changes made

- `src/components/apikey/RejectionModal.tsx`: call `handleClose()` (which clears `reason`/`error`) instead of `onClose()` on a successful rejection.

## Test plan

- [x] `yarn lint` passes (no changes after running)
- [x] `yarn build` passes — verified via the repo's `Dockerfile` builder stage (UBI9 / Node 22, the Linux CI target); webpack compiled with 0 errors and emitted `dist/plugin-manifest.json`.
- [x] `yarn i18n` passes (no new user-facing strings added)
- [ ] Tested manually in OpenShift Console
- [ ] Tested in both light and dark themes
- [ ] Tested in all-namespaces and single namespace mode

> Note: this is a no-UI-change logic fix (state reset), so there are no visual/theme/namespace differences. I don't have a live cluster to run the Playwright e2e suite locally. Happy to add a regression test to `e2e/tests/apikey-approvals.spec.ts` (reject one request with a reason, then open a second rejection and assert `#rejection-reason` is empty) if you'd like it in this PR.

## Checklist

- [x] All user-facing strings use `t()` (no new strings introduced)
- [x] CSS classes are prefixed with `kuadrant-` — no bare `.pf-*` or `.co-*` selectors, no hex colors (no CSS changed)
- [x] No `console.log` statements left in
- [x] Commits include `Signed-off-by` line (`git commit -s`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the rejection flow so the modal now fully resets after a successful action.
  * Cleared previous reason/error values and refreshed the request list for smoother repeated use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->