### PR TITLE
Unit tests for utils 

### DIFF
--- a/src/utils/getModelFromResource.test.ts
+++ b/src/utils/getModelFromResource.test.ts
@@ -1,0 +1,111 @@
+import { getModelFromResource, getResourceNameFromKind } from './getModelFromResource';
+
+// ── getResourceNameFromKind ───────────────────────────────────────────────────
+
+describe('getResourceNameFromKind', () => {
+  it('returns lowercase plural with +s for kinds not ending in y', () => {
+    expect(getResourceNameFromKind('HTTPRoute')).toBe('httproutes');
+  });
+
+  it('returns lowercase plural with +s when kind ends in y preceded by a vowel', () => {
+    expect(getResourceNameFromKind('Gateway')).toBe('gateways');
+  });
+
+  it('returns ies plural when kind ends in y preceded by a consonant', () => {
+    expect(getResourceNameFromKind('AuthPolicy')).toBe('authpolicies');
+  });
+
+  it('returns ies plural for RateLimitPolicy', () => {
+    expect(getResourceNameFromKind('RateLimitPolicy')).toBe('ratelimitpolicies');
+  });
+
+  it('returns ies plural for DNSPolicy', () => {
+    expect(getResourceNameFromKind('DNSPolicy')).toBe('dnspolicies');
+  });
+
+  it('returns "ies" when kind is the single letter "y"', () => {
+    expect(getResourceNameFromKind('y')).toBe('ies');
+  });
+
+  it('returns "s" when kind is an empty string', () => {
+    expect(getResourceNameFromKind('')).toBe('s');
+  });
+});
+
+// ── getModelFromResource ──────────────────────────────────────────────────────
+
+describe('getModelFromResource', () => {
+  const makeResource = (overrides = {}) => ({
+    apiVersion: 'kuadrant.io/v1',
+    kind: 'AuthPolicy',
+    metadata: { name: 'my-policy', namespace: 'default' },
+    ...overrides,
+  });
+
+  it('extracts apiGroup as the part before / in apiVersion', () => {
+    const model = getModelFromResource(makeResource());
+    expect(model.apiGroup).toBe('kuadrant.io');
+  });
+
+  it('extracts apiVersion as the part after / in apiVersion', () => {
+    const model = getModelFromResource(makeResource());
+    expect(model.apiVersion).toBe('v1');
+  });
+
+  it('sets plural to the pluralized kind', () => {
+    const model = getModelFromResource(makeResource());
+    expect(model.plural).toBe('authpolicies');
+  });
+
+  it('sets namespaced to true when metadata.namespace is present', () => {
+    const model = getModelFromResource(makeResource());
+    expect(model.namespaced).toBe(true);
+  });
+
+  it('sets namespaced to false when metadata.namespace is absent', () => {
+    const model = getModelFromResource(makeResource({ metadata: { name: 'my-policy' } }));
+    expect(model.namespaced).toBe(false);
+  });
+
+  it('sets abbr to the first character of kind', () => {
+    const model = getModelFromResource(makeResource());
+    expect(model.abbr).toBe('A');
+  });
+
+  it('uses pluralization rule for kinds ending in y preceded by a vowel', () => {
+    const model = getModelFromResource(makeResource({ kind: 'Gateway' }));
+    expect(model.plural).toBe('gateways');
+  });
+
+  it('uses ies pluralization for kinds ending in y preceded by a consonant', () => {
+    const model = getModelFromResource(makeResource({ kind: 'DNSPolicy' }));
+    expect(model.plural).toBe('dnspolicies');
+  });
+
+  it('sets apiVersion to undefined when apiVersion has no slash (core resource like "v1")', () => {
+    const model = getModelFromResource(makeResource({ apiVersion: 'v1' }));
+    expect(model.apiVersion).toBeUndefined();
+  });
+
+  it('sets abbr to empty string when kind is empty', () => {
+    const model = getModelFromResource(makeResource({ kind: '' }));
+    expect(model.abbr).toBe('');
+  });
+
+  it('sets namespaced to false when metadata.namespace is an empty string', () => {
+    const model = getModelFromResource(
+      makeResource({ metadata: { name: 'my-policy', namespace: '' } }),
+    );
+    expect(model.namespaced).toBe(false);
+  });
+
+  it('sets label to the kind as-is', () => {
+    const model = getModelFromResource(makeResource());
+    expect(model.label).toBe('AuthPolicy');
+  });
+
+  it('sets labelPlural to the pluralized kind', () => {
+    const model = getModelFromResource(makeResource());
+    expect(model.labelPlural).toBe('authpolicies');
+  });
+});

--- a/src/utils/nameFromPath.test.ts
+++ b/src/utils/nameFromPath.test.ts
@@ -1,0 +1,102 @@
+import extractResourceNameFromURL, {
+  extractKindFromURL,
+  extractNamespaceFromURL,
+} from './nameFromPath';
+
+describe('extractResourceNameFromURL', () => {
+  it('returns the segment after the GVK for a standard v1 path', () => {
+    expect(
+      extractResourceNameFromURL('/k8s/ns/my-ns/gateway.networking.k8s.io~v1~Gateway/my-gateway'),
+    ).toBe('my-gateway');
+  });
+
+  it('returns the segment after the GVK for a v1alpha1 version path', () => {
+    expect(
+      extractResourceNameFromURL('/k8s/ns/my-ns/kuadrant.io~v1alpha1~AuthPolicy/my-policy'),
+    ).toBe('my-policy');
+  });
+
+  it('returns the segment after the GVK for a v2beta3 version path', () => {
+    expect(
+      extractResourceNameFromURL('/k8s/ns/my-ns/kuadrant.io~v2beta3~RateLimitPolicy/my-policy'),
+    ).toBe('my-policy');
+  });
+
+  it('returns the segment immediately after the GVK ignoring any subpath', () => {
+    expect(
+      extractResourceNameFromURL(
+        '/k8s/ns/my-ns/gateway.networking.k8s.io~v1~HTTPRoute/my-route/policies',
+      ),
+    ).toBe('my-route');
+  });
+
+  it('returns null when the path is an empty string', () => {
+    expect(extractResourceNameFromURL('')).toBeNull();
+  });
+
+  it('returns null when the path has no group~vX~Kind segment', () => {
+    expect(extractResourceNameFromURL('/k8s/ns/my-ns/not-a-gvk')).toBeNull();
+  });
+
+  it('returns null when the path ends at the GVK segment with no name after it', () => {
+    expect(
+      extractResourceNameFromURL('/k8s/ns/my-ns/gateway.networking.k8s.io~v1~Gateway'),
+    ).toBeNull();
+  });
+});
+
+describe('extractKindFromURL', () => {
+  it('returns the Kind from a standard v1 path', () => {
+    expect(
+      extractKindFromURL('/k8s/ns/my-ns/gateway.networking.k8s.io~v1~HTTPRoute/my-route'),
+    ).toBe('HTTPRoute');
+  });
+
+  it('returns the Kind from a v1alpha1 version path', () => {
+    expect(extractKindFromURL('/k8s/ns/my-ns/kuadrant.io~v1alpha1~AuthPolicy/my-policy')).toBe(
+      'AuthPolicy',
+    );
+  });
+
+  it('returns the Kind from a v2beta3 version path', () => {
+    expect(extractKindFromURL('/k8s/ns/my-ns/kuadrant.io~v2beta3~RateLimitPolicy/my-policy')).toBe(
+      'RateLimitPolicy',
+    );
+  });
+
+  it('returns null when the path is an empty string', () => {
+    expect(extractKindFromURL('')).toBeNull();
+  });
+
+  it('returns null when the path has no group~vX~Kind segment', () => {
+    expect(extractKindFromURL('/k8s/ns/my-ns/not-a-gvk')).toBeNull();
+  });
+});
+
+describe('extractNamespaceFromURL', () => {
+  it('returns the segment after /ns/ as the namespace', () => {
+    expect(
+      extractNamespaceFromURL(
+        '/k8s/ns/my-namespace/gateway.networking.k8s.io~v1~Gateway/my-gateway',
+      ),
+    ).toBe('my-namespace');
+  });
+
+  it('returns the namespace when there is no resource name after the GVK', () => {
+    expect(
+      extractNamespaceFromURL('/k8s/ns/my-namespace/gateway.networking.k8s.io~v1~Gateway'),
+    ).toBe('my-namespace');
+  });
+
+  it('returns null when the path is an empty string', () => {
+    expect(extractNamespaceFromURL('')).toBeNull();
+  });
+
+  it('returns null when the path has no /ns/ segment', () => {
+    expect(extractNamespaceFromURL('/k8s/cluster/gateway.networking.k8s.io~v1~Gateway')).toBeNull();
+  });
+
+  it('returns null when /ns/ is the last segment with nothing after it', () => {
+    expect(extractNamespaceFromURL('/k8s/ns/')).toBeNull();
+  });
+});

--- a/src/utils/resources.test.ts
+++ b/src/utils/resources.test.ts
@@ -1,0 +1,202 @@
+import {
+  getAPIKeyPhase,
+  getPolicyKinds,
+  getTopologyDefaultKinds,
+  getPoliciesForResource,
+  getGVK,
+  getResourceMetadata,
+} from './resources';
+import type { APIKey } from './resources';
+
+// ── getPolicyKinds ────────────────────────────────────────────────────────────
+
+describe('getPolicyKinds', () => {
+  it('includes all known policy kinds', () => {
+    const kinds = getPolicyKinds();
+    expect(kinds).toEqual(
+      expect.arrayContaining([
+        'AuthPolicy',
+        'RateLimitPolicy',
+        'DNSPolicy',
+        'TLSPolicy',
+        'TokenRateLimitPolicy',
+        'OIDCPolicy',
+        'PlanPolicy',
+      ]),
+    );
+  });
+
+  it('does not include non-policy kinds like Gateway', () => {
+    const kinds = getPolicyKinds();
+    expect(kinds).not.toContain('Gateway');
+  });
+
+  it('does not include non-policy kinds like HTTPRoute', () => {
+    const kinds = getPolicyKinds();
+    expect(kinds).not.toContain('HTTPRoute');
+  });
+});
+
+// ── getTopologyDefaultKinds ───────────────────────────────────────────────────
+
+describe('getTopologyDefaultKinds', () => {
+  it('includes Gateway and HTTPRoute which are shown by default', () => {
+    const kinds = getTopologyDefaultKinds();
+    expect(kinds).toEqual(expect.arrayContaining(['Gateway', 'HTTPRoute']));
+  });
+
+  it('includes policy kinds that are shown by default', () => {
+    const kinds = getTopologyDefaultKinds();
+    expect(kinds).toEqual(expect.arrayContaining(['AuthPolicy', 'RateLimitPolicy']));
+  });
+
+  it('does not include APIKey which is not shown by default', () => {
+    const kinds = getTopologyDefaultKinds();
+    expect(kinds).not.toContain('APIKey');
+  });
+
+  it('does not include APIKeyRequest which is not shown by default', () => {
+    const kinds = getTopologyDefaultKinds();
+    expect(kinds).not.toContain('APIKeyRequest');
+  });
+});
+
+// ── getPoliciesForResource ────────────────────────────────────────────────────
+
+describe('getPoliciesForResource', () => {
+  it('returns the policies that can target a Gateway', () => {
+    const policies = getPoliciesForResource('Gateway');
+    expect(policies).toEqual(
+      expect.arrayContaining(['AuthPolicy', 'DNSPolicy', 'RateLimitPolicy', 'TLSPolicy']),
+    );
+  });
+
+  it('returns the policies that can target an HTTPRoute', () => {
+    const policies = getPoliciesForResource('HTTPRoute');
+    expect(policies).toEqual(expect.arrayContaining(['AuthPolicy', 'RateLimitPolicy']));
+  });
+
+  it('does not include DNSPolicy for HTTPRoute', () => {
+    const policies = getPoliciesForResource('HTTPRoute');
+    expect(policies).not.toContain('DNSPolicy');
+  });
+
+  it('returns an empty array for a kind with no policy mappings', () => {
+    expect(getPoliciesForResource('APIKey')).toEqual([]);
+  });
+});
+
+// ── getGVK ────────────────────────────────────────────────────────────────────
+// getGVK is a direct registry lookup — only valid ResourceKind values are accepted
+// (enforced by TypeScript). toEqual catches wrong field values so no separate
+// "wrong data" tests are needed.
+
+describe('getGVK', () => {
+  it('returns the correct GVK for Gateway', () => {
+    expect(getGVK('Gateway')).toEqual({
+      group: 'gateway.networking.k8s.io',
+      version: 'v1',
+      kind: 'Gateway',
+    });
+  });
+
+  it('returns the correct GVK for AuthPolicy', () => {
+    expect(getGVK('AuthPolicy')).toEqual({
+      group: 'kuadrant.io',
+      version: 'v1',
+      kind: 'AuthPolicy',
+    });
+  });
+});
+
+// ── getResourceMetadata ───────────────────────────────────────────────────────
+
+describe('getResourceMetadata', () => {
+  it('returns metadata with isPolicy true for AuthPolicy', () => {
+    expect(getResourceMetadata('AuthPolicy').isPolicy).toBe(true);
+  });
+
+  it('returns metadata with isPolicy false for Gateway', () => {
+    expect(getResourceMetadata('Gateway').isPolicy).toBe(false);
+  });
+});
+
+// ── getAPIKeyPhase ────────────────────────────────────────────────────────────
+
+const makeAPIKey = (conditions: { type: string; status: string }[] = []): APIKey =>
+  ({
+    apiVersion: 'devportal.kuadrant.io/v1alpha1',
+    kind: 'APIKey',
+    metadata: { name: 'my-key', namespace: 'default' },
+    status: { conditions },
+  } as APIKey);
+
+describe('getAPIKeyPhase', () => {
+  it('returns Pending when there are no conditions', () => {
+    expect(getAPIKeyPhase(makeAPIKey([]))).toBe('Pending');
+  });
+
+  it('returns Pending when status is undefined', () => {
+    const apiKey = { ...makeAPIKey(), status: undefined };
+    expect(getAPIKeyPhase(apiKey)).toBe('Pending');
+  });
+
+  it('returns Approved when Approved condition has status True', () => {
+    expect(getAPIKeyPhase(makeAPIKey([{ type: 'Approved', status: 'True' }]))).toBe('Approved');
+  });
+
+  it('returns Denied when Denied condition has status True', () => {
+    expect(getAPIKeyPhase(makeAPIKey([{ type: 'Denied', status: 'True' }]))).toBe('Denied');
+  });
+
+  it('returns Failed when Failed condition has status True', () => {
+    expect(getAPIKeyPhase(makeAPIKey([{ type: 'Failed', status: 'True' }]))).toBe('Failed');
+  });
+
+  it('returns Pending when explicit Pending condition has status True', () => {
+    expect(getAPIKeyPhase(makeAPIKey([{ type: 'Pending', status: 'True' }]))).toBe('Pending');
+  });
+
+  // A condition only counts when its status is the string 'True'.
+  // Testing Approved with 'False' is representative — the same check applies to all types.
+  it('returns Pending when Approved condition has status False', () => {
+    expect(getAPIKeyPhase(makeAPIKey([{ type: 'Approved', status: 'False' }]))).toBe('Pending');
+  });
+
+  it('returns Approved when both Approved and Denied are True — Approved has higher priority', () => {
+    expect(
+      getAPIKeyPhase(
+        makeAPIKey([
+          { type: 'Approved', status: 'True' },
+          { type: 'Denied', status: 'True' },
+        ]),
+      ),
+    ).toBe('Approved');
+  });
+
+  it('returns Denied when both Denied and Failed are True — Denied has higher priority', () => {
+    expect(
+      getAPIKeyPhase(
+        makeAPIKey([
+          { type: 'Denied', status: 'True' },
+          { type: 'Failed', status: 'True' },
+        ]),
+      ),
+    ).toBe('Denied');
+  });
+
+  it('returns Failed when both Failed and Pending are True — Failed has higher priority', () => {
+    expect(
+      getAPIKeyPhase(
+        makeAPIKey([
+          { type: 'Failed', status: 'True' },
+          { type: 'Pending', status: 'True' },
+        ]),
+      ),
+    ).toBe('Failed');
+  });
+
+  it('returns Pending when condition type is unrecognised', () => {
+    expect(getAPIKeyPhase(makeAPIKey([{ type: 'Unknown', status: 'True' }]))).toBe('Pending');
+  });
+});


### PR DESCRIPTION

Adds unit tests for three pure utility modules. All functions under test are pure with no external dependencies — no mocking required.

Fixes #565

## Type of change

- [x] `[test]` Test create

## Changes made

**`src/utils/nameFromPath.test.ts`**
- Extracts resource name, kind, and namespace from OpenShift console URL paths
- Handles v1, v1alpha1, v2beta3 API version formats
- Returns null for empty strings, missing segments, and paths without a GVK

**`src/utils/getModelFromResource.test.ts`**
- Pluralizes kinds ending in y preceded by a vowel (Gateway → gateways)
- Pluralizes kinds ending in y preceded by a consonant (AuthPolicy → authpolicies)
- Derives apiGroup, apiVersion, plural, namespaced, abbr, label, labelPlural from a resource object
- Handles apiVersion without a slash (core resources like v1)

**`src/utils/resources.test.ts`**
- getAPIKeyPhase: each status branch, priority order when multiple conditions are True, status False ignored, no conditions defaults to Pending
- getPolicyKinds: returns only resources with isPolicy true
- getTopologyDefaultKinds: returns only resources shown in topology by default
- getPoliciesForResource: returns mapped policies for Gateway and HTTPRoute, empty array for unmapped kinds
- getGVK and getResourceMetadata: correct field values for known kinds

## Test plan

- [ ] `yarn lint` passes (no changes after running)
- [ ] `yarn build` passes
- [ ] `yarn i18n` passes (no changes after running — commit updated locale files if needed)
- [x] `yarn test` passes — all new tests green

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit test coverage for resource, name, and URL helper behaviour.
  * Verified pluralisation logic, model field derivation, namespace detection, and API version parsing across standard and edge-case inputs.
  * Covered URL path parsing for resource names, kinds, and namespaces in multiple Kubernetes-style formats, including missing or incomplete values.
  * Expanded validation for policy and topology kind selection, GVK and metadata mapping, and API key phase/status handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->