### PR TITLE
add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# default reviewers for all files
+* @jasonmadigan @R-Lawton

--- a/OWNERS
+++ b/OWNERS
@@ -1,9 +1,0 @@
-# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
-
-approvers:
-- jasonmadigan
-- R-Lawton
-
-reviewers:
-- jasonmadigan
-- R-Lawton

--- a/OWNERS
+++ b/OWNERS
@@ -1,13 +1,9 @@
 # See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
 
 approvers:
-- david-martin
-- maleck13
 - jasonmadigan
 - R-Lawton
 
 reviewers:
-- david-martin
-- maleck13
 - jasonmadigan
 - R-Lawton


### PR DESCRIPTION
Org ruleset requires code owner review but no CODEOWNERS file existed, causing merge blocks that required admin bypass every time.

- Add `.github/CODEOWNERS` with current active approvers (@jasonmadigan, @R-Lawton)
- Delete unused `OWNERS` file (Prow format, not used by this repo)