### PR TITLE
Upgrade fast-uri to 3.1.3 via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "upstream-replacements": "node downstream.js --upstream && yarn i18n && yarn lint"
   },
   "resolutions": {
+    "fast-uri": "^3.1.3",
     "follow-redirects": "^1.16.0",
     "http-proxy-middleware": "2.0.7",
     "immutable": "3.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8874,10 +8874,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-uri@npm:^3.0.1":
-  version: 3.1.2
-  resolution: "fast-uri@npm:3.1.2"
-  checksum: 10c0/5b35641895959f3f7ab7a7b1b5542bded159346f25ec9f256817b206d50b64eda5828e90d605a2e2fc645c90519a7259c2bab2c942ee728c88b88e5be21b090d
+"fast-uri@npm:^3.1.3":
+  version: 3.1.3
+  resolution: "fast-uri@npm:3.1.3"
+  checksum: 10c0/0ce405815546770ad7e730b8f8fd58db80cefe4533ee99ee1a3263f11d2ccc3b8a0cf10d6cd9ba590e9746eb43b60f2ef2631d0c379a9ebba063ce0d4076b109
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrade fast-uri from 3.1.2 to 3.1.3 via a yarn resolution. fast-uri < 3.1.3 fails to canonicalize Unicode/IDN hostnames for HTTP-family URLs, allowing security policy bypass (CVSS 7.2).

fast-uri is a transitive dependency pulled in via ajv (JSON schema validation). Adding a yarn resolution forces the patched version across all consumers.

## Changes

- `package.json`: add `"fast-uri": "^3.1.3"` to resolutions
- `yarn.lock`: regenerated (fast-uri 3.1.2 → 3.1.3)