### PR TITLE
fix(apiproduct): add form view to details page edit action

### DIFF
--- a/console-extensions.json
+++ b/console-extensions.json
@@ -404,6 +404,17 @@
     "type": "console.action/resource-provider",
     "properties": {
       "model": {
+        "group": "devportal.kuadrant.io",
+        "version": "v1alpha1",
+        "kind": "APIProduct"
+      },
+      "provider": { "$codeRef": "useAPIProductActions" }
+    }
+  },
+  {
+    "type": "console.action/resource-provider",
+    "properties": {
+      "model": {
         "group": "extensions.kuadrant.io",
         "version": "v1alpha1",
         "kind": "OIDCPolicy"

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
       "MyAPIKeysPage": "./components/apikey/MyAPIKeysPage",
       "APIKeyDetailPage": "./components/apikey/APIKeyDetailPage",
       "APIKeyApprovalPage": "./components/apikey/APIKeyApprovalPage",
+      "useAPIProductActions": "./components/apiproduct/useAPIProductActions",
       "useDNSPolicyActions": "./components/dnspolicy/useDNSPolicyActions",
       "useTLSPolicyActions": "./components/tlspolicy/useTLSPolicyActions",
       "useOIDCPolicyActions": "./components/oidcpolicy/useOIDCPolicyActions"

--- a/src/components/apiproduct/useAPIProductActions.tsx
+++ b/src/components/apiproduct/useAPIProductActions.tsx
@@ -1,0 +1,98 @@
+import * as React from 'react';
+import { useNavigate } from 'react-router-dom-v5-compat';
+import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
+import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
+import {
+  K8sResourceCommon,
+  useK8sModel,
+  getGroupVersionKindForResource,
+} from '@openshift-console/dynamic-plugin-sdk';
+import { AccessReviewResourceAttributes } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
+import {
+  useAnnotationsModal,
+  useDeleteModal,
+  useLabelsModal,
+} from '@openshift-console/dynamic-plugin-sdk';
+
+const useAPIProductActions = (obj: K8sResourceCommon): ExtensionHookResult<Action[]> => {
+  const navigate = useNavigate();
+  const gvk = obj ? getGroupVersionKindForResource(obj) : undefined;
+  const [apiProductModel] = useK8sModel(
+    gvk
+      ? { group: gvk.group, version: gvk.version, kind: gvk.kind }
+      : { group: '', version: '', kind: '' },
+  );
+  const launchDeleteModal = useDeleteModal(obj);
+  const launchLabelsModal = useLabelsModal(obj);
+  const launchAnnotationsModal = useAnnotationsModal(obj);
+
+  const actions = React.useMemo<Action[]>(() => {
+    if (!obj || obj.kind !== 'APIProduct') return [];
+    const namespace = obj.metadata?.namespace || 'default';
+    const name = obj.metadata?.name || '';
+
+    const updateAccess: AccessReviewResourceAttributes | undefined = apiProductModel
+      ? {
+          group: apiProductModel.apiGroup,
+          resource: apiProductModel.plural,
+          verb: 'update',
+          name,
+          namespace,
+        }
+      : undefined;
+    const deleteAccess: AccessReviewResourceAttributes | undefined = apiProductModel
+      ? {
+          group: apiProductModel.apiGroup,
+          resource: apiProductModel.plural,
+          verb: 'delete',
+          name,
+          namespace,
+        }
+      : undefined;
+
+    const actionsList: Action[] = [
+      {
+        id: 'edit-labels-apiproduct',
+        label: 'Edit labels',
+        cta: launchLabelsModal,
+        accessReview: updateAccess,
+      },
+      {
+        id: 'edit-annotations-apiproduct',
+        label: 'Edit annotations',
+        cta: launchAnnotationsModal,
+        accessReview: updateAccess,
+      },
+      {
+        id: 'kuadrant-apiproduct-edit-form',
+        label: 'Edit APIProduct',
+        description: 'Edit via form',
+        cta: () =>
+          navigate({
+            pathname: `/kuadrant/apiproducts/ns/${namespace}/${name}/edit`,
+          }),
+        insertBefore: 'edit-yaml',
+        accessReview: updateAccess,
+      },
+      {
+        id: 'delete-apiproduct',
+        label: 'Delete APIProduct',
+        cta: launchDeleteModal,
+        accessReview: deleteAccess,
+      },
+    ];
+
+    return actionsList;
+  }, [
+    navigate,
+    obj,
+    apiProductModel,
+    launchAnnotationsModal,
+    launchDeleteModal,
+    launchLabelsModal,
+  ]);
+
+  return [actions, true, undefined];
+};
+
+export default useAPIProductActions;


### PR DESCRIPTION
## Description
Fixes API Product edit page missing Form view toggle when accessed via details page Actions menu.

Fixes #589

## Problem
- Edit from list page: shows Form/YAML toggle 
- Edit from details page: YAML only, no toggle 

## Solution
Added `useAPIProductActions` resource action provider (same pattern as DNSPolicy/TLSPolicy/OIDCPolicy):
- Registers custom "Edit API Product" action
- Navigates to form edit route instead of default YAML editor
- Uses `insertBefore: 'edit-yaml'` to override default action

## Testing
1. Navigate to API Product details page
2. Click **Actions** → **Edit API Product**
3. Verify Form/YAML toggle appears
4. Verify can edit fields and switch views

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added console actions for API Products, including edit labels, edit annotations, edit details, and delete options.
  * API Product actions now appear alongside other resource actions in the console.
  * Added support for opening the API Product edit view from the resource actions menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->