### PR TITLE
test: wait for URL after SPA navigate in create APIProduct test

### DIFF
--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -83,10 +83,8 @@ test.describe('APIProduct CRUD Operations', () => {
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
     await page.waitForLoadState('networkidle');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
-
-    // Verify we're on the create page
-    await expect(page.locator('text=Create API Product')).toBeVisible({ timeout: 15000 });
+    // Wait for form to render — confirms routing and component mount, not just URL change
+    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
 
     // Fill display name
     const displayNameInput = page.locator('#display-name');


### PR DESCRIPTION
## Description

\`should create APIProduct via form and verify in list\` was consistently failing in CI with parallel workers. After the SPA navigate (\`pushState + popstate\`), \`waitForLoadState('networkidle')\` was resolving before React Router had finished rendering the component. Replaced with \`waitForSelector('#display-name')\` which waits for the actual form input to appear — confirms both routing and component mount, not just network idle.

## Changes
- Replace post-navigate sync with \`waitForSelector('#display-name')\` to confirm create page has rendered

## Testing
1. Run \`npx playwright test --config=e2e/playwright.config.ts e2e/tests/apiproduct-crud.spec.ts -g "should create APIProduct via form and verify in list"\`
2. Verify test passes