### PR TITLE
fix: bump oinc to v0.2.2 to pick up the kuadrant readiness fixes

### DIFF
--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Install oinc
         run: |
-          OINC_VERSION="${OINC_VERSION:-v0.1.2}"
+          OINC_VERSION="${OINC_VERSION:-v0.2.2}"
           curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
           chmod +x oinc
           sudo mv oinc /usr/local/bin/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,7 +10,7 @@
 
 ### Install oinc
 ```bash
-OINC_VERSION="v0.1.1"
+OINC_VERSION="v0.2.2"
 curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
 chmod +x oinc
 sudo mv oinc /usr/local/bin/

--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -14,8 +14,11 @@ PLUGIN_PORT="${PLUGIN_PORT:-9001}"
 
 # the console plugin tracks the latest Kuadrant CRDs, so default to the latest
 # operator. override (e.g. KUADRANT_VERSION=1.4.4) to pin to a known-good version
-# if a latest release breaks plugin development or CI (GH-361).
+# if a latest release breaks plugin development or CI.
 KUADRANT_VERSION="${KUADRANT_VERSION:-latest}"
+
+# pin to a published, soaked image; oinc v0.2.2 defaults to 4.22
+OCP_VERSION="${OCP_VERSION:-4.21}"
 
 check_command oinc "Install from https://github.com/jasonmadigan/oinc"
 check_command kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
@@ -27,12 +30,14 @@ HOST=$(container_host "${RUNTIME}")
 
 PLUGIN_NAME=$(node -p "require('${REPO_DIR}/package.json').consolePlugin.name")
 
-# on a failed cluster create, dump kuadrant addon state so the "kuadrant not
-# ready after 5m0s" timeout (GH-361) is debuggable from CI logs instead of
-# opaque. oinc waits on more than the operator deployment, so capture the
-# Kuadrant CR conditions, namespace events, and the operator logs.
+# on a failed cluster create, dump kuadrant addon state so failures are
+# debuggable from CI logs instead of opaque. the GH-361 "kuadrant not ready
+# after 5m0s" race is fixed in oinc v0.2.2 (Kuadrant CR creation gated on the
+# admission RESTMapper being warm); keep the dump for whatever fails next.
+# oinc waits on more than the operator deployment, so capture the Kuadrant CR
+# conditions, namespace events, and the operator logs.
 dump_kuadrant_diagnostics() {
-	log "oinc create failed - dumping kuadrant addon diagnostics for GH-361..."
+	log "oinc create failed - dumping kuadrant addon diagnostics..."
 	kubectl get kuadrant kuadrant -n kuadrant-system -o yaml 2>&1 || true
 	kubectl get pods -n kuadrant-system -o wide 2>&1 || true
 	kubectl get events -n kuadrant-system --sort-by='.lastTimestamp' 2>&1 || true
@@ -44,6 +49,7 @@ dump_kuadrant_diagnostics() {
 # dump and an explicit exit instead of dying silently.
 log "creating oinc cluster with addons (kuadrant@${KUADRANT_VERSION})..."
 if ! oinc create \
+	--version "${OCP_VERSION}" \
 	--addons "gateway-api,cert-manager,metallb,istio,kuadrant@${KUADRANT_VERSION}" \
 	--console-plugin "${PLUGIN_NAME}=http://${HOST}:${PLUGIN_PORT}"; then
 	dump_kuadrant_diagnostics


### PR DESCRIPTION
Bumps pinned oinc from v0.1.2 to v0.2.2 and pins OCP 4.21 in `cluster-setup.sh`.

This is a sort of bandaid until this is fixed in the operator, but it should make flakes go away.

- **v0.2.1 admission gate:** waits for the apiserver's OwnerReferencesPermissionEnforcement RESTMapper to learn the Kuadrant CRD before creating the CR, killing the "kuadrant not ready after 5m0s" flake (Kuadrant/kuadrant-operator#1578). 
- **v0.2.2 operator watchdog:** one-shot `rollout restart` if the Kuadrant CR wedges before Ready (covers the MissingDependency class, Kuadrant/kuadrant-operator#1784).
- **OCP 4.21 pin:** oinc v0.2.2 defaults to 4.22; 4.21 is what main's green runs used. Overridable via `OCP_VERSION`.

To verify locally: run `cluster-setup.sh` with oinc v0.2.2, look for "admission RESTMapper ready" in output. `OCP_VERSION` and `OINC_VERSION` are both overridable as env vars.

Closes #595
Closes #361


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default installation/version settings for the E2E tooling so environments use the newer release by default.
  * Cluster setup now passes an explicit OpenShift version when creating clusters, improving consistency.

* **Documentation**
  * Refreshed E2E installation guidance and diagnostics wording to better reflect the latest setup and collected troubleshooting information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->