### PR TITLE
fix: prevent API Product delete modal auto-closing

### DIFF
--- a/src/components/DropdownWithKebab.tsx
+++ b/src/components/DropdownWithKebab.tsx
@@ -21,12 +21,12 @@ import { useNavigate } from 'react-router-dom-v5-compat';
 import { RESOURCES, ResourceKind } from '../utils/resources';
 import useAccessReviews from '../utils/resourceRBAC';
 import { getModelFromResource, getResourceNameFromKind } from '../utils/getModelFromResource';
-import APIProductDeleteModal from './apiproduct/APIProductDeleteModal';
 type DropdownWithKebabProps = {
   obj: K8sResourceCommon;
+  onDeleteClick?: (obj: K8sResourceCommon) => void;
 };
 
-const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
+const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj, onDeleteClick }) => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
   const [isOpen, setIsOpen] = React.useState(false);
   const [isDeleteModalOpen, setIsDeleteModalOpen] = React.useState(false);
@@ -50,13 +50,16 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
   const policyType = obj.kind.toLowerCase();
   const resourceName = getResourceNameFromKind(obj.kind);
 
-  const resourceGVK: { group: string; kind: string; namespace?: string }[] = [
-    {
-      group: RESOURCES[obj.kind as ResourceKind].gvk.group,
-      kind: resourceName,
-      namespace: obj.metadata?.namespace,
-    },
-  ];
+  const resourceGVK = React.useMemo(
+    () => [
+      {
+        group: RESOURCES[obj.kind as ResourceKind].gvk.group,
+        kind: resourceName,
+        namespace: obj.metadata?.namespace,
+      },
+    ],
+    [obj.kind, resourceName, obj.metadata?.namespace],
+  );
   const { userRBAC, loading: rbacLoading } = useAccessReviews(resourceGVK);
 
   // keys from useAccessReviews use the plural resource name (e.g. authpolicies-delete)
@@ -92,8 +95,12 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
     }
   };
 
-  const onDeleteClick = () => {
-    setIsDeleteModalOpen(true);
+  const handleDeleteClick = () => {
+    if (onDeleteClick) {
+      onDeleteClick(obj);
+    } else {
+      setIsDeleteModalOpen(true);
+    }
   };
 
   const onSelect = (
@@ -102,7 +109,7 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
   ) => {
     setIsOpen(false);
     if (value === 'delete') {
-      onDeleteClick();
+      handleDeleteClick();
     }
   };
 
@@ -163,13 +170,7 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj }) => {
           )}
         </DropdownList>
       </Dropdown>
-      {obj.kind === 'APIProduct' ? (
-        <APIProductDeleteModal
-          isOpen={isDeleteModalOpen}
-          onClose={() => setIsDeleteModalOpen(false)}
-          resource={obj}
-        />
-      ) : (
+      {obj.kind !== 'APIProduct' && (
         <Modal
           isOpen={isDeleteModalOpen}
           onClose={() => setIsDeleteModalOpen(false)}

--- a/src/components/DropdownWithKebab.tsx
+++ b/src/components/DropdownWithKebab.tsx
@@ -170,7 +170,7 @@ const DropdownWithKebab: React.FC<DropdownWithKebabProps> = ({ obj, onDeleteClic
           )}
         </DropdownList>
       </Dropdown>
-      {obj.kind !== 'APIProduct' && (
+      {!onDeleteClick && (
         <Modal
           isOpen={isDeleteModalOpen}
           onClose={() => setIsDeleteModalOpen(false)}

--- a/src/components/apiproduct/APIProductsListPage.tsx
+++ b/src/components/apiproduct/APIProductsListPage.tsx
@@ -641,7 +641,10 @@ const APIProductsListPage: React.FC = () => {
                   activeColumnIDs={activeColumnIDs}
                   className="pf-v6-c-table__action"
                 >
-                  <DropdownWithKebab obj={obj} onDeleteClick={setDeleteModalProduct} />
+                  <DropdownWithKebab
+                    obj={obj}
+                    onDeleteClick={(resource) => setDeleteModalProduct(resource as APIProduct)}
+                  />
                 </TableData>
               );
             default:

--- a/src/components/apiproduct/APIProductsListPage.tsx
+++ b/src/components/apiproduct/APIProductsListPage.tsx
@@ -49,6 +49,7 @@ import {
 import { RESOURCES } from '../../utils/resources';
 import { APIProduct, PlanPolicy } from './types';
 import DropdownWithKebab from '../DropdownWithKebab';
+import APIProductDeleteModal from './APIProductDeleteModal';
 import '../kuadrant.css';
 import { getResourceNameFromKind } from '../../utils/getModelFromResource';
 import { useKuadrantNamespaceChange } from '../../hooks/useKuadrantNamespaceChange';
@@ -59,6 +60,7 @@ const APIProductsListPage: React.FC = () => {
   const { handleNamespaceChange, activeNamespace } = useKuadrantNamespaceChange('/apiproducts');
   const allNamespacesSubPath = '#ALL_NS#';
   const isAllNamespaces = activeNamespace === allNamespacesSubPath;
+  const [deleteModalProduct, setDeleteModalProduct] = React.useState<APIProduct | null>(null);
 
   // Watch APIProduct resources
   const [apiProducts, productsLoaded, productsLoadError] = useK8sWatchResource<APIProduct[]>({
@@ -639,7 +641,7 @@ const APIProductsListPage: React.FC = () => {
                   activeColumnIDs={activeColumnIDs}
                   className="pf-v6-c-table__action"
                 >
-                  <DropdownWithKebab obj={obj} />
+                  <DropdownWithKebab obj={obj} onDeleteClick={setDeleteModalProduct} />
                 </TableData>
               );
             default:
@@ -952,6 +954,13 @@ const APIProductsListPage: React.FC = () => {
           </div>
         </div>
       </PageSection>
+      {deleteModalProduct && (
+        <APIProductDeleteModal
+          isOpen={!!deleteModalProduct}
+          onClose={() => setDeleteModalProduct(null)}
+          resource={deleteModalProduct}
+        />
+      )}
     </>
   );
 };


### PR DESCRIPTION
## Description

Delete confirmation modal for API Products was closing automatically after approximately 20 seconds, before user can confirm deletion. 

Fixes #610

## Changes
- Modified `DropdownWithKebab` to accept `onDeleteClick` callback for API Products
- Moved modal rendering to `APIProductsListPage` component
- Modal state now survives table row unmount/remount cycles

## Testing
1. Navigate to API Products list
2. Click kebab menu → Delete for any product
3. Verify modal stays open (previously closed after ~10-20s)
4. Confirm deletion works correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an optional delete callback to the kebab menu, allowing pages to handle deletion and confirmation directly when needed.
  * API products now use a list-driven delete confirmation flow from the kebab menu, with the selected item tracked for the dialog.

* **Bug Fixes**
  * Improved consistency of delete confirmation behaviour across resource types.
  * Ensured the delete action uses the currently selected item when opening the confirmation dialog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->