### PR TITLE
fix: add null guards for policy form create page metadata

### DIFF
--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -178,11 +178,11 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
   const [dnsData, dnsLoaded, dnsError] = useK8sWatchResource(dnsResource);
 
   React.useEffect(() => {
-    if (dnsLoaded && !dnsError) {
+    if (dnsLoaded && !dnsError && dnsData) {
       if (!Array.isArray(dnsData)) {
         const dnsPolicyUpdate = dnsData as dnsPolicyEdit;
-        setCreationTimestamp(dnsPolicyUpdate.metadata.creationTimestamp);
-        setResourceVersion(dnsPolicyUpdate.metadata.resourceVersion);
+        setCreationTimestamp(dnsPolicyUpdate.metadata?.creationTimestamp || '');
+        setResourceVersion(dnsPolicyUpdate.metadata?.resourceVersion || '');
         setFormDisabled(true);
         setCreate(false);
         setPolicyName(dnsPolicyUpdate.metadata?.name || '');

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -120,11 +120,11 @@ const KuadrantOIDCPolicyCreatePage: React.FC = () => {
     : [null, false, null];
 
   React.useEffect(() => {
-    if (oidcLoaded && !oidcError) {
+    if (oidcLoaded && !oidcError && oidcData) {
       if (!Array.isArray(oidcData)) {
         const oidcPolicyUpdate = oidcData as OIDCPolicyEdit;
-        setCreationTimestamp(oidcPolicyUpdate.metadata.creationTimestamp);
-        setResourceVersion(oidcPolicyUpdate.metadata.resourceVersion);
+        setCreationTimestamp(oidcPolicyUpdate.metadata?.creationTimestamp || '');
+        setResourceVersion(oidcPolicyUpdate.metadata?.resourceVersion || '');
         setFormDisabled(true);
         setCreate(false);
         setPolicyName(oidcPolicyUpdate.metadata?.name || '');

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -133,11 +133,11 @@ const KuadrantTLSCreatePage: React.FC = () => {
 
   // When a resource is being updated setting the form from the yaml it gets from useK8sWatchResource
   React.useEffect(() => {
-    if (tlsLoaded && !tlsError) {
+    if (tlsLoaded && !tlsError && tlsData) {
       if (!Array.isArray(tlsData)) {
         const tlsPolicyUpdate = tlsData as TLSPolicyEdit;
-        setCreationTimestamp(tlsPolicyUpdate.metadata.creationTimestamp);
-        setResourceVersion(tlsPolicyUpdate.metadata.resourceVersion);
+        setCreationTimestamp(tlsPolicyUpdate.metadata?.creationTimestamp || '');
+        setResourceVersion(tlsPolicyUpdate.metadata?.resourceVersion || '');
         setFormDisabled(true);
         setCreate(false);
         setPolicyName(tlsPolicyUpdate.metadata?.name || '');


### PR DESCRIPTION
## Summary

Fixes DNS and TLS policy create pages crashing on load with "Cannot read properties of undefined (reading 'metadata')".

## What Changed

Added null guards and optional chaining in `useK8sWatchResource` effect hooks:
- `KuadrantDNSPolicyCreatePage.tsx`
- `KuadrantTLSCreatePage.tsx`
- `KuadrantOIDCPolicyCreatePage.tsx` (preventative)

## Root Cause

`useK8sWatchResource(null)` returns `[undefined, true, undefined]` when creating new policies. Code accessed `data.metadata.creationTimestamp` without checking if data exists.

## Testing

- Navigate to DNS Policy create page → loads without error
- Navigate to TLS Policy create page → loads without error
- Test editing existing DNS/TLS policies → metadata loads correctly

Closes #577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved editing flows for DNS Policy, OIDC Policy, and TLS resources.
  * Prevented form initialisation issues when loaded resource data or metadata fields are missing.
  * Added safer handling for resource timestamps and versions, reducing the risk of crashes or undefined values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->