### PR TITLE
ci: auto-create GitHub issues on nightly e2e failure

### DIFF
--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -12,11 +12,17 @@ on:
         required: false
         type: string
         default: ''
+    outputs:
+      failure-type:
+        description: 'Type of failure: none, infrastructure, or test'
+        value: ${{ jobs.e2e-rbac.outputs.failure-type }}
 
 jobs:
   e2e-rbac:
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    outputs:
+      failure-type: ${{ steps.classify.outputs.type }}
 
     steps:
       - uses: actions/checkout@v4
@@ -52,9 +58,11 @@ jobs:
           NODE_ENV: development
 
       - name: Setup cluster
+        id: setup
         run: ./e2e/setup.sh
 
       - name: Wait for plugin dev server
+        id: wait-server
         run: |
           DEV_SERVER_PID=$(cat /tmp/dev-server.pid)
           for i in $(seq 1 30); do
@@ -73,6 +81,7 @@ jobs:
           exit 1
 
       - name: Run E2E tests (smoke)
+        id: tests
         if: inputs.suite == 'smoke'
         env:
           SPEC_FILTER: ${{ inputs.specs }}
@@ -84,8 +93,21 @@ jobs:
           fi
 
       - name: Run E2E tests (full)
+        id: tests-full
         if: inputs.suite == 'full'
         run: npx playwright test --config=e2e/playwright.config.ts
+
+      - name: Classify failure
+        id: classify
+        if: always()
+        run: |
+          if [[ "${{ steps.setup.outcome }}" == "failure" || "${{ steps.wait-server.outcome }}" == "failure" ]]; then
+            echo "type=infrastructure" >> "$GITHUB_OUTPUT"
+          elif [[ "${{ steps.tests.outcome }}" == "failure" || "${{ steps.tests-full.outcome }}" == "failure" ]]; then
+            echo "type=test" >> "$GITHUB_OUTPUT"
+          else
+            echo "type=none" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Upload test results
         if: always()
@@ -94,6 +116,15 @@ jobs:
           name: playwright-report-${{ inputs.suite }}
           path: playwright-report/
           retention-days: 7
+
+      - name: Upload test results JSON
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-results-json
+          path: playwright-results.json
+          retention-days: 7
+          if-no-files-found: ignore
 
       - name: Teardown
         if: always()

--- a/.github/workflows/e2e-nightly.yaml
+++ b/.github/workflows/e2e-nightly.yaml
@@ -5,8 +5,123 @@ on:
     - cron: '0 2 * * *'  # Every night at 2:00 UTC
   workflow_dispatch:
 
+permissions:
+  issues: write
+  actions: read
+
 jobs:
-  e2e-full:
+  e2e:
     uses: ./.github/workflows/e2e-common.yaml
     with:
       suite: full
+
+  create-issue:
+    needs: e2e
+    if: failure()
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure labels exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          for label in nightly-failure nightly-infrastructure e2e; do
+            gh label create "$label" --force 2>/dev/null || true
+          done
+
+      - name: Determine failure type
+        id: failure
+        run: |
+          echo "type=${{ needs.e2e.outputs.failure-type }}" >> "$GITHUB_OUTPUT"
+
+      - name: Download test results
+        if: steps.failure.outputs.type == 'test'
+        uses: actions/download-artifact@v4
+        with:
+          name: playwright-results-json
+          path: ./results
+        continue-on-error: true
+
+      - name: Extract failed tests
+        if: steps.failure.outputs.type == 'test'
+        run: |
+          if [[ -f ./results/playwright-results.json ]]; then
+            node -e "
+              const r = require('./results/playwright-results.json');
+              function collectSpecs(suites) {
+                return suites.flatMap(s => [...(s.specs || []), ...collectSpecs(s.suites || [])]);
+              }
+              const failed = collectSpecs(r.suites)
+                .filter(spec => spec.tests?.some(t => t.status === 'unexpected' || t.status === 'flaky'))
+                .map(spec => '- ' + spec.title);
+              require('fs').writeFileSync('/tmp/failed-tests.txt',
+                failed.join('\n') || 'Could not determine individual test names');
+            " 2>/dev/null || echo "Could not parse test results" > /tmp/failed-tests.txt
+          else
+            echo "Test results JSON not available" > /tmp/failed-tests.txt
+          fi
+
+      - name: Determine label
+        id: label
+        run: |
+          if [[ "${{ steps.failure.outputs.type }}" == "infrastructure" ]]; then
+            echo "name=nightly-infrastructure" >> "$GITHUB_OUTPUT"
+          else
+            echo "name=nightly-failure" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Check for existing issue
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          EXISTING=$(gh issue list --label "${{ steps.label.outputs.name }}" --state open --json number --limit 1 -q '.[0].number // empty')
+          echo "number=$EXISTING" >> "$GITHUB_OUTPUT"
+
+      - name: Build issue body
+        if: steps.existing.outputs.number == ''
+        run: |
+          FAILURE_TYPE="${{ steps.failure.outputs.type }}"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          cat > /tmp/issue-body.md <<EOF
+          ## Nightly E2E Failure
+
+          **Date:** $(date -u +%Y-%m-%d)
+          **Run:** ${RUN_URL}
+          **Failure type:** ${FAILURE_TYPE}
+          EOF
+
+          if [[ "$FAILURE_TYPE" == "test" ]]; then
+            FAILED_TESTS=$(cat /tmp/failed-tests.txt 2>/dev/null || echo "Unknown")
+            cat >> /tmp/issue-body.md <<EOF
+
+          ### Failed Tests
+
+          ${FAILED_TESTS}
+          EOF
+          elif [[ "$FAILURE_TYPE" == "infrastructure" ]]; then
+            cat >> /tmp/issue-body.md <<EOF
+
+          The e2e test environment failed to set up.
+          This may indicate a problem with the cluster, kuadrant operator, or test fixtures.
+          EOF
+          fi
+
+          cat >> /tmp/issue-body.md <<EOF
+
+          ---
+          *This issue was automatically created by the nightly e2e workflow.*
+          EOF
+
+      - name: Create issue
+        if: steps.existing.outputs.number == ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue create \
+            --title "Nightly E2E failure — $(date -u +%Y-%m-%d)" \
+            --label "${{ steps.label.outputs.name }}" \
+            --label "e2e" \
+            --body-file /tmp/issue-body.md

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -7,7 +7,11 @@ export default defineConfig({
   fullyParallel: true,
   retries: 1,
   workers: 3,
-  reporter: [['html', { open: 'never' }], ['list']],
+  reporter: [
+    ['html', { open: 'never' }],
+    ['list'],
+    ['json', { outputFile: 'playwright-results.json' }],
+  ],
   use: {
     baseURL: process.env.CONSOLE_URL || 'http://localhost:9000',
     screenshot: 'only-on-failure',


### PR DESCRIPTION
## Summary

- automatically create a GitHub issue when nightly e2e tests fail, with the list of failed tests and a link to the run
- classifies failures as `infrastructure` (setup/cluster) or `test` (playwright) and labels accordingly
- no duplicate issues — checks for existing open issues before creating
- issues left open for manual triage

## Changes

- **`e2e-nightly.yaml`** — `create-issue` job files issues labelled `nightly-failure`/`nightly-infrastructure` + `e2e`
- **`e2e-common.yaml`** — added failure classification output (`infrastructure` vs `test` vs `none`) and JSON results artifact upload
- **`e2e/playwright.config.ts`** — added JSON reporter for machine-readable test results

## Verification

Tested on fork with a deliberate failing test:

- [Run 1 — issue created](https://github.com/R-Lawton/kuadrant-console-plugin/actions/runs/29104274538)
- [Run 2 — no duplicate issue created](https://github.com/R-Lawton/kuadrant-console-plugin/actions/runs/29107400321)
- [Auto-created issue](https://github.com/R-Lawton/kuadrant-console-plugin/issues/1)

## Test plan

- [x] trigger via `workflow_dispatch` and verify the workflow runs successfully
- [x] verify issue creation on test failure
- [x] verify no duplicate issues are created

Closes #586

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly end-to-end test failures now automatically create GitHub issues with relevant labels and failure details.
  * Test runs now produce JSON results alongside the existing HTML report.
  * Failure outcomes are classified as infrastructure failures, test failures, or successful runs.

* **Bug Fixes**
  * Improved failure reporting by including failed and flaky test names where available.
  * Duplicate nightly failure issues are avoided when an existing open issue is found.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->