### PR TITLE
test: add unit tests for API key, metrics, and topology utilities

### DIFF
--- a/__mocks__/esmStubs.ts
+++ b/__mocks__/esmStubs.ts
@@ -1,0 +1,20 @@
+// Stub for Jest — these modules use ESM exports that Jest cannot parse.
+// Tests that need specific behaviour should add their own jest.mock() overrides.
+
+// @openshift-console/dynamic-plugin-sdk
+export const k8sCreate = () => Promise.resolve({});
+export const k8sUpdate = () => Promise.resolve({});
+export const k8sList = () => Promise.resolve([]);
+export const k8sDelete = () => Promise.resolve({});
+export const k8sGet = () => Promise.resolve({});
+export const consoleFetchJSON = Object.assign(() => Promise.resolve({}), {
+  post: () => Promise.resolve({}),
+});
+export const useK8sModel = () => [null, false];
+export const useK8sWatchResource = () => [[], true, null];
+
+// @patternfly/react-topology
+export const NodeShape = { rect: 'rect', ellipse: 'ellipse' };
+export const LabelPosition = { bottom: 'bottom' };
+export const EdgeStyle = { default: 'default', dashedMd: 'dashedMd' };
+export const EdgeAnimationSpeed = { medium: 'medium' };

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -14,6 +14,9 @@ const config: Config = {
   moduleNameMapper: {
     // CSS and static file imports
     '\\.(css|svg|png|jpg|jpeg|gif)$': '<rootDir>/__mocks__/fileMock.ts',
+    // ESM modules that Jest cannot parse — stub with no-op exports
+    '^@openshift-console/dynamic-plugin-sdk$': '<rootDir>/__mocks__/esmStubs.ts',
+    '^@patternfly/react-topology$': '<rootDir>/__mocks__/esmStubs.ts',
   },
   testMatch: ['**/*.test.{ts,tsx}'],
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],

--- a/src/components/apikey/utils.test.ts
+++ b/src/components/apikey/utils.test.ts
@@ -1,0 +1,59 @@
+import { getRequestStatus } from './utils';
+import { APIKeyRequest } from './types';
+
+const makeRequest = (conditions?: { type: string; status: string }[]): APIKeyRequest =>
+  ({
+    metadata: { name: 'test', namespace: 'default' },
+    ...(conditions !== undefined && { status: { conditions } }),
+  } as APIKeyRequest);
+
+describe('getRequestStatus', () => {
+  it('returns Pending when status is undefined', () => {
+    expect(getRequestStatus(makeRequest())).toBe('Pending');
+  });
+
+  it('returns Pending when conditions is undefined', () => {
+    const request = makeRequest();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    request.status = {} as any;
+    expect(getRequestStatus(request)).toBe('Pending');
+  });
+
+  it('returns Pending when conditions is empty', () => {
+    expect(getRequestStatus(makeRequest([]))).toBe('Pending');
+  });
+
+  it('returns Approved when Approved condition is True', () => {
+    expect(getRequestStatus(makeRequest([{ type: 'Approved', status: 'True' }]))).toBe('Approved');
+  });
+
+  it('returns Denied when Denied condition is True', () => {
+    expect(getRequestStatus(makeRequest([{ type: 'Denied', status: 'True' }]))).toBe('Denied');
+  });
+
+  it('returns Pending when conditions exist but none are True', () => {
+    expect(
+      getRequestStatus(
+        makeRequest([
+          { type: 'Approved', status: 'False' },
+          { type: 'Denied', status: 'False' },
+        ]),
+      ),
+    ).toBe('Pending');
+  });
+
+  it('returns Approved over Denied when both are True', () => {
+    expect(
+      getRequestStatus(
+        makeRequest([
+          { type: 'Denied', status: 'True' },
+          { type: 'Approved', status: 'True' },
+        ]),
+      ),
+    ).toBe('Approved');
+  });
+
+  it('ignores conditions with unrecognised types', () => {
+    expect(getRequestStatus(makeRequest([{ type: 'Ready', status: 'True' }]))).toBe('Pending');
+  });
+});

--- a/src/utils/apiKeyUtils.test.ts
+++ b/src/utils/apiKeyUtils.test.ts
@@ -1,0 +1,54 @@
+import { formatLimits } from './apiKeyUtils';
+
+describe('formatLimits', () => {
+  it('returns null when limits is undefined', () => {
+    expect(formatLimits(undefined)).toBeNull();
+  });
+
+  it('returns null when limits is an empty object', () => {
+    expect(formatLimits({})).toBeNull();
+  });
+
+  it('returns daily format when daily is set', () => {
+    expect(formatLimits({ daily: 100 })).toBe('100 requests per day');
+  });
+
+  it('returns weekly format when weekly is set', () => {
+    expect(formatLimits({ weekly: 500 })).toBe('500 requests per week');
+  });
+
+  it('returns monthly format when monthly is set', () => {
+    expect(formatLimits({ monthly: 2000 })).toBe('2000 requests per month');
+  });
+
+  it('returns yearly format when yearly is set', () => {
+    expect(formatLimits({ yearly: 10000 })).toBe('10000 requests per year');
+  });
+
+  it('returns custom format from the first custom entry', () => {
+    expect(formatLimits({ custom: [{ limit: 50, window: '10s' }] })).toBe('50 requests per 10s');
+  });
+
+  it('returns null when custom array is empty', () => {
+    expect(formatLimits({ custom: [] })).toBeNull();
+  });
+
+  it('returns daily over weekly when both are set', () => {
+    expect(formatLimits({ daily: 10, weekly: 70 })).toBe('10 requests per day');
+  });
+
+  it('treats zero as a valid limit value', () => {
+    expect(formatLimits({ daily: 0 })).toBe('0 requests per day');
+  });
+
+  it('uses only the first entry when custom has multiple entries', () => {
+    expect(
+      formatLimits({
+        custom: [
+          { limit: 10, window: '1m' },
+          { limit: 100, window: '1h' },
+        ],
+      }),
+    ).toBe('10 requests per 1m');
+  });
+});

--- a/src/utils/metricsQueries.test.ts
+++ b/src/utils/metricsQueries.test.ts
@@ -1,0 +1,79 @@
+import {
+  buildTotalRequestsQuery,
+  buildErrorRequestQuery,
+  buildErrorsByCodeQuery,
+  buildGatewayKey,
+} from './metricsQueries';
+
+describe('buildTotalRequestsQuery', () => {
+  it('returns cluster-wide query when no namespace is provided', () => {
+    const query = buildTotalRequestsQuery();
+    expect(query).toContain('sum by (source_workload, source_workload_namespace)');
+    expect(query).toContain('istio_requests_total');
+    expect(query).toContain('increase(');
+    expect(query).toContain('[24h]');
+    expect(query).not.toContain('source_workload_namespace=');
+  });
+
+  it('returns namespace-filtered query when namespace is provided', () => {
+    const query = buildTotalRequestsQuery('my-namespace');
+    expect(query).toContain('source_workload_namespace="my-namespace"');
+    expect(query).toContain('istio_requests_total');
+    expect(query).toContain('increase(');
+    expect(query).toContain('[24h]');
+  });
+
+  it('escapes special characters in namespace values', () => {
+    const query = buildTotalRequestsQuery('ns-with"quotes');
+    expect(query).toContain('source_workload_namespace="ns-with\\"quotes"');
+  });
+});
+
+describe('buildErrorRequestQuery', () => {
+  it('returns cluster-wide error query when no namespace is provided', () => {
+    const query = buildErrorRequestQuery();
+    expect(query).toContain('response_code!~"2(.*)|3(.*)"');
+    expect(query).toContain('istio_requests_total');
+    expect(query).not.toContain('source_workload_namespace=');
+  });
+
+  it('returns namespace-filtered error query when namespace is provided', () => {
+    const query = buildErrorRequestQuery('prod');
+    expect(query).toContain('source_workload_namespace="prod"');
+    expect(query).toContain('response_code!~"2(.*)|3(.*)"');
+  });
+});
+
+describe('buildErrorsByCodeQuery', () => {
+  it('returns cluster-wide errors-by-code query when no namespace is provided', () => {
+    const query = buildErrorsByCodeQuery();
+    expect(query).toContain('sum by (response_code, source_workload, source_workload_namespace)');
+    expect(query).toContain('response_code!~"2(.*)|3(.*)"');
+    expect(query).not.toContain('source_workload_namespace=');
+  });
+
+  it('returns namespace-filtered errors-by-code query when namespace is provided', () => {
+    const query = buildErrorsByCodeQuery('staging');
+    expect(query).toContain('source_workload_namespace="staging"');
+    expect(query).toContain('sum by (response_code, source_workload, source_workload_namespace)');
+  });
+
+  it('includes the response_code grouping that buildErrorRequestQuery does not', () => {
+    const byCode = buildErrorsByCodeQuery();
+    const errors = buildErrorRequestQuery();
+    expect(byCode).toContain('sum by (response_code,');
+    expect(errors).not.toContain('response_code,');
+  });
+});
+
+describe('buildGatewayKey', () => {
+  it('combines namespace, name, and suffix into a lookup key', () => {
+    expect(buildGatewayKey('ingress-gateway', 'my-gateway', '-openshift-default')).toBe(
+      'ingress-gateway/my-gateway-openshift-default',
+    );
+  });
+
+  it('works with an empty suffix', () => {
+    expect(buildGatewayKey('default', 'gw', '')).toBe('default/gw');
+  });
+});

--- a/src/utils/topology/graphParser.test.ts
+++ b/src/utils/topology/graphParser.test.ts
@@ -1,0 +1,243 @@
+import { kindToAbbr, parseDotToModel, preserveTransitiveEdges } from './graphParser';
+
+describe('kindToAbbr', () => {
+  it('extracts uppercase letters from a mixed-case kind', () => {
+    expect(kindToAbbr('Gateway')).toBe('G');
+  });
+
+  it('extracts multiple uppercase letters', () => {
+    expect(kindToAbbr('HTTPRoute')).toBe('HTTP');
+  });
+
+  it('truncates to 4 characters when more than 4 uppercase letters', () => {
+    expect(kindToAbbr('HTTPRouteRule')).toBe('HTTP');
+  });
+
+  it('falls back to toUpperCase when no uppercase letters exist', () => {
+    expect(kindToAbbr('gateway')).toBe('GATE');
+  });
+
+  it('handles single character kind', () => {
+    expect(kindToAbbr('A')).toBe('A');
+  });
+
+  it('extracts 2 uppercase letters from AuthPolicy', () => {
+    expect(kindToAbbr('AuthPolicy')).toBe('AP');
+  });
+});
+
+describe('parseDotToModel', () => {
+  it('parses a single node with kind and name', () => {
+    const dotString = 'digraph { n1 [label="Gateway\\nmy-gateway"] }';
+    const { nodes, edges } = parseDotToModel(dotString);
+
+    expect(nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'n1',
+          label: 'my-gateway',
+          resourceType: 'Gateway',
+          data: expect.objectContaining({ badge: 'G' }),
+        }),
+      ]),
+    );
+    expect(edges).toHaveLength(0);
+  });
+
+  it('parses nodes and edges', () => {
+    const dotString = `digraph {
+      n1 [label="Gateway\\nmy-gw"]
+      n2 [label="HTTPRoute\\nmy-route"]
+      n1 -> n2
+    }`;
+    const { nodes, edges } = parseDotToModel(dotString);
+
+    const regularNodes = nodes.filter((n) => n.type === 'node');
+    expect(regularNodes).toHaveLength(2);
+    expect(edges).toHaveLength(1);
+    expect(edges[0].source).toBe('n1');
+    expect(edges[0].target).toBe('n2');
+  });
+
+  it('groups unconnected policy nodes as Unattached Policies', () => {
+    const dotString = `digraph {
+      n1 [label="Gateway\\nmy-gw"]
+      n2 [label="AuthPolicy\\nmy-policy"]
+    }`;
+    const { nodes } = parseDotToModel(dotString);
+
+    expect(nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'group-unattached',
+          label: 'Unattached Policies',
+          children: expect.arrayContaining(['n2']),
+        }),
+      ]),
+    );
+  });
+
+  it('does not group connected policy nodes', () => {
+    const dotString = `digraph {
+      n1 [label="Gateway\\nmy-gw"]
+      n2 [label="AuthPolicy\\nmy-policy"]
+      n1 -> n2
+    }`;
+    const { nodes } = parseDotToModel(dotString);
+
+    const group = nodes.find((n) => n.id === 'group-unattached');
+    expect(group).toBeUndefined();
+  });
+
+  it('groups kuadrant internal nodes', () => {
+    const dotString = `digraph {
+      n1 [label="Kuadrant\\nmy-kuadrant"]
+      n2 [label="ConfigMap\\ntopology"]
+    }`;
+    const { nodes } = parseDotToModel(dotString);
+
+    expect(nodes).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: 'group-kuadrant-internals',
+          label: 'Kuadrant Internals',
+          children: expect.arrayContaining(['n1', 'n2']),
+        }),
+      ]),
+    );
+  });
+
+  it('throws on invalid DOT string', () => {
+    // eslint-disable-next-line @typescript-eslint/no-empty-function
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => parseDotToModel('not a valid dot string {')).toThrow();
+    jest.restoreAllMocks();
+  });
+
+  it('handles empty graph', () => {
+    const dotString = 'digraph {}';
+    const { nodes, edges } = parseDotToModel(dotString);
+    expect(nodes).toHaveLength(0);
+    expect(edges).toHaveLength(0);
+  });
+});
+
+describe('preserveTransitiveEdges', () => {
+  const makeNode = (id: string, resourceType: string) => ({ id, resourceType });
+  const makeEdge = (source: string, target: string) => ({
+    id: `edge-${source}-${target}`,
+    type: 'edge',
+    source,
+    target,
+    edgeStyle: 'default',
+    style: { strokeWidth: 2, stroke: '#393F44' },
+  });
+
+  it('keeps original edges when all nodes are kept', () => {
+    const nodes = [makeNode('gw', 'Gateway'), makeNode('route', 'HTTPRoute')];
+    const edges = [makeEdge('gw', 'route')];
+    const kept = new Set(['gw', 'route']);
+
+    const result = preserveTransitiveEdges(nodes, edges, kept);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('gw');
+    expect(result[0].target).toBe('route');
+  });
+
+  it('creates transitive edge when a Listener is filtered out', () => {
+    const nodes = [
+      makeNode('gw', 'Gateway'),
+      makeNode('listener', 'Listener'),
+      makeNode('route', 'HTTPRoute'),
+    ];
+    const edges = [makeEdge('gw', 'listener'), makeEdge('listener', 'route')];
+    const kept = new Set(['gw', 'route']);
+
+    const result = preserveTransitiveEdges(nodes, edges, kept);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('gw');
+    expect(result[0].target).toBe('route');
+  });
+
+  it('creates transitive edge when an HTTPRouteRule is filtered out', () => {
+    const nodes = [
+      makeNode('route', 'HTTPRoute'),
+      makeNode('rule', 'HTTPRouteRule'),
+      makeNode('policy', 'AuthPolicy'),
+    ];
+    const edges = [makeEdge('route', 'rule'), makeEdge('rule', 'policy')];
+    const kept = new Set(['route', 'policy']);
+
+    const result = preserveTransitiveEdges(nodes, edges, kept);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('route');
+    expect(result[0].target).toBe('policy');
+  });
+
+  it('does not create transitive edge for non-transitive node types', () => {
+    const nodes = [
+      makeNode('gw', 'Gateway'),
+      makeNode('route', 'HTTPRoute'),
+      makeNode('policy', 'AuthPolicy'),
+    ];
+    const edges = [makeEdge('gw', 'route'), makeEdge('route', 'policy')];
+    const kept = new Set(['gw', 'policy']);
+
+    const result = preserveTransitiveEdges(nodes, edges, kept);
+    expect(result).toHaveLength(0);
+  });
+
+  it('deduplicates transitive edges from multiple intermediate nodes', () => {
+    // Two Listeners both connect the same Gateway to the same HTTPRoute
+    const nodes = [
+      makeNode('gw', 'Gateway'),
+      makeNode('listener1', 'Listener'),
+      makeNode('listener2', 'Listener'),
+      makeNode('route', 'HTTPRoute'),
+    ];
+    const edges = [
+      makeEdge('gw', 'listener1'),
+      makeEdge('listener1', 'route'),
+      makeEdge('gw', 'listener2'),
+      makeEdge('listener2', 'route'),
+    ];
+    const kept = new Set(['gw', 'route']);
+
+    const result = preserveTransitiveEdges(nodes, edges, kept);
+    expect(result).toHaveLength(1);
+    expect(result[0].source).toBe('gw');
+    expect(result[0].target).toBe('route');
+  });
+
+  it('returns empty array when no nodes are kept', () => {
+    const nodes = [makeNode('gw', 'Gateway')];
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const edges: any[] = [];
+    const kept = new Set<string>();
+
+    const result = preserveTransitiveEdges(nodes, edges, kept);
+    expect(result).toHaveLength(0);
+  });
+
+  it('handles chain of two transitive nodes filtered out', () => {
+    // Gateway -> Listener -> HTTPRouteRule -> AuthPolicy
+    // Both Listener and HTTPRouteRule filtered
+    const nodes = [
+      makeNode('gw', 'Gateway'),
+      makeNode('listener', 'Listener'),
+      makeNode('rule', 'HTTPRouteRule'),
+      makeNode('policy', 'AuthPolicy'),
+    ];
+    const edges = [
+      makeEdge('gw', 'listener'),
+      makeEdge('listener', 'rule'),
+      makeEdge('rule', 'policy'),
+    ];
+    const kept = new Set(['gw', 'policy']);
+
+    const result = preserveTransitiveEdges(nodes, edges, kept);
+    // Listener bridges gw -> rule, but rule is not kept
+    // HTTPRouteRule bridges listener -> policy, but listener is not kept
+    expect(result).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

- adds 50 unit tests across 4 co-located test files for pure utility functions
- adds a single jest ESM stub for SDK and PatternFly topology (no behavioural mocking, just so jest can parse the imports)
- jest config updated with moduleNameMapper entries for the stub

Fixes https://github.com/Kuadrant/kuadrant-console-plugin/issues/566

## How to review

suggested order:
1. `__mocks__/esmStubs.ts` — single stub file, minimal exports to stop ESM parse failures
2. `jest.config.ts` — two moduleNameMapper additions pointing to the same stub
3. `src/utils/apiKeyUtils.test.ts` — formatLimits, start simple
4. `src/components/apikey/utils.test.ts` — getRequestStatus
5. `src/utils/metricsQueries.test.ts` — PromQL query builders + buildGatewayKey
6. `src/utils/topology/graphParser.test.ts` — most complex, topology parsing + transitive edges

## Test plan

- [ ] `yarn test` runs and all 50 tests pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for API key status and limit formatting logic.
  * Added query-builder tests to verify namespace filtering and key generation.
  * Added topology parsing tests for node grouping, edge handling, and invalid input cases.

* **Bug Fixes**
  * Improved test support for ESM-only dependencies so the suite runs more reliably.
  * Added stubs for external topology and console-related packages used during testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->