### PR TITLE
Add e2e coverage for policy forms, topology view and overview dashboard

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -70,10 +70,21 @@ npx playwright test --config=e2e/playwright.config.ts
 
 ## Test Files
 
+- `e2e/tests/apikey-approvals.spec.ts` - API key request approval and rejection
 - `e2e/tests/apikey-lifecycle.spec.ts` - Full API key lifecycle (request, reveal, delete)
+- `e2e/tests/apiproduct-apikeys-tab.spec.ts` - API product API keys tab
 - `e2e/tests/apiproduct-crud.spec.ts` - API product CRUD operations
+- `e2e/tests/apiproduct-details-tabs.spec.ts` - API product details tabs
+- `e2e/tests/apiproduct-overview-tab.spec.ts` - API product overview tab
+- `e2e/tests/apiproduct-rbac.spec.ts` - API product RBAC
 - `e2e/tests/api-product-list.spec.ts` - API product list page
+- `e2e/tests/overview.spec.ts` - Overview dashboard cards, stats, and navigation
+- `e2e/tests/policy-forms.spec.ts` - Policy creation forms (DNS, TLS, Auth, RateLimit, etc.)
 - `e2e/tests/rbac.spec.ts` - RBAC permission tests
+- `e2e/tests/topology.spec.ts` - Policy topology rendering, filtering, and navigation
+
+PR CI runs the smoke subset listed in `.github/workflows/e2e-common.yaml`; the nightly
+run executes every spec in `e2e/tests/`.
 
 ## Test Environment
 

--- a/e2e/tests/overview.spec.ts
+++ b/e2e/tests/overview.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import {
+  TEST_NAMESPACE,
+  dismissConsoleTour,
+  spaNavigate,
+  waitForPermissionsLoaded,
+} from './helpers';
+
+// read-only tests against fixtures from e2e/manifests/test-resources.yaml.
+// namespace-scoped so resources seeded elsewhere by parallel specs are not
+// visible; the overview page reads the namespace from the URL param.
+test.describe('Overview dashboard', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await dismissConsoleTour(page);
+    await spaNavigate(page, `/kuadrant/overview/ns/${TEST_NAMESPACE}`);
+    await waitForPermissionsLoaded(page);
+  });
+
+  test('renders the dashboard cards', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Kuadrant Overview' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await expect(page.locator('text=Getting started resources')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Gateways', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Gateways - Traffic Analysis' })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Policies', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'HTTPRoutes', exact: true })).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'GRPCRoutes', exact: true })).toBeVisible();
+  });
+
+  test('gateway summary shows health stats', async ({ page }) => {
+    await expect(page.locator('span:text-is("Total Gateways")')).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('span:text-is("Healthy Gateways")')).toBeVisible();
+    await expect(page.locator('span:text-is("Unhealthy Gateways")')).toBeVisible();
+
+    // at least the fixture gateway is counted
+    const totalCount = page
+      .locator('span:text-is("Total Gateways")')
+      .locator('xpath=preceding-sibling::strong');
+    await expect(totalCount).toHaveText(/^[1-9]\d*$/, { timeout: 15_000 });
+  });
+
+  test('traffic analysis card lists gateways with metric columns', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Gateways - Traffic Analysis' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    for (const column of ['Total Requests', 'Successful Requests', 'Error Rate', 'Error Codes']) {
+      await expect(page.locator(`text=${column}`).first()).toBeVisible();
+    }
+
+    await expect(page.locator('a[data-test="test-gateway"]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+
+  test('policies card lists fixture policies', async ({ page }) => {
+    await expect(page.locator('a[data-test="test-auth-policy"]').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('a[data-test="test-plan-policy"]').first()).toBeVisible();
+  });
+
+  test('navigates to gateway details from the traffic analysis card', async ({ page }) => {
+    const gatewayLink = page.locator('a[data-test="test-gateway"]').first();
+    await expect(gatewayLink).toBeVisible({ timeout: 15_000 });
+    await gatewayLink.click();
+
+    await expect(page).toHaveURL(
+      /\/k8s\/ns\/kuadrant-test\/gateway\.networking\.k8s\.io~v1~Gateway\/test-gateway/,
+      { timeout: 15_000 },
+    );
+  });
+
+  test('navigates to policy details from the policies card', async ({ page }) => {
+    const policyLink = page.locator('a[data-test="test-auth-policy"]').first();
+    await expect(policyLink).toBeVisible({ timeout: 15_000 });
+    await policyLink.click();
+
+    await expect(page).toHaveURL(
+      /\/k8s\/ns\/kuadrant-test\/kuadrant\.io~v1~AuthPolicy\/test-auth-policy/,
+      { timeout: 15_000 },
+    );
+  });
+
+  test('navigates to HTTPRoute details from the routes card', async ({ page }) => {
+    const routeLink = page.locator('a[data-test="test-route"]').first();
+    await expect(routeLink).toBeVisible({ timeout: 15_000 });
+    await routeLink.click();
+
+    await expect(page).toHaveURL(
+      /\/k8s\/ns\/kuadrant-test\/gateway\.networking\.k8s\.io~v1~HTTPRoute\/test-route/,
+      { timeout: 15_000 },
+    );
+  });
+});

--- a/e2e/tests/policy-forms.spec.ts
+++ b/e2e/tests/policy-forms.spec.ts
@@ -22,7 +22,12 @@ function resourceExists(kind: string, name: string, namespace: string): boolean 
 
 function deleteNamespace(namespace: string): void {
   if (namespace) {
-    kubectl(['delete', 'namespace', namespace, '--ignore-not-found', '--wait=false']);
+    try {
+      kubectl(['delete', 'namespace', namespace, '--ignore-not-found', '--wait=false']);
+    } catch (error) {
+      // cleanup failure must not fail the test from afterEach
+      console.error(`Failed to delete namespace ${namespace}:`, error);
+    }
   }
 }
 

--- a/e2e/tests/policy-forms.spec.ts
+++ b/e2e/tests/policy-forms.spec.ts
@@ -1,0 +1,523 @@
+import { test, expect, Page } from '@playwright/test';
+import { execFileSync } from 'child_process';
+import { TEST_NAMESPACE, dismissConsoleTour } from './helpers';
+
+// unique suffix per call so parallel workers and repeated runs never collide
+const uid = () => `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
+
+function kubectl(args: string[], input?: string): string {
+  return execFileSync('kubectl', args, {
+    encoding: 'utf-8',
+    ...(input !== undefined ? { input } : {}),
+  }).trim();
+}
+
+function applyManifest(manifest: string): void {
+  kubectl(['apply', '-f', '-'], manifest);
+}
+
+function resourceExists(kind: string, name: string, namespace: string): boolean {
+  return kubectl(['get', kind, name, '-n', namespace, '--ignore-not-found', '-o', 'name']) !== '';
+}
+
+function deleteNamespace(namespace: string): void {
+  if (namespace) {
+    kubectl(['delete', 'namespace', namespace, '--ignore-not-found', '--wait=false']);
+  }
+}
+
+const gatewayManifest = (name: string, namespace: string) => `
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ${name}
+  namespace: ${namespace}
+spec:
+  gatewayClassName: istio
+  listeners:
+  - name: http
+    port: 80
+    protocol: HTTP
+    allowedRoutes:
+      namespaces:
+        from: Same
+`;
+
+// full page navigation so the console derives the active namespace from the
+// URL (pushState does not update the console's namespace state)
+async function gotoPage(page: Page, path: string): Promise<void> {
+  await page.goto(path);
+  await page.waitForLoadState('networkidle');
+  await dismissConsoleTour(page);
+}
+
+const createPagePath = (namespace: string, gvk: string) => `/k8s/ns/${namespace}/${gvk}/~new`;
+
+test.describe('DNSPolicy form', () => {
+  test('create form renders with required fields', async ({ page }) => {
+    await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~DNSPolicy'));
+
+    await expect(page.getByRole('heading', { name: 'Create DNS Policy' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    // form view is the default
+    await expect(page.locator('#create-type-radio-form')).toBeChecked();
+
+    await expect(page.locator('#policy-name')).toBeVisible();
+    await expect(page.locator('#gateway-select')).toBeVisible();
+    await expect(page.locator('#provider-ref')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Create', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  });
+
+  test('create button enables only when required fields are set', async ({ page }) => {
+    await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~DNSPolicy'));
+
+    const createButton = page.getByRole('button', { name: 'Create', exact: true });
+    await expect(createButton).toBeDisabled();
+
+    await page.locator('#policy-name').fill(`e2e-dns-${uid()}`);
+    await expect(createButton).toBeDisabled();
+
+    // fixture gateway from e2e/manifests/test-resources.yaml (read-only use)
+    const gatewayOption = page.locator(
+      `#gateway-select option[value="${TEST_NAMESPACE}/test-gateway"]`,
+    );
+    await expect(gatewayOption).toBeAttached({ timeout: 15_000 });
+    await page.locator('#gateway-select').selectOption(`${TEST_NAMESPACE}/test-gateway`);
+    await expect(createButton).toBeDisabled();
+
+    await page.locator('#provider-ref').fill('e2e-provider-secret');
+    await expect(createButton).toBeEnabled();
+
+    // clearing a required field disables it again
+    await page.locator('#policy-name').fill('');
+    await expect(createButton).toBeDisabled();
+  });
+
+  test.describe('with seeded namespace', () => {
+    let namespace = '';
+    let gateway = '';
+
+    test.beforeEach(async () => {
+      namespace = `e2e-dnsp-${uid()}`;
+      gateway = `e2e-gw-${uid()}`;
+      kubectl(['create', 'namespace', namespace]);
+      applyManifest(gatewayManifest(gateway, namespace));
+    });
+
+    test.afterEach(async () => {
+      deleteNamespace(namespace);
+    });
+
+    test('creates a DNSPolicy via the form', async ({ page }) => {
+      const policyName = `e2e-dns-${uid()}`;
+      await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~DNSPolicy'));
+
+      await expect(page.getByRole('heading', { name: 'Create DNS Policy' })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await page.locator('#policy-name').fill(policyName);
+
+      const gatewayOption = page.locator(`#gateway-select option[value="${namespace}/${gateway}"]`);
+      await expect(gatewayOption).toBeAttached({ timeout: 15_000 });
+      await page.locator('#gateway-select').selectOption(`${namespace}/${gateway}`);
+
+      await page.locator('#provider-ref').fill('e2e-provider-secret');
+
+      const createButton = page.getByRole('button', { name: 'Create', exact: true });
+      await expect(createButton).toBeEnabled();
+      await createButton.click();
+
+      // successful creation redirects to the DNS tab of the policies page
+      await expect(page).toHaveURL(new RegExp(`/kuadrant/policies/ns/${namespace}/dns`), {
+        timeout: 15_000,
+      });
+
+      expect(resourceExists('dnspolicy', policyName, namespace)).toBe(true);
+
+      // created policy appears in the list
+      await expect(page.locator(`a[data-test="${policyName}"]`)).toBeVisible({
+        timeout: 15_000,
+      });
+    });
+
+    test('edits an existing DNSPolicy (name immutable, provider ref persisted)', async ({
+      page,
+    }) => {
+      const policyName = `e2e-dns-${uid()}`;
+      applyManifest(`
+apiVersion: kuadrant.io/v1
+kind: DNSPolicy
+metadata:
+  name: ${policyName}
+  namespace: ${namespace}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ${gateway}
+  providerRefs:
+  - name: e2e-provider-a
+`);
+
+      await gotoPage(page, `/k8s/ns/${namespace}/dnspolicy/name/${policyName}/edit`);
+
+      await expect(page.getByRole('heading', { name: 'Edit DNS Policy' })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      // form prefilled from the existing resource; name is immutable
+      const nameInput = page.locator('#policy-name');
+      await expect(nameInput).toHaveValue(policyName, { timeout: 15_000 });
+      await expect(nameInput).toBeDisabled();
+      await expect(page.locator('#gateway-select')).toHaveValue(`${namespace}/${gateway}`);
+      await expect(page.locator('#provider-ref')).toHaveValue('e2e-provider-a');
+
+      await page.locator('#provider-ref').fill('e2e-provider-b');
+
+      const saveButton = page.getByRole('button', { name: 'Save', exact: true });
+      await expect(saveButton).toBeEnabled();
+      await saveButton.click();
+
+      await expect(page).toHaveURL(new RegExp(`/kuadrant/policies/ns/${namespace}/dns`), {
+        timeout: 15_000,
+      });
+
+      expect(
+        kubectl([
+          'get',
+          'dnspolicy',
+          policyName,
+          '-n',
+          namespace,
+          '-o',
+          'jsonpath={.spec.providerRefs[0].name}',
+        ]),
+      ).toBe('e2e-provider-b');
+    });
+  });
+});
+
+test.describe('TLSPolicy form', () => {
+  test('create form renders with required fields', async ({ page }) => {
+    await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~TLSPolicy'));
+
+    await expect(page.getByRole('heading', { name: 'Create TLS Policy' })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    await expect(page.locator('#simple-form-policy-name-01')).toBeVisible();
+    await expect(page.locator('#gateway-select')).toBeVisible();
+
+    // cluster issuer is the default issuer type
+    await expect(page.locator('#cluster-issuer')).toBeChecked();
+    await expect(page.locator('#clusterissuer-select')).toBeVisible();
+
+    await expect(page.getByRole('button', { name: 'Create', exact: true })).toBeDisabled();
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  });
+
+  test('create button enables only when required fields are set', async ({ page }) => {
+    await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~TLSPolicy'));
+
+    const createButton = page.getByRole('button', { name: 'Create', exact: true });
+    await expect(createButton).toBeDisabled();
+
+    await page.locator('#simple-form-policy-name-01').fill(`e2e-tls-${uid()}`);
+    await expect(createButton).toBeDisabled();
+
+    const gatewayOption = page.locator(
+      `#gateway-select option[value="${TEST_NAMESPACE}/test-gateway"]`,
+    );
+    await expect(gatewayOption).toBeAttached({ timeout: 15_000 });
+    await page.locator('#gateway-select').selectOption(`${TEST_NAMESPACE}/test-gateway`);
+    await expect(createButton).toBeDisabled();
+
+    // fixture ClusterIssuer from e2e/manifests/test-resources.yaml (read-only use)
+    const issuerOption = page.locator('#clusterissuer-select option[value="test-selfsigned"]');
+    await expect(issuerOption).toBeAttached({ timeout: 15_000 });
+    await page.locator('#clusterissuer-select').selectOption('test-selfsigned');
+    await expect(createButton).toBeEnabled();
+  });
+
+  test.describe('with seeded namespace', () => {
+    let namespace = '';
+    let gateway = '';
+
+    test.beforeEach(async () => {
+      namespace = `e2e-tlsp-${uid()}`;
+      gateway = `e2e-gw-${uid()}`;
+      kubectl(['create', 'namespace', namespace]);
+      applyManifest(gatewayManifest(gateway, namespace));
+    });
+
+    test.afterEach(async () => {
+      deleteNamespace(namespace);
+    });
+
+    test('creates a TLSPolicy via the form', async ({ page }) => {
+      const policyName = `e2e-tls-${uid()}`;
+      await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~TLSPolicy'));
+
+      await expect(page.getByRole('heading', { name: 'Create TLS Policy' })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      await page.locator('#simple-form-policy-name-01').fill(policyName);
+
+      const gatewayOption = page.locator(`#gateway-select option[value="${namespace}/${gateway}"]`);
+      await expect(gatewayOption).toBeAttached({ timeout: 15_000 });
+      await page.locator('#gateway-select').selectOption(`${namespace}/${gateway}`);
+
+      const issuerOption = page.locator('#clusterissuer-select option[value="test-selfsigned"]');
+      await expect(issuerOption).toBeAttached({ timeout: 15_000 });
+      await page.locator('#clusterissuer-select').selectOption('test-selfsigned');
+
+      const createButton = page.getByRole('button', { name: 'Create', exact: true });
+      await expect(createButton).toBeEnabled();
+      await createButton.click();
+
+      await expect(page).toHaveURL(new RegExp(`/kuadrant/policies/ns/${namespace}/tls`), {
+        timeout: 15_000,
+      });
+
+      expect(resourceExists('tlspolicy', policyName, namespace)).toBe(true);
+      expect(
+        kubectl([
+          'get',
+          'tlspolicy',
+          policyName,
+          '-n',
+          namespace,
+          '-o',
+          'jsonpath={.spec.issuerRef.name}',
+        ]),
+      ).toBe('test-selfsigned');
+    });
+
+    test('edits an existing TLSPolicy (retarget gateway persisted)', async ({ page }) => {
+      const policyName = `e2e-tls-${uid()}`;
+      const secondGateway = `e2e-gw-b-${uid()}`;
+      applyManifest(gatewayManifest(secondGateway, namespace));
+      applyManifest(`
+apiVersion: kuadrant.io/v1
+kind: TLSPolicy
+metadata:
+  name: ${policyName}
+  namespace: ${namespace}
+spec:
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: Gateway
+    name: ${gateway}
+  issuerRef:
+    name: test-selfsigned
+    kind: ClusterIssuer
+`);
+
+      await gotoPage(page, `/k8s/ns/${namespace}/tlspolicy/name/${policyName}/edit`);
+
+      await expect(page.getByRole('heading', { name: 'Edit TLS Policy' })).toBeVisible({
+        timeout: 15_000,
+      });
+
+      const nameInput = page.locator('#simple-form-policy-name-01');
+      await expect(nameInput).toHaveValue(policyName, { timeout: 15_000 });
+      await expect(nameInput).toBeDisabled();
+      await expect(page.locator('#gateway-select')).toHaveValue(`${namespace}/${gateway}`);
+
+      const secondGatewayOption = page.locator(
+        `#gateway-select option[value="${namespace}/${secondGateway}"]`,
+      );
+      await expect(secondGatewayOption).toBeAttached({ timeout: 15_000 });
+      await page.locator('#gateway-select').selectOption(`${namespace}/${secondGateway}`);
+
+      const saveButton = page.getByRole('button', { name: 'Save', exact: true });
+      await expect(saveButton).toBeEnabled();
+      await saveButton.click();
+
+      await expect(page).toHaveURL(new RegExp(`/kuadrant/policies/ns/${namespace}/tls`), {
+        timeout: 15_000,
+      });
+
+      expect(
+        kubectl([
+          'get',
+          'tlspolicy',
+          policyName,
+          '-n',
+          namespace,
+          '-o',
+          'jsonpath={.spec.targetRef.name}',
+        ]),
+      ).toBe(secondGateway);
+    });
+  });
+});
+
+// AuthPolicy and RateLimitPolicy create pages are YAML-editor only, prefilled
+// with an example resource. Creating with the default YAML uses the example
+// name, so each creation test runs in its own namespace for isolation.
+test.describe('YAML-based policy create pages', () => {
+  // wait for the monaco editor to render the given text
+  async function expectEditorContains(page: Page, text: string): Promise<void> {
+    await page.waitForSelector('.monaco-editor .view-lines', {
+      state: 'visible',
+      timeout: 15_000,
+    });
+    await page.waitForFunction(
+      (expected) => {
+        const lines = document.querySelector('.monaco-editor .view-lines');
+        return (lines?.textContent || '').includes(expected);
+      },
+      text,
+      { timeout: 15_000 },
+    );
+  }
+
+  test('AuthPolicy create page renders YAML editor with example resource', async ({ page }) => {
+    await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~AuthPolicy'));
+
+    await expect(page.locator('text=Create AuthPolicy').first()).toBeVisible({ timeout: 15_000 });
+    await expectEditorContains(page, 'example-authpolicy');
+    await expect(page.getByRole('button', { name: 'Create', exact: true })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
+  });
+
+  test('RateLimitPolicy create page renders YAML editor with example resource', async ({
+    page,
+  }) => {
+    await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~RateLimitPolicy'));
+
+    await expect(page.locator('text=Create RateLimit Policy').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expectEditorContains(page, 'example-ratelimitpolicy');
+    await expect(page.getByRole('button', { name: 'Create', exact: true })).toBeVisible();
+  });
+
+  test.describe('with seeded namespace', () => {
+    let namespace = '';
+
+    test.beforeEach(async () => {
+      namespace = `e2e-yamlp-${uid()}`;
+      kubectl(['create', 'namespace', namespace]);
+    });
+
+    test.afterEach(async () => {
+      deleteNamespace(namespace);
+    });
+
+    test('creates an AuthPolicy from the default YAML', async ({ page }) => {
+      await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~AuthPolicy'));
+
+      await expect(page.locator('text=Create AuthPolicy').first()).toBeVisible({
+        timeout: 15_000,
+      });
+      // active namespace propagated from the URL into the example resource
+      await expectEditorContains(page, namespace);
+
+      await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+      await expect
+        .poll(() => resourceExists('authpolicy', 'example-authpolicy', namespace), {
+          timeout: 15_000,
+        })
+        .toBe(true);
+    });
+
+    test('creates a RateLimitPolicy from the default YAML', async ({ page }) => {
+      await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~RateLimitPolicy'));
+
+      await expect(page.locator('text=Create RateLimit Policy').first()).toBeVisible({
+        timeout: 15_000,
+      });
+      await expectEditorContains(page, namespace);
+
+      await page.getByRole('button', { name: 'Create', exact: true }).click();
+
+      await expect
+        .poll(() => resourceExists('ratelimitpolicy', 'example-ratelimitpolicy', namespace), {
+          timeout: 15_000,
+        })
+        .toBe(true);
+    });
+  });
+});
+
+test.describe('other policy create pages render', () => {
+  test('OIDCPolicy create form renders', async ({ page }) => {
+    await gotoPage(
+      page,
+      createPagePath(TEST_NAMESPACE, 'extensions.kuadrant.io~v1alpha1~OIDCPolicy'),
+    );
+
+    await expect(page.getByRole('heading', { name: 'Create OIDC Policy' })).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('#policy-name')).toBeVisible();
+    await expect(page.locator('#client-id')).toBeVisible();
+    await expect(page.locator('#issuer-url')).toBeVisible();
+  });
+
+  test('PlanPolicy create page renders YAML editor', async ({ page }) => {
+    await gotoPage(
+      page,
+      createPagePath(TEST_NAMESPACE, 'extensions.kuadrant.io~v1alpha1~PlanPolicy'),
+    );
+
+    await expect(page.locator('text=Create Plan Policy').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('TokenRateLimitPolicy create page renders YAML editor', async ({ page }) => {
+    await gotoPage(
+      page,
+      createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1alpha1~TokenRateLimitPolicy'),
+    );
+
+    await expect(page.locator('text=Create TokenRateLimit Policy').first()).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 15_000 });
+  });
+});
+
+test.describe('policies page create dropdown', () => {
+  test('lists all policy types and navigates to the DNSPolicy form', async ({ page }) => {
+    await gotoPage(page, `/kuadrant/policies/ns/${TEST_NAMESPACE}`);
+
+    const createButton = page.locator('button:has-text("Create Policy")');
+    await expect(createButton).toBeVisible({ timeout: 15_000 });
+    await expect(createButton).toBeEnabled();
+    await createButton.click();
+
+    for (const policy of [
+      'AuthPolicy',
+      'RateLimitPolicy',
+      'TokenRateLimitPolicy',
+      'OIDCPolicy',
+      'PlanPolicy',
+      'DNSPolicy',
+      'TLSPolicy',
+    ]) {
+      await expect(page.getByRole('menuitem', { name: policy, exact: true })).toBeVisible();
+    }
+
+    await page.getByRole('menuitem', { name: 'DNSPolicy', exact: true }).click();
+
+    // namespace resolution depends on console state; the destination form is what matters
+    await expect(page).toHaveURL(/\/k8s\/ns\/[^/]+\/kuadrant\.io~v1~DNSPolicy\/~new/, {
+      timeout: 15_000,
+    });
+    await expect(page.getByRole('heading', { name: 'Create DNS Policy' })).toBeVisible({
+      timeout: 15_000,
+    });
+  });
+});

--- a/e2e/tests/topology.spec.ts
+++ b/e2e/tests/topology.spec.ts
@@ -1,0 +1,115 @@
+import { test, expect, Page, Locator } from '@playwright/test';
+import { dismissConsoleTour, navigateToTopology } from './helpers';
+
+// topology nodes rendered by patternfly react-topology; groups have
+// data-type="group" so [data-type="node"] selects only resource nodes
+const NODE_SELECTOR = 'g[data-kind="node"][data-type="node"]';
+
+// fixture resources from e2e/manifests/test-resources.yaml, present in the
+// operator-generated topology ConfigMap. read-only: filters are client-side.
+const GATEWAY_NODE_LABEL = 'kuadrant-test/test-gateway';
+const SECOND_GATEWAY_NODE_LABEL = 'kuadrant-test-2/test-gateway-2';
+const ROUTE_NODE_LABEL = 'kuadrant-test/test-route';
+
+function nodeByLabel(page: Page, label: string): Locator {
+  return page.locator(NODE_SELECTOR).filter({ hasText: label });
+}
+
+async function openResourceFilter(page: Page): Promise<void> {
+  await page.getByRole('button', { name: /^Resource(\s+\d+)?$/ }).click();
+}
+
+async function closeFilterMenu(page: Page): Promise<void> {
+  await page.keyboard.press('Escape');
+}
+
+test.describe('Policy Topology', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/');
+    await page.waitForLoadState('networkidle');
+    await dismissConsoleTour(page);
+    await navigateToTopology(page);
+
+    // wait for the graph to render nodes from the topology ConfigMap
+    await expect(page.locator('text=Topology View')).toBeVisible({ timeout: 15_000 });
+    await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
+  });
+
+  test('renders the topology graph with fixture resources', async ({ page }) => {
+    await expect(page.getByRole('heading', { name: 'Policy Topology' })).toBeVisible();
+
+    // filter toolbar and control bar are present
+    await expect(page.getByRole('button', { name: /^Resource(\s+\d+)?$/ })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Zoom In' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Zoom Out' })).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Fit to Screen' })).toBeVisible();
+
+    // fixture gateway and route nodes are rendered by default
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
+    expect(await page.locator(NODE_SELECTOR).count()).toBeGreaterThan(1);
+  });
+
+  test('filters nodes by resource type', async ({ page }) => {
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
+
+    // deselect Gateway (selected by default)
+    await openResourceFilter(page);
+    await page.getByRole('menuitem', { name: 'Gateway', exact: true }).click();
+    await closeFilterMenu(page);
+
+    await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeHidden({ timeout: 15_000 });
+    // other resource types remain visible
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible();
+
+    // reselect Gateway restores the nodes
+    await openResourceFilter(page);
+    await page.getByRole('menuitem', { name: 'Gateway', exact: true }).click();
+    await closeFilterMenu(page);
+
+    await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('clearing all resource filters empties the graph', async ({ page }) => {
+    // remove the whole Resource filter group via its close button
+    await page
+      .getByRole('button', { name: /close label group/i })
+      .first()
+      .click();
+
+    await expect(page.locator(NODE_SELECTOR)).toHaveCount(0, { timeout: 15_000 });
+
+    // selecting a resource type again restores nodes
+    await openResourceFilter(page);
+    await page.getByRole('menuitem', { name: 'Gateway', exact: true }).click();
+    await closeFilterMenu(page);
+
+    await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 15_000 });
+  });
+
+  test('filters nodes by namespace', async ({ page }) => {
+    // both fixture gateways visible before filtering
+    await expect(nodeByLabel(page, SECOND_GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
+
+    await page.getByRole('button', { name: /^Namespace(\s+\d+)?$/ }).click();
+    await page.getByRole('menuitem', { name: 'kuadrant-test', exact: true }).click();
+
+    // only kuadrant-test resources and their connected infrastructure remain
+    await expect(nodeByLabel(page, SECOND_GATEWAY_NODE_LABEL)).toBeHidden({ timeout: 15_000 });
+    await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible();
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible();
+  });
+
+  test('node context menu navigates to the resource details page', async ({ page }) => {
+    const gatewayNode = nodeByLabel(page, GATEWAY_NODE_LABEL);
+    await gatewayNode.click({ button: 'right' });
+
+    const goToResource = page.getByRole('menuitem', { name: 'Go to Resource' });
+    await expect(goToResource).toBeVisible({ timeout: 10_000 });
+    await goToResource.click();
+
+    await expect(page).toHaveURL(
+      /\/k8s\/ns\/kuadrant-test\/gateway\.networking\.k8s\.io~v1~Gateway\/test-gateway/,
+      { timeout: 15_000 },
+    );
+  });
+});

--- a/e2e/tests/topology.spec.ts
+++ b/e2e/tests/topology.spec.ts
@@ -46,7 +46,7 @@ test.describe('Policy Topology', () => {
 
     // fixture gateway and route nodes are rendered by default
     await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
-    expect(await page.locator(NODE_SELECTOR).count()).toBeGreaterThan(1);
+    await expect.poll(() => page.locator(NODE_SELECTOR).count()).toBeGreaterThan(1);
   });
 
   test('filters nodes by resource type', async ({ page }) => {
@@ -71,10 +71,7 @@ test.describe('Policy Topology', () => {
 
   test('clearing all resource filters empties the graph', async ({ page }) => {
     // remove the whole Resource filter group via its close button
-    await page
-      .getByRole('button', { name: /close label group/i })
-      .first()
-      .click();
+    await page.getByRole('button', { name: /close label group resource/i }).click();
 
     await expect(page.locator(NODE_SELECTOR)).toHaveCount(0, { timeout: 15_000 });
 


### PR DESCRIPTION
## Summary

- Adds e2e coverage for the three untested areas from #568: policy creation forms (16 tests), policy topology (5) and the overview dashboard (7)
- All 28 new tests run in the nightly suite only. The PR smoke list in `.github/workflows/e2e-common.yaml` is untouched, so PR CI stays at 58 tests (~11 min). Nightly grows from 96 to 124 tests across the existing 3 parallel workers
- New specs follow the #562 parallel-safety patterns: unique per-run namespaces (`e2e-*-<timestamp>-<rand>`) cleaned up in `afterEach`, read-only assertions against the seeded `kuadrant-test` fixtures, no serial mode

## How to review

Suggested order:

1. `e2e/tests/policy-forms.spec.ts`. DNS/TLS form tests seed their own gateway per test and assert the created resource via kubectl. AuthPolicy/RateLimitPolicy create pages are YAML-editor-only in the console, so those tests create from the default YAML
2. `e2e/tests/topology.spec.ts`. Read-only against seeded fixtures. Node interaction is the right-click context menu ("Go to Resource"), the only navigation the view offers
3. `e2e/tests/overview.spec.ts`. Scoped to the `kuadrant-test` namespace via the URL so resources created by parallel tests stay invisible
4. `e2e/README.md`. Documents where new specs land (nightly by default, smoke only if critical-path)

Worth knowing: selectors were verified against component source and fixture names against `e2e/manifests/test-resources.yaml`, but not against a live cluster, so the first nightly run may surface drift.

## Test evidence

- `yarn lint`: pass
- `tsc --noEmit` on the new specs: pass
- `npx playwright test --config=e2e/playwright.config.ts --list`: 124 tests in 12 files, new specs enumerated, smoke selection unchanged at 58
- Not run against a live cluster locally; nightly exercises the full suite

To verify locally: `yarn test:e2e:setup && yarn test:e2e`

Closes #568

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end coverage for the Overview dashboard, policy creation and editing flows, and the topology view.
  * Expanded the policy creation menu to include the full set of policy types.

* **Bug Fixes**
  * Improved navigation checks across dashboard, policy, and topology screens to help prevent broken links and unexpected routing issues.

* **Documentation**
  * Updated the end-to-end test guide to reflect the current test coverage and CI execution split.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->