### PR TITLE
Add @smoke and @nightly tags to all e2e tests

### DIFF
--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -69,13 +69,7 @@ jobs:
 
       - name: Run E2E tests (smoke)
         if: inputs.suite == 'smoke'
-        run: npx playwright test --config=e2e/playwright.config.ts
-          e2e/tests/apiproduct-crud.spec.ts
-          e2e/tests/apikey-lifecycle.spec.ts
-          e2e/tests/apikey-approvals.spec.ts
-          e2e/tests/apiproduct-rbac.spec.ts
-          e2e/tests/apiproduct-apikeys-tab.spec.ts
-          e2e/tests/rbac.spec.ts
+        run: npx playwright test --config=e2e/playwright.config.ts --grep @smoke
 
       - name: Run E2E tests (full)
         if: inputs.suite == 'full'

--- a/e2e/tests/api-product-list.spec.ts
+++ b/e2e/tests/api-product-list.spec.ts
@@ -21,7 +21,7 @@ test.describe('APIProduct List Page - Display and Filters', () => {
     await stopImpersonation(page);
   });
 
-  test('displays API Products list with correct columns', async ({ page }) => {
+  test('displays API Products list with correct columns', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Verify page title
@@ -42,7 +42,7 @@ test.describe('APIProduct List Page - Display and Filters', () => {
     await expect(page.locator('th button div span:has-text("Created")')).toBeVisible();
   });
 
-  test('displays API Products from test fixtures', async ({ page }) => {
+  test('displays API Products from test fixtures', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for table rows to load
@@ -65,7 +65,7 @@ test.describe('APIProduct List Page - Display and Filters', () => {
     expect(rows.length).toBeGreaterThan(4);
   });
 
-  test('displays correct status labels', async ({ page }) => {
+  test('displays correct status labels', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for table to load
@@ -82,7 +82,7 @@ test.describe('APIProduct List Page - Display and Filters', () => {
     expect(draftCount).toBeGreaterThanOrEqual(1);
   });
 
-  test('displays PlanPolicy links correctly', async ({ page }) => {
+  test('displays PlanPolicy links correctly', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for table to load
@@ -97,7 +97,7 @@ test.describe('APIProduct List Page - Display and Filters', () => {
     await expect(planPolicyLink).toBeVisible({ timeout: 10_000 });
   });
 
-  test('displays tags with correct styling', async ({ page }) => {
+  test('displays tags with correct styling', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Find the row for gamestore-api (has a PlanPolicy)
@@ -124,7 +124,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
     await stopImpersonation(page);
   });
 
-  test('filters by Published status', async ({ page }) => {
+  test('filters by Published status', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -157,7 +157,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
     await expect(page.locator('a:has-text("draft-api")')).not.toBeVisible();
   });
 
-  test('filters by Draft status', async ({ page }) => {
+  test('filters by Draft status', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -188,7 +188,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
     await expect(page.locator('a:has-text("gamestore-api")')).not.toBeVisible();
   });
 
-  test('clears status filter when clicking X on filter label', async ({ page }) => {
+  test('clears status filter when clicking X on filter label', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Apply Published filter
@@ -240,7 +240,7 @@ test.describe('APIProduct List Page - Name Filter', () => {
     await stopImpersonation(page);
   });
 
-  test('filters by name (partial match)', async ({ page }) => {
+  test('filters by name (partial match)', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -265,7 +265,7 @@ test.describe('APIProduct List Page - Name Filter', () => {
     await expect(page.locator('a:has-text("payment-api")')).not.toBeVisible();
   });
 
-  test('filters by name (case insensitive)', async ({ page }) => {
+  test('filters by name (case insensitive)', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -282,7 +282,7 @@ test.describe('APIProduct List Page - Name Filter', () => {
     await expect(page.locator('a:has-text("payment-api")')).toBeVisible();
   });
 
-  test('shows empty state when no results match name filter', async ({ page }) => {
+  test('shows empty state when no results match name filter', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -300,7 +300,7 @@ test.describe('APIProduct List Page - Name Filter', () => {
     await expect(page.locator('text=No API Products match the filter criteria.')).toBeVisible();
   });
 
-  test('clears name filter when input is cleared', async ({ page }) => {
+  test('clears name filter when input is cleared', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -339,7 +339,7 @@ test.describe('APIProduct List Page - Namespace Filter', () => {
     await stopImpersonation(page);
   });
 
-  test('switches to namespace filter type', async ({ page }) => {
+  test('switches to namespace filter type', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -366,7 +366,7 @@ test.describe('APIProduct List Page - Namespace Filter', () => {
     ).toBeVisible();
   });
 
-  test('filters by namespace (partial match)', async ({ page }) => {
+  test('filters by namespace (partial match)', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -395,7 +395,7 @@ test.describe('APIProduct List Page - Namespace Filter', () => {
     await expect(filterLabel).toBeVisible();
   });
 
-  test('clears namespace filter when input is cleared', async ({ page }) => {
+  test('clears namespace filter when input is cleared', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -438,7 +438,7 @@ test.describe('APIProduct List Page - HTTPRoute Filter', () => {
     await stopImpersonation(page);
   });
 
-  test('switches to HTTPRoute filter type', async ({ page }) => {
+  test('switches to HTTPRoute filter type', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -465,7 +465,7 @@ test.describe('APIProduct List Page - HTTPRoute Filter', () => {
     await expect(selectToggle).toBeVisible();
   });
 
-  test('filters by HTTPRoute', async ({ page }) => {
+  test('filters by HTTPRoute', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -498,7 +498,7 @@ test.describe('APIProduct List Page - HTTPRoute Filter', () => {
     await expect(badge).toBeVisible();
   });
 
-  test('clears HTTPRoute filter when clicking X on filter label', async ({ page }) => {
+  test('clears HTTPRoute filter when clicking X on filter label', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -542,7 +542,7 @@ test.describe('APIProduct List Page - HTTPRoute Filter', () => {
     await expect(page.locator('a:has-text("gamestore-api")')).toBeVisible();
   });
 
-  test('selects multiple HTTPRoutes', async ({ page }) => {
+  test('selects multiple HTTPRoutes', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -594,7 +594,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await stopImpersonation(page);
   });
 
-  test('applies both status and name filters together', async ({ page }) => {
+  test('applies both status and name filters together', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -630,7 +630,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await expect(page.locator('a:has-text("draft-api")')).not.toBeVisible();
   });
 
-  test('applies status and namespace filters together', async ({ page }) => {
+  test('applies status and namespace filters together', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -670,7 +670,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await expect(page.locator('a:has-text("gamestore-api")')).toBeVisible();
   });
 
-  test('applies status and HTTPRoute filters together', async ({ page }) => {
+  test('applies status and HTTPRoute filters together', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load
@@ -713,7 +713,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await expect(badge).toBeVisible();
   });
 
-  test('shows empty state when combined filters match nothing', async ({ page }) => {
+  test('shows empty state when combined filters match nothing', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
     // Wait for initial data to load

--- a/e2e/tests/apikey-approvals.spec.ts
+++ b/e2e/tests/apikey-approvals.spec.ts
@@ -43,7 +43,7 @@ async function navigateAsOwner(page: Parameters<typeof navigateToAPIKeyApprovals
 // ── RBAC ──────────────────────────────────────────────────────────────────────
 
 test.describe('APIKey Approvals - RBAC', () => {
-  test('user without apikeyrequests access cannot see the approval table', async ({ page }) => {
+  test('user without apikeyrequests access cannot see the approval table', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     await dismissConsoleTour(page);
@@ -75,7 +75,7 @@ test.describe('APIKey Approvals - Approve flow', () => {
     await stopImpersonation(page);
   });
 
-  test('cancel approval modal leaves row unchanged', async ({ page }) => {
+  test('cancel approval modal leaves row unchanged', { tag: '@smoke' }, async ({ page }) => {
     const aliceRow = page.locator('tr:has-text("alice@example.com")');
     await expect(aliceRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
     await aliceRow.locator('[aria-label="Actions"]').click();
@@ -141,7 +141,7 @@ EOF
       execSync(`kubectl delete namespace ${aliceNs} --ignore-not-found=true`, { stdio: 'inherit' });
     });
 
-    test('approve single request shows success toast', async ({ page }) => {
+    test('approve single request shows success toast', { tag: '@smoke' }, async ({ page }) => {
       const aliceApproveRow = page.locator(`tr:has-text("${aliceEmail}")`);
       await expect(aliceApproveRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
       await aliceApproveRow.locator('[aria-label="Actions"]').click();
@@ -214,7 +214,7 @@ EOF
     execSync(`kubectl delete namespace ${bobNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
-  test('reject request with reason shows success toast', async ({ page }) => {
+  test('reject request with reason shows success toast', { tag: '@smoke' }, async ({ page }) => {
     const bobRow = page.locator(`tr:has-text("${bobEmail}")`);
     await expect(bobRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
     await bobRow.locator('[aria-label="Actions"]').click();
@@ -287,7 +287,7 @@ EOF
     execSync(`kubectl delete namespace ${bob2Ns} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
-  test('reject request without reason is allowed', async ({ page }) => {
+  test('reject request without reason is allowed', { tag: '@nightly' }, async ({ page }) => {
     const bob2Row = page.locator(`tr:has-text("${bob2Email}")`);
     await expect(bob2Row.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
     await bob2Row.locator('[aria-label="Actions"]').click();
@@ -395,7 +395,7 @@ EOF
     execSync(`kubectl delete namespace ${carolNs} ${daveNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
-  test('bulk approve selected requests shows success toast', async ({ page }) => {
+  test('bulk approve selected requests shows success toast', { tag: '@smoke' }, async ({ page }) => {
     await page.locator(`tr:has-text("${carolEmail}") input[type="checkbox"]`).click();
     await page.locator(`tr:has-text("${daveEmail}") input[type="checkbox"]`).click();
 
@@ -502,7 +502,7 @@ EOF
     execSync(`kubectl delete namespace ${ellenNs} ${frankNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
-  test('bulk reject selected requests shows success toast', async ({ page }) => {
+  test('bulk reject selected requests shows success toast', { tag: '@smoke' }, async ({ page }) => {
     await page.locator(`tr:has-text("${ellenEmail}") input[type="checkbox"]`).click();
     await page.locator(`tr:has-text("${frankEmail}") input[type="checkbox"]`).click();
 
@@ -574,7 +574,7 @@ EOF
     execSync(`kubectl delete namespace ${georgeNs} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
-  test('should deny an active API key', async ({ page }) => {
+  test('should deny an active API key', { tag: '@smoke' }, async ({ page }) => {
     let georgeRow = page.locator(`tr:has-text("${georgeEmail}")`);
     await expect(georgeRow.locator('[aria-label="Actions"]')).toBeEnabled({ timeout: 30_000 });
     await georgeRow.locator('[aria-label="Actions"]').click();

--- a/e2e/tests/apikey-lifecycle.spec.ts
+++ b/e2e/tests/apikey-lifecycle.spec.ts
@@ -257,7 +257,7 @@ test.describe('API Key Lifecycle', () => {
     });
   });
 
-  test('should validate API key name format in request form', { tag: '@smoke' }, async ({ page }) => {
+  test('should validate API key name format in request form', { tag: '@nightly' }, async ({ page }) => {
     await navigateToMyAPIKeys(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
     await dismissConsoleTour(page);

--- a/e2e/tests/apikey-lifecycle.spec.ts
+++ b/e2e/tests/apikey-lifecycle.spec.ts
@@ -64,7 +64,7 @@ test.describe('API Key Lifecycle', () => {
     execSync(`kubectl delete apikey ${testAPIKeyName} -n ${TEST_NAMESPACE} --ignore-not-found=true`, { stdio: 'inherit' });
   });
 
-  test('should complete full API key lifecycle: request, reveal, and delete', async ({ page }) => {
+  test('should complete full API key lifecycle: request, reveal, and delete', { tag: '@smoke' }, async ({ page }) => {
     // Step 1: Navigate to My API Keys page
     await navigateToMyAPIKeys(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
@@ -239,7 +239,7 @@ test.describe('API Key Lifecycle', () => {
     await expect(deletedKeyRow).not.toBeVisible({ timeout: 10000 });
   });
 
-  test('should show disabled request button when namespace is not selected', async ({ page }) => {
+  test('should show disabled request button when namespace is not selected', { tag: '@smoke' }, async ({ page }) => {
     // Navigate to all namespaces view
     await spaNavigate(page, '/kuadrant/apikeys/all-namespaces');
     await page.waitForLoadState('networkidle');
@@ -257,7 +257,7 @@ test.describe('API Key Lifecycle', () => {
     });
   });
 
-  test('should validate API key name format in request form', async ({ page }) => {
+  test('should validate API key name format in request form', { tag: '@smoke' }, async ({ page }) => {
     await navigateToMyAPIKeys(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
     await dismissConsoleTour(page);
@@ -308,7 +308,7 @@ test.describe('API Key Lifecycle', () => {
     await expect(errorMessage).not.toBeVisible();
   });
 
-  test('should filter API products in request form', async ({ page }) => {
+  test('should filter API products in request form', { tag: '@nightly' }, async ({ page }) => {
     await navigateToMyAPIKeys(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
     await dismissConsoleTour(page);

--- a/e2e/tests/apiproduct-apikeys-tab.spec.ts
+++ b/e2e/tests/apiproduct-apikeys-tab.spec.ts
@@ -222,7 +222,7 @@ test.describe('APIProduct API Keys Tab - View and Actions', () => {
     await deleteNamespace(helenNs);
   });
 
-  test('should display pending API key requests', async ({ page }) => {
+  test('should display pending API key requests', { tag: '@smoke' }, async ({ page }) => {
     // Verify george request is visible
     await expect(page.locator(`tr:has-text("${georgeKey}")`)).toBeVisible();
     const georgeRow = page.locator(`tr:has-text("${georgeKey}")`);
@@ -239,7 +239,7 @@ test.describe('APIProduct API Keys Tab - View and Actions', () => {
     await expect(helenRow.locator('text=Pending')).toBeVisible();
   });
 
-  test('should show actionable items for pending requests', async ({ page }) => {
+  test('should show actionable items for pending requests', { tag: '@smoke' }, async ({ page }) => {
     // George row should already be visible from beforeEach filter
     const georgeRow = page.locator(`tr:has-text("${georgeKey}")`);
     await expect(georgeRow).toBeVisible();
@@ -260,7 +260,7 @@ test.describe('APIProduct API Keys Tab - View and Actions', () => {
     await page.locator('body').click();
   });
 
-  test('should show use case info icon when use case exists', async ({ page }) => {
+  test('should show use case info icon when use case exists', { tag: '@nightly' }, async ({ page }) => {
     // George row should already be visible from beforeEach filter
     const georgeRow = page.locator(`tr:has-text("${georgeKey}")`);
     await expect(georgeRow).toBeVisible();
@@ -309,7 +309,7 @@ test.describe('APIProduct API Keys Tab - Approve Request', () => {
     await deleteNamespace(ivanNs);
   });
 
-  test('should approve a pending request and update status', async ({ page }) => {
+  test('should approve a pending request and update status', { tag: '@smoke' }, async ({ page }) => {
     const ivanRow = page.locator(`tr:has-text("${ivanKey}")`);
 
     // Open actions menu and click Approve
@@ -369,7 +369,7 @@ test.describe('APIProduct API Keys Tab - Reject Request', () => {
     await deleteNamespace(judyNs);
   });
 
-  test('should reject a pending request and update status', async ({ page }) => {
+  test('should reject a pending request and update status', { tag: '@smoke' }, async ({ page }) => {
     const judyRow = page.locator(`tr:has-text("${judyKey}")`);
 
     // Open actions menu and click Deny
@@ -431,7 +431,7 @@ test.describe('APIProduct API Keys Tab - Deny Active Key', () => {
     await deleteNamespace(kateNs);
   });
 
-  test('should deny an active API key', async ({ page }) => {
+  test('should deny an active API key', { tag: '@smoke' }, async ({ page }) => {
     const kateRow = page.locator(`tr:has-text("${kateKey}")`);
 
     // Step 1: Approve the pending request

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -632,7 +632,7 @@ EOF`, { stdio: 'inherit' });
     await expect(automaticRadio).not.toBeChecked();
   });
 
-  test('should auto-generate resource name with unique suffix', { tag: '@smoke' }, async ({ page }) => {
+  test('should auto-generate resource name with unique suffix', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -658,7 +658,7 @@ EOF`, { stdio: 'inherit' });
     expect(secondGenerated).toBe(firstGenerated);
   });
 
-  test('should handle special characters in display name conversion', { tag: '@smoke' }, async ({ page }) => {
+  test('should handle special characters in display name conversion', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -52,7 +52,7 @@ test.describe('APIProduct CRUD Operations', () => {
     }
   });
 
-  test('should navigate from list page to create page via Create button', async ({ page }) => {
+  test('should navigate from list page to create page via Create button', { tag: '@smoke' }, async ({ page }) => {
     // Navigate to API Products list page
     await navigateToAPIProducts(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
@@ -76,7 +76,7 @@ test.describe('APIProduct CRUD Operations', () => {
     await expect(page.locator('#resource-name')).toBeVisible();
   });
 
-  test('should create APIProduct via form and verify in list', async ({ page }) => {
+  test('should create APIProduct via form and verify in list', { tag: '@smoke' }, async ({ page }) => {
     // Full page load to a namespace-scoped URL so the console sets activeNamespace to
     // TEST_NAMESPACE before we SPA-navigate to the create page. Without this,
     // useActiveNamespace() returns '#ALL_NS#' and k8sCreate posts to an invalid namespace.
@@ -183,7 +183,7 @@ test.describe('APIProduct CRUD Operations', () => {
     );
   });
 
-  test('should validate resource name format', async ({ page }) => {
+  test('should validate resource name format', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -340,7 +340,7 @@ test.describe('APIProduct CRUD Operations', () => {
     expect(yamlContent).toContain('test-httproute');
   });
 
-  test('should sync YAML to form correctly', async ({ page }) => {
+  test('should sync YAML to form correctly', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -361,7 +361,7 @@ test.describe('APIProduct CRUD Operations', () => {
     await expect(page.locator('#display-name')).toBeVisible();
   });
 
-  test('should disable Deprecated and Retired statuses', async ({ page }) => {
+  test('should disable Deprecated and Retired statuses', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -387,7 +387,7 @@ test.describe('APIProduct CRUD Operations', () => {
     expect(await retiredOption.isDisabled()).toBe(true);
   });
 
-  test('should prevent form submission on Enter in tags', async ({ page }) => {
+  test('should prevent form submission on Enter in tags', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -468,7 +468,7 @@ EOF`, { stdio: 'inherit' });
       }
     });
 
-  test('should edit existing APIProduct (resource name immutable)', async ({ page }) => {
+  test('should edit existing APIProduct (resource name immutable)', { tag: '@smoke' }, async ({ page }) => {
     const testProductName = editProductName;
     await spaNavigate(page, `/kuadrant/apiproducts/ns/${TEST_NAMESPACE}/${testProductName}/edit`);
 
@@ -520,7 +520,7 @@ EOF`, { stdio: 'inherit' });
     await expect(descriptionInput).toHaveValue('Updated description for testing');
   });
 
-  test('should delete APIProduct with confirmation', async ({ page }) => {
+  test('should delete APIProduct with confirmation', { tag: '@smoke' }, async ({ page }) => {
     const testProductName = editProductName;
 
     // Navigate to APIProducts list
@@ -591,7 +591,7 @@ EOF`, { stdio: 'inherit' });
 
   }); // end of 'edit and delete' describe
 
-  test('should display validation messages for required fields', async ({ page }) => {
+  test('should display validation messages for required fields', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -609,7 +609,7 @@ EOF`, { stdio: 'inherit' });
     await expect(saveButton).toBeDisabled();
   });
 
-  test('should handle approval mode selection', async ({ page }) => {
+  test('should handle approval mode selection', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -632,7 +632,7 @@ EOF`, { stdio: 'inherit' });
     await expect(automaticRadio).not.toBeChecked();
   });
 
-  test('should auto-generate resource name with unique suffix', async ({ page }) => {
+  test('should auto-generate resource name with unique suffix', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 
@@ -658,7 +658,7 @@ EOF`, { stdio: 'inherit' });
     expect(secondGenerated).toBe(firstGenerated);
   });
 
-  test('should handle special characters in display name conversion', async ({ page }) => {
+  test('should handle special characters in display name conversion', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('networkidle');
 

--- a/e2e/tests/apiproduct-details-tabs.spec.ts
+++ b/e2e/tests/apiproduct-details-tabs.spec.ts
@@ -38,7 +38,7 @@ test.describe('APIProduct Details Page - Custom Tabs', () => {
     await dismissConsoleTour(page);
   });
 
-  test('should display custom plugin tabs on APIProduct detail page', async ({ page }) => {
+  test('should display custom plugin tabs on APIProduct detail page', { tag: '@nightly' }, async ({ page }) => {
     // Navigate to APIProduct detail page
     await navigateToAPIProductDetails(page, TEST_NAMESPACE, API_PRODUCT_NAME);
 
@@ -65,7 +65,7 @@ test.describe('APIProduct Details Page - Custom Tabs', () => {
     ).toBeVisible();
   });
 
-  test('should display Definition tab empty state when no spec available', async ({ page }) => {
+  test('should display Definition tab empty state when no spec available', { tag: '@nightly' }, async ({ page }) => {
     const { execSync } = await import('child_process');
     const testNs = `test-tabs-${Date.now()}`;
     const httpRouteName = 'test-route-no-spec';
@@ -132,7 +132,7 @@ spec:
     }
   });
 
-  test('should display Definition tab with OpenAPI spec (Swagger UI)', async ({ page }) => {
+  test('should display Definition tab with OpenAPI spec (Swagger UI)', { tag: '@nightly' }, async ({ page }) => {
     // Use toystore-api which has a valid openAPISpecURL that the controller syncs
     const TOYSTORE_API = 'toystore-api';
 
@@ -149,7 +149,7 @@ spec:
     });
   });
 
-  test('should display Policies tab empty state when no policies attached', async ({ page }) => {
+  test('should display Policies tab empty state when no policies attached', { tag: '@nightly' }, async ({ page }) => {
     const { execSync } = await import('child_process');
     const testNs = `test-tabs-${Date.now()}`;
     const httpRouteName = 'test-route-no-policies';
@@ -216,7 +216,7 @@ spec:
     }
   });
 
-  test('should display Policies tab with actual policies when they exist', async ({ page }) => {
+  test('should display Policies tab with actual policies when they exist', { tag: '@nightly' }, async ({ page }) => {
     const { execSync } = await import('child_process');
     const testNs = `test-tabs-${Date.now()}`;
     const httpRouteName = 'test-route-with-policies';
@@ -314,7 +314,7 @@ spec:
     }
   });
 
-  test('should display Target tab with HTTPRoute targetRef', async ({ page }) => {
+  test('should display Target tab with HTTPRoute targetRef', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductTab(page, TEST_NAMESPACE, API_PRODUCT_NAME, 'targetref');
 
     // Verify HTTPRoute targetRef is displayed
@@ -325,7 +325,7 @@ spec:
     await expect(httpRouteText).toBeVisible({ timeout: 10_000 });
   });
 
-  test('should navigate between custom tabs successfully', async ({ page }) => {
+  test('should navigate between custom tabs successfully', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductDetails(page, TEST_NAMESPACE, API_PRODUCT_NAME);
 
     // Click on Definition tab

--- a/e2e/tests/apiproduct-overview-tab.spec.ts
+++ b/e2e/tests/apiproduct-overview-tab.spec.ts
@@ -25,7 +25,7 @@ test.describe('APIProduct Overview Tab', () => {
     await dismissConsoleTour(page);
   });
 
-  test('should display About section with all fields and correct styling', async ({ page }) => {
+  test('should display About section with all fields and correct styling', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductOverview(page);
     await expect(page.locator('text=About').first()).toBeVisible({ timeout: 10_000 });
 
@@ -68,7 +68,7 @@ test.describe('APIProduct Overview Tab', () => {
     await expect(page.locator('dd').filter({ has: page.locator('text=manual') })).toBeVisible();
   });
 
-  test('should display authentication methods with "Not set" and configured states', async ({
+  test('should display authentication methods with "Not set" and configured states', { tag: '@nightly' }, async ({
     page,
   }) => {
     // Test "Not set" state
@@ -101,7 +101,7 @@ test.describe('APIProduct Overview Tab', () => {
     expect(apiKeyClass).toContain('pf-m-green');
   });
 
-  test('should display plan tiers with "Not set" and configured states', async ({ page }) => {
+  test('should display plan tiers with "Not set" and configured states', { tag: '@nightly' }, async ({ page }) => {
     // Test "Not set" state
     await navigateToAPIProductOverview(page);
     await expect(page.locator('text=About').first()).toBeVisible({ timeout: 10_000 });
@@ -128,7 +128,7 @@ test.describe('APIProduct Overview Tab', () => {
     await expect(planTiersSection.locator('text=50 requests per day')).toBeVisible();
   });
 
-  test('should display Documentation section with links, "Not set" states, and edit buttons', async ({
+  test('should display Documentation section with links, "Not set" states, and edit buttons', { tag: '@nightly' }, async ({
     page,
   }) => {
     // Test with documentation links present
@@ -177,7 +177,7 @@ test.describe('APIProduct Overview Tab', () => {
     await expect(apiDocsValue.locator('text=Not set')).toBeVisible();
   });
 
-  test('should display Contact section with links, "Not set" states, and edit buttons', async ({
+  test('should display Contact section with links, "Not set" states, and edit buttons', { tag: '@nightly' }, async ({
     page,
   }) => {
     // Test "Not set" states
@@ -222,7 +222,7 @@ test.describe('APIProduct Overview Tab', () => {
     expect(count).toBeGreaterThanOrEqual(4);
   });
 
-  test('should open and close edit modals', async ({ page }) => {
+  test('should open and close edit modals', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductOverview(page);
     await expect(page.locator('text=About').first()).toBeVisible({ timeout: 10_000 });
 
@@ -278,7 +278,7 @@ test.describe('APIProduct Overview Tab', () => {
     await expect(page.locator('.pf-v6-c-modal-box')).not.toBeVisible();
   });
 
-  test('should navigate to Overview tab from detail page', async ({ page }) => {
+  test('should navigate to Overview tab from detail page', { tag: '@nightly' }, async ({ page }) => {
     // Navigate to APIProduct details (default tab)
     await page.evaluate(
       ({ ns, name }) => {
@@ -311,7 +311,7 @@ test.describe('APIProduct Overview Tab', () => {
     await expect(page.locator('h2:has-text("About")')).toBeVisible({ timeout: 10_000 });
   });
 
-  test('should display all sections in correct order', async ({ page }) => {
+  test('should display all sections in correct order', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductOverview(page);
     await expect(page.locator('text=About').first()).toBeVisible({ timeout: 10_000 });
 

--- a/e2e/tests/apiproduct-rbac.spec.ts
+++ b/e2e/tests/apiproduct-rbac.spec.ts
@@ -30,7 +30,7 @@ test.describe('APIProduct RBAC - no permission user', () => {
     await stopImpersonation(page);
   });
 
-  test('list page shows no-permission view', async ({ page }) => {
+  test('list page shows no-permission view', { tag: '@smoke' }, async ({ page }) => {
     const url = `/kuadrant/apiproducts/ns/${TEST_NAMESPACE}`;
     await impersonateAndNavigate(page, url, url);
 
@@ -42,7 +42,7 @@ test.describe('APIProduct RBAC - no permission user', () => {
     await expect(page.locator('text=Error loading API Products')).not.toBeVisible();
   });
 
-  test('definition tab shows access denied', async ({ page }) => {
+  test('definition tab shows access denied', { tag: '@smoke' }, async ({ page }) => {
     // Start at the list page to pre-load the Kuadrant plugin into React memory,
     // then impersonate and SPA navigate to the tab URL.
     await impersonateAndNavigate(
@@ -64,7 +64,7 @@ test.describe('APIProduct RBAC - no permission user', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('policies tab shows access denied', async ({ page }) => {
+  test('policies tab shows access denied', { tag: '@smoke' }, async ({ page }) => {
     await impersonateAndNavigate(
       page,
       `/kuadrant/apiproducts/ns/${TEST_NAMESPACE}`,

--- a/e2e/tests/rbac.spec.ts
+++ b/e2e/tests/rbac.spec.ts
@@ -21,7 +21,7 @@ test.describe('RBAC - test-dev persona', () => {
     await stopImpersonation(page);
   });
 
-  test('policies page shows no-permission view', async ({ page }) => {
+  test('policies page shows no-permission view', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -30,7 +30,7 @@ test.describe('RBAC - test-dev persona', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('create policy button is hidden', async ({ page }) => {
+  test('create policy button is hidden', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -40,7 +40,7 @@ test.describe('RBAC - test-dev persona', () => {
 
   // namespace-scoped users get redirected from /kuadrant/overview to
   // /kuadrant/overview/ns/default/ (fallback namespace when activeNamespace is #ALL_NS#).
-  test('overview redirects to namespace-scoped view (namespace-scoped user)', async ({ page }) => {
+  test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
     await page.waitForLoadState('networkidle');
 
@@ -53,7 +53,7 @@ test.describe('RBAC - test-dev persona', () => {
     // user can then switch to kuadrant-test namespace using the console namespace dropdown
   });
 
-  test('overview shows resources when accessed via kuadrant-test namespace', async ({ page }) => {
+  test('overview shows resources when accessed via kuadrant-test namespace', { tag: '@smoke' }, async ({ page }) => {
     // navigate directly to their accessible namespace
     await page.evaluate(() => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
@@ -77,7 +77,7 @@ test.describe('RBAC - test-dev persona', () => {
     ).not.toBeVisible();
   });
 
-  test('topology page shows no-permission view', async ({ page }) => {
+  test('topology page shows no-permission view', { tag: '@smoke' }, async ({ page }) => {
     await navigateToTopology(page);
     await expect(
       page.locator('text=You do not have permission to view Policy Topology'),
@@ -108,7 +108,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
     await kebab.click();
   };
 
-  test('read-only user sees disabled edit and delete', async ({ page }) => {
+  test('read-only user sees disabled edit and delete', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     await impersonateUser(page, 'test-viewer');
@@ -126,7 +126,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
     await stopImpersonation(page);
   });
 
-  test('CRUD user sees enabled edit and delete', async ({ page }) => {
+  test('CRUD user sees enabled edit and delete', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     await impersonateUser(page, 'test-devops');
@@ -144,7 +144,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
     await stopImpersonation(page);
   });
 
-  test('admin user sees enabled edit and delete', async ({ page }) => {
+  test('admin user sees enabled edit and delete', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
     await page.waitForLoadState('networkidle');
     await impersonateUser(page, 'test-admin');
@@ -176,7 +176,7 @@ test.describe('RBAC - test-viewer persona', () => {
     await stopImpersonation(page);
   });
 
-  test('policies page shows Auth and RateLimit tabs', async ({ page }) => {
+  test('policies page shows Auth and RateLimit tabs', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -188,7 +188,7 @@ test.describe('RBAC - test-viewer persona', () => {
   // DNS/TLS tabs are visible in admin perspective regardless of RBAC.
   // only the tab content is gated (shows no-permission message).
   // the "All Policies" view correctly filters by RBAC, but individual tabs don't.
-  test('DNS and TLS tabs are visible but content is permission-gated', async ({ page }) => {
+  test('DNS and TLS tabs are visible but content is permission-gated', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -199,7 +199,7 @@ test.describe('RBAC - test-viewer persona', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('create policy button is disabled (read-only)', async ({ page }) => {
+  test('create policy button is disabled (read-only)', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -208,7 +208,7 @@ test.describe('RBAC - test-viewer persona', () => {
     await expect(createButton).toBeDisabled();
   });
 
-  test('overview redirects to namespace-scoped view (namespace-scoped user)', async ({ page }) => {
+  test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
     await page.waitForLoadState('networkidle');
 
@@ -221,7 +221,7 @@ test.describe('RBAC - test-viewer persona', () => {
     // user can then switch to kuadrant-test namespace using the console namespace dropdown
   });
 
-  test('overview shows resources when accessed via kuadrant-test namespace', async ({ page }) => {
+  test('overview shows resources when accessed via kuadrant-test namespace', { tag: '@smoke' }, async ({ page }) => {
     // navigate directly to their accessible namespace
     await page.evaluate(() => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
@@ -259,7 +259,7 @@ test.describe('RBAC - test-devops persona', () => {
     await stopImpersonation(page);
   });
 
-  test('policies page shows AuthPolicy and RateLimitPolicy tabs', async ({ page }) => {
+  test('policies page shows AuthPolicy and RateLimitPolicy tabs', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -268,7 +268,7 @@ test.describe('RBAC - test-devops persona', () => {
     await expect(page.locator('[data-test-id="horizontal-link-RateLimit"]')).toBeVisible();
   });
 
-  test('DNS and TLS tabs are visible but content is permission-gated', async ({ page }) => {
+  test('DNS and TLS tabs are visible but content is permission-gated', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -279,7 +279,7 @@ test.describe('RBAC - test-devops persona', () => {
     ).toBeVisible({ timeout: 15_000 });
   });
 
-  test('create policy dropdown shows AuthPolicy enabled, DNSPolicy disabled', async ({ page }) => {
+  test('create policy dropdown shows AuthPolicy enabled, DNSPolicy disabled', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -303,7 +303,7 @@ test.describe('RBAC - test-devops persona', () => {
     }
   });
 
-  test('overview redirects to namespace-scoped view (namespace-scoped user)', async ({ page }) => {
+  test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
     await page.waitForLoadState('networkidle');
 
@@ -316,7 +316,7 @@ test.describe('RBAC - test-devops persona', () => {
     // user can then switch to kuadrant-test namespace using the console namespace dropdown
   });
 
-  test('overview shows resources when accessed via kuadrant-test namespace', async ({ page }) => {
+  test('overview shows resources when accessed via kuadrant-test namespace', { tag: '@smoke' }, async ({ page }) => {
     // navigate directly to their accessible namespace
     await page.evaluate(() => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
@@ -354,7 +354,7 @@ test.describe('RBAC - test-admin persona', () => {
     await stopImpersonation(page);
   });
 
-  test('policies page shows all policy tabs', async ({ page }) => {
+  test('policies page shows all policy tabs', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -365,7 +365,7 @@ test.describe('RBAC - test-admin persona', () => {
     await expect(page.locator('[data-test-id="horizontal-link-TLS"]')).toBeVisible();
   });
 
-  test('create policy dropdown has all policies enabled', async ({ page }) => {
+  test('create policy dropdown has all policies enabled', { tag: '@smoke' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -381,7 +381,7 @@ test.describe('RBAC - test-admin persona', () => {
     }
   });
 
-  test('overview stays on cluster-wide view (no redirect for cluster-admin)', async ({ page }) => {
+  test('overview stays on cluster-wide view (no redirect for cluster-admin)', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
     await page.waitForLoadState('networkidle');
 
@@ -397,7 +397,7 @@ test.describe('RBAC - test-admin persona', () => {
     ).not.toBeVisible();
   });
 
-  test('overview shows all cards with create buttons enabled', async ({ page }) => {
+  test('overview shows all cards with create buttons enabled', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
     await waitForPermissionsLoaded(page);
 
@@ -418,7 +418,7 @@ test.describe('RBAC - test-admin persona', () => {
     ).not.toBeVisible();
   });
 
-  test('overview create policy dropdown items are all enabled', async ({ page }) => {
+  test('overview create policy dropdown items are all enabled', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
     await waitForPermissionsLoaded(page);
 
@@ -433,7 +433,7 @@ test.describe('RBAC - test-admin persona', () => {
     }
   });
 
-  test('topology page is accessible', async ({ page }) => {
+  test('topology page is accessible', { tag: '@smoke' }, async ({ page }) => {
     await navigateToTopology(page);
     await expect(
       page.locator('text=You do not have permission to view Policy Topology'),

--- a/e2e/tests/rbac.spec.ts
+++ b/e2e/tests/rbac.spec.ts
@@ -208,7 +208,7 @@ test.describe('RBAC - test-viewer persona', () => {
     await expect(createButton).toBeDisabled();
   });
 
-  test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@smoke' }, async ({ page }) => {
+  test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@nightly' }, async ({ page }) => {
     await navigateToOverview(page);
     await page.waitForLoadState('networkidle');
 
@@ -221,7 +221,7 @@ test.describe('RBAC - test-viewer persona', () => {
     // user can then switch to kuadrant-test namespace using the console namespace dropdown
   });
 
-  test('overview shows resources when accessed via kuadrant-test namespace', { tag: '@smoke' }, async ({ page }) => {
+  test('overview shows resources when accessed via kuadrant-test namespace', { tag: '@nightly' }, async ({ page }) => {
     // navigate directly to their accessible namespace
     await page.evaluate(() => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
@@ -268,7 +268,7 @@ test.describe('RBAC - test-devops persona', () => {
     await expect(page.locator('[data-test-id="horizontal-link-RateLimit"]')).toBeVisible();
   });
 
-  test('DNS and TLS tabs are visible but content is permission-gated', { tag: '@smoke' }, async ({ page }) => {
+  test('DNS and TLS tabs are visible but content is permission-gated', { tag: '@nightly' }, async ({ page }) => {
     await navigateToPolicies(page);
     await waitForPermissionsLoaded(page);
 
@@ -303,7 +303,7 @@ test.describe('RBAC - test-devops persona', () => {
     }
   });
 
-  test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@smoke' }, async ({ page }) => {
+  test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@nightly' }, async ({ page }) => {
     await navigateToOverview(page);
     await page.waitForLoadState('networkidle');
 
@@ -316,7 +316,7 @@ test.describe('RBAC - test-devops persona', () => {
     // user can then switch to kuadrant-test namespace using the console namespace dropdown
   });
 
-  test('overview shows resources when accessed via kuadrant-test namespace', { tag: '@smoke' }, async ({ page }) => {
+  test('overview shows resources when accessed via kuadrant-test namespace', { tag: '@nightly' }, async ({ page }) => {
     // navigate directly to their accessible namespace
     await page.evaluate(() => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
@@ -418,7 +418,7 @@ test.describe('RBAC - test-admin persona', () => {
     ).not.toBeVisible();
   });
 
-  test('overview create policy dropdown items are all enabled', { tag: '@smoke' }, async ({ page }) => {
+  test('overview create policy dropdown items are all enabled', { tag: '@nightly' }, async ({ page }) => {
     await navigateToOverview(page);
     await waitForPermissionsLoaded(page);
 


### PR DESCRIPTION
## Description

Implements Playwright tag-based test selection to replace the file-based smoke/nightly split. Tests are now tagged with `@smoke` or `@nightly` directly in the test files, and CI filters by tag instead of listing specific files.

Closes #585

## Type of change

- [x] `[test]` Test updates
- [x] `[chore]` Dependency / config update

## Changes made

- Added `{ tag: '@smoke' }` or `{ tag: '@nightly' }` to every test across all 9 spec files
- Updated `e2e-common.yaml` smoke run to use `--grep @smoke` instead of listing files
- The nightly full run remains unchanged (`--grep` not set, runs everything)
- Three files already moved to nightly in the previous spike (`api-product-list`,
  `apiproduct-overview-tab`, `apiproduct-details-tabs`) have been tagged `@nightly`
- Nightly candidates identified during spike #559 tagged accordingly

## Test plan

- [ ] `yarn lint` passes (no changes after running)
- [ ] `yarn build` passes
- [ ] `yarn i18n` passes (no changes after running — commit updated locale files if needed)
- [ ] Smoke suite runs correctly in CI with `--grep @smoke`

## Smoke tests can be run locally:


  bash
`npx playwright test --config=e2e/playwright.config.ts --grep @smoke`


  Nightly tests can be run locally:


` npx playwright test --config=e2e/playwright.config.ts --grep @nightly`


Notes

Some tests are left as @smoke pending team discussion — see inline PR comment
for the full list of disputed candidates and reasoning.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test tagging by adding explicit `@smoke` and `@nightly` metadata across API product, API key, and RBAC scenarios.
  * Updated smoke test execution to select tests via tag-based filtering (instead of a fixed spec list), keeping coverage aligned with the current suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->