### PR TITLE
Fix delete test: dismiss console tour after SPA navigation to list page

### DIFF
--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -525,6 +525,9 @@ EOF`, { stdio: 'inherit' });
 
     // Navigate to APIProducts list
     await navigateToAPIProducts(page, TEST_NAMESPACE);
+    // Dismiss the console tour if it appears after SPA navigation — the tour can
+    // retrigger on the list page and block subsequent clicks if not dismissed.
+    await dismissConsoleTour(page);
 
     // Wait for table to load
     await page.waitForSelector('table', { timeout: 10000 });


### PR DESCRIPTION
## Description

The "should delete APIProduct with confirmation" test fails intermittently because
the console tour modal blocks the product link click after SPA navigation to the
list page.

`beforeEach` dismisses the tour after `page.goto('/')`, but `navigateToAPIProducts`
uses `window.history.pushState` which can retrigger the tour on the list page.
The modal then intercepts `productLink.click()` before it can be dismissed.

The edit test above it avoids this because it navigates directly to the edit URL,
which does not retrigger the tour the same way.

Fix: add `dismissConsoleTour` after `navigateToAPIProducts` in the delete test.

Fixes #617 

## Type of change

- [x] `[fix]` Bug fix

## Changes made

- Added `await dismissConsoleTour(page)` after `navigateToAPIProducts` in the
  delete test to prevent the console tour modal from blocking subsequent clicks

## Test plan

- [ ] `yarn lint` passes (no changes after running)
- [ ] `yarn build` passes
- [ ] `yarn i18n` passes (no changes after running — commit updated locale files if needed)
- [ ] `should delete APIProduct with confirmation` passes consistently in CI


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the API product deletion flow so the on-screen tour no longer reappears after returning to the list, helping prevent interruptions during delete actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->