### PR TITLE
Alignment Issue Fix

### DIFF
--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -292,9 +292,7 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
           {create ? t('Create DNS Policy') : t('Edit DNS Policy')}
         </title>
       </Helmet>
-      <PageSection
-        hasBodyWrapper={false} 
-        >
+      <PageSection hasBodyWrapper={false}>
         <div className="co-m-nav-title">
           <Title headingLevel="h1">{create ? t('Create DNS Policy') : t('Edit DNS Policy')}</Title>
           <p className="help-block">

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -292,7 +292,9 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
           {create ? t('Create DNS Policy') : t('Edit DNS Policy')}
         </title>
       </Helmet>
-      <PageSection hasBodyWrapper={false} className="pf-m-no-padding">
+      <PageSection
+        hasBodyWrapper={false} //className="pf-m-no-padding"
+      >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">{create ? t('Create DNS Policy') : t('Edit DNS Policy')}</Title>
           <p className="help-block">

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -293,8 +293,8 @@ const KuadrantDNSPolicyCreatePage: React.FC = () => {
         </title>
       </Helmet>
       <PageSection
-        hasBodyWrapper={false} //className="pf-m-no-padding"
-      >
+        hasBodyWrapper={false} 
+        >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">{create ? t('Create DNS Policy') : t('Edit DNS Policy')}</Title>
           <p className="help-block">

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -184,9 +184,7 @@ const KuadrantOIDCPolicyCreatePage: React.FC = () => {
           {create ? t('Create OIDC Policy') : t('Edit OIDC Policy')}
         </title>
       </Helmet>
-      <PageSection
-        hasBodyWrapper={false}
-      >
+      <PageSection hasBodyWrapper={false}>
         <div className="co-m-nav-title">
           <Title headingLevel="h1">
             {create ? t('Create OIDC Policy') : t('Edit OIDC Policy')}

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -184,7 +184,8 @@ const KuadrantOIDCPolicyCreatePage: React.FC = () => {
           {create ? t('Create OIDC Policy') : t('Edit OIDC Policy')}
         </title>
       </Helmet>
-      <PageSection hasBodyWrapper={false} className="pf-m-no-padding">
+      <PageSection hasBodyWrapper={false} //className="pf-m-no-padding"
+      >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">
             {create ? t('Create OIDC Policy') : t('Edit OIDC Policy')}

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -185,7 +185,7 @@ const KuadrantOIDCPolicyCreatePage: React.FC = () => {
         </title>
       </Helmet>
       <PageSection
-        hasBodyWrapper={false} //className="pf-m-no-padding"
+        hasBodyWrapper={false}
       >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -184,7 +184,8 @@ const KuadrantOIDCPolicyCreatePage: React.FC = () => {
           {create ? t('Create OIDC Policy') : t('Edit OIDC Policy')}
         </title>
       </Helmet>
-      <PageSection hasBodyWrapper={false} //className="pf-m-no-padding"
+      <PageSection
+        hasBodyWrapper={false} //className="pf-m-no-padding"
       >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -228,7 +228,8 @@ const KuadrantTLSCreatePage: React.FC = () => {
           {create ? t('Create TLS Policy') : t('Edit TLS Policy')}
         </title>
       </Helmet>
-      <PageSection hasBodyWrapper={false} //className="pf-m-no-padding"
+      <PageSection
+        hasBodyWrapper={false} //className="pf-m-no-padding"
       >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">{create ? t('Create TLS Policy') : t('Edit TLS Policy')}</Title>

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -229,7 +229,7 @@ const KuadrantTLSCreatePage: React.FC = () => {
         </title>
       </Helmet>
       <PageSection
-        hasBodyWrapper={false} //className="pf-m-no-padding"
+        hasBodyWrapper={false}
       >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">{create ? t('Create TLS Policy') : t('Edit TLS Policy')}</Title>

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -228,9 +228,7 @@ const KuadrantTLSCreatePage: React.FC = () => {
           {create ? t('Create TLS Policy') : t('Edit TLS Policy')}
         </title>
       </Helmet>
-      <PageSection
-        hasBodyWrapper={false}
-      >
+      <PageSection hasBodyWrapper={false}>
         <div className="co-m-nav-title">
           <Title headingLevel="h1">{create ? t('Create TLS Policy') : t('Edit TLS Policy')}</Title>
           <p className="help-block">

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -228,7 +228,8 @@ const KuadrantTLSCreatePage: React.FC = () => {
           {create ? t('Create TLS Policy') : t('Edit TLS Policy')}
         </title>
       </Helmet>
-      <PageSection hasBodyWrapper={false} className="pf-m-no-padding">
+      <PageSection hasBodyWrapper={false} //className="pf-m-no-padding"
+      >
         <div className="co-m-nav-title">
           <Title headingLevel="h1">{create ? t('Create TLS Policy') : t('Edit TLS Policy')}</Title>
           <p className="help-block">


### PR DESCRIPTION
## Description

- Header contents where extremely left-aligned in the tabs to create DNS, TLS, and OIDC policies. 
- Patternfly `[className="pf-m-no-padding]` modifier class found in body wrapper property for each respective header.
- Class commented out. Now headers are align with the rest of the page's contents.

Fixes #590

## Type of change

- [x] `[style]` Code style changes (Formatting)

## Changes made

- Intervening class commented out. 

## Screenshots

<!-- For UI changes, add before/after screenshots -->

| Before | 
|---------|
<img width="1512" height="982" alt="Screenshot 2026-07-06 at 17 21 05" src="https://github.com/user-attachments/assets/a766bc0b-25cf-4028-9bf2-3ee39647c716" />


| After | 
|---------|
<img width="1512" height="982" alt="Screenshot 2026-07-06 at 17 24 00" src="https://github.com/user-attachments/assets/b7013651-a627-4e0d-be30-7649b36e5842" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Adjusted the layout of several policy creation pages to better match the current page structure.
  * Removed extra top-section padding so these pages display more cleanly and consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->