### PR TITLE
test: replace waitForLoadState with element wait in smoke tests

### DIFF
--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -241,12 +241,12 @@ test.describe('APIProduct CRUD Operations', () => {
     }
   });
 
-  test('should sync between Form and YAML views', async ({ page }) => {
+  test('should sync between Form and YAML views', { tag: '@smoke' }, async ({ page }) => {
     // Full page load first so activeNamespace is set correctly before SPA navigation
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
     await page.waitForLoadState('networkidle');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
 
     // Fill form fields
     await page.locator('#display-name').fill('YAML Sync Test');
@@ -579,7 +579,7 @@ EOF`, { stdio: 'inherit' });
 
   test('should display validation messages for required fields', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
 
     // Leave display name empty and try to proceed
     const saveButton = page.locator('button:has-text("Create")');
@@ -597,10 +597,10 @@ EOF`, { stdio: 'inherit' });
 
   test('should handle approval mode selection', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
 
     // Scroll to approval mode section
-    await page.locator('text=API key approval').scrollIntoViewIfNeeded();
+    await page.getByRole('heading', { name: 'API Key approval' }).scrollIntoViewIfNeeded();
 
     // Default should be manual
     const manualRadio = page.locator('#approval-manual');

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -1,30 +1,13 @@
 import { test, expect, Page } from '@playwright/test';
 import { execSync } from 'child_process';
-import { TEST_NAMESPACE, dismissConsoleTour } from './helpers';
-
-// SPA navigation using pushState - preserves redux state
-async function spaNavigate(page: Page, path: string): Promise<void> {
-  await page.evaluate((p) => {
-    window.history.pushState({}, '', p);
-    window.dispatchEvent(new PopStateEvent('popstate'));
-  }, path);
-  await page.waitForLoadState('networkidle');
-}
+import { TEST_NAMESPACE, dismissConsoleTour, spaNavigate } from './helpers';
 
 async function navigateToAPIProductCreate(page: Page, namespace = 'kuadrant-test'): Promise<void> {
-  await page.evaluate((ns) => {
-    window.history.pushState({}, '', `/kuadrant/apiproducts/ns/${ns}/~new`);
-    window.dispatchEvent(new PopStateEvent('popstate'));
-  }, namespace);
-  await page.waitForLoadState('networkidle');
+  await spaNavigate(page, `/kuadrant/apiproducts/ns/${namespace}/~new`);
 }
 
 const navigateToAPIProducts = async (page: Page, namespace = 'kuadrant-test') => {
-  await page.evaluate((ns) => {
-    window.history.pushState({}, '', `/kuadrant/apiproducts/ns/${ns}`);
-    window.dispatchEvent(new PopStateEvent('popstate'));
-  }, namespace);
-  await page.waitForLoadState('networkidle');
+  await spaNavigate(page, `/kuadrant/apiproducts/ns/${namespace}`);
 };
 
 // Note: Tests rely on test-httproute HTTPRoute existing in the test namespace
@@ -246,6 +229,7 @@ test.describe('APIProduct CRUD Operations', () => {
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
     await page.waitForLoadState('networkidle');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
+    await dismissConsoleTour(page);
     await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
     // Fill form fields

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -1,14 +1,11 @@
 import { test, expect, Page } from '@playwright/test';
 import { execSync } from 'child_process';
-import { TEST_NAMESPACE, dismissConsoleTour, spaNavigate } from './helpers';
+import { TEST_NAMESPACE, dismissConsoleTour, spaNavigate, navigateToAPIProducts } from './helpers';
 
 async function navigateToAPIProductCreate(page: Page, namespace = 'kuadrant-test'): Promise<void> {
   await spaNavigate(page, `/kuadrant/apiproducts/ns/${namespace}/~new`);
+  await dismissConsoleTour(page);
 }
-
-const navigateToAPIProducts = async (page: Page, namespace = 'kuadrant-test') => {
-  await spaNavigate(page, `/kuadrant/apiproducts/ns/${namespace}`);
-};
 
 // Note: Tests rely on test-httproute HTTPRoute existing in the test namespace
 // This is created by applying e2e/manifests/test-apiproduct-fixtures.yaml before running tests
@@ -229,7 +226,6 @@ test.describe('APIProduct CRUD Operations', () => {
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
     await page.waitForLoadState('networkidle');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await dismissConsoleTour(page);
     await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
     // Fill form fields

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -84,7 +84,7 @@ test.describe('APIProduct CRUD Operations', () => {
     await page.waitForLoadState('networkidle');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     // Wait for form to render — confirms routing and component mount, not just URL change
-    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
+    await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
     // Fill display name
     const displayNameInput = page.locator('#display-name');
@@ -153,7 +153,7 @@ test.describe('APIProduct CRUD Operations', () => {
     });
 
     // The new product may land on any pagination page; iterate until found or exhausted.
-    await page.waitForSelector('table', { timeout: 15000 });
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 15000 });
     const row = page.locator(`tr:has-text("${generatedResourceName}")`);
 
     let found = false;
@@ -246,7 +246,7 @@ test.describe('APIProduct CRUD Operations', () => {
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
     await page.waitForLoadState('networkidle');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
+    await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
     // Fill form fields
     await page.locator('#display-name').fill('YAML Sync Test');
@@ -516,7 +516,7 @@ EOF`, { stdio: 'inherit' });
     await dismissConsoleTour(page);
 
     // Wait for table to load
-    await page.waitForSelector('table', { timeout: 10000 });
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 10000 });
 
     // Find the product row
     const row = page.locator(`tr:has-text("${testProductName}")`);
@@ -579,7 +579,7 @@ EOF`, { stdio: 'inherit' });
 
   test('should display validation messages for required fields', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
+    await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
     // Leave display name empty and try to proceed
     const saveButton = page.locator('button:has-text("Create")');
@@ -597,7 +597,7 @@ EOF`, { stdio: 'inherit' });
 
   test('should handle approval mode selection', { tag: '@smoke' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
+    await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
     // Scroll to approval mode section
     await page.getByRole('heading', { name: 'API Key approval' }).scrollIntoViewIfNeeded();


### PR DESCRIPTION
## Description

Three `@smoke` tests in `apiproduct-crud.spec.ts` were using `waitForLoadState('networkidle')` after SPA navigate (`pushState + popstate`). This is the same root cause as #621 — `networkidle` resolves when there's no network activity, but React Router rendering happens synchronously so the component may not have mounted yet. These tests were observed failing in CI under parallel execution for the same reason.

Replaced with `expect(page.locator('#display-name')).toBeVisible()` which waits for the actual form input to appear, confirming the page has fully rendered before interacting. Also updates the same pattern in `should create APIProduct via form and verify in list` (from #621) to use the modern locator-based API consistently.

Also adds `@smoke` tag to `should sync between Form and YAML views` and fixes an ambiguous locator (`text=API key approval` matched both a nav link and a form heading — narrowed to `getByRole('heading')`).

After tagging `should sync between Form and YAML views` as `@smoke` it was caught failing in CI with two distinct errors:

1. **`#display-name` not found (20s timeout)** — the local `spaNavigate` function in `apiproduct-crud.spec.ts` was a duplicate of the one in `helpers.ts` but was missing the `waitForKuadrantPlugin` call. This meant SPA navigation could fire before the Kuadrant plugin had registered its routes, so the create form never mounted.

2. **Modal backdrop blocking tags button click (retry)** — the OpenShift console tour can re-trigger on the first visit to a plugin page. `dismissConsoleTour` was only called in `beforeEach` at `/`. On retry, the form loaded but the tour modal appeared mid-test and blocked subsequent clicks.

   `should sync between Form and YAML views` is the only test that performs a second `page.goto` in the test body (to set `activeNamespace` before SPA navigation). This full page reload resets the console's "first visit" state and can re-trigger the tour. Other smoke tests only have the `beforeEach` goto to `/`, so one `dismissConsoleTour` is sufficient and SPA navigation does not re-trigger the modal.

Fixed by importing `spaNavigate` from `helpers.ts` (which includes the Kuadrant plugin wait) instead of the local duplicate, and adding `dismissConsoleTour` after navigation in the yaml-sync test.

## Changes
- Replace `waitForLoadState('networkidle')` with `expect(locator).toBeVisible()` in 4 smoke tests
- Add `@smoke` tag to `should sync between Form and YAML views`
- Fix ambiguous `text=API key approval` locator to `getByRole('heading', { name: 'API Key approval' })`
- Modernize all `page.waitForSelector` calls to locator-based API
- Replace local `spaNavigate` (missing Kuadrant plugin wait) with the exported version from `helpers.ts`
- Import `navigateToAPIProducts` from `helpers.ts` instead of keeping a local duplicate
- Add `dismissConsoleTour` after navigation in `should sync between Form and YAML views` to handle late-appearing tour modals

## Testing
1. Run `npx playwright test --config=e2e/playwright.config.ts e2e/tests/apiproduct-crud.spec.ts`
2. Verify all 12 pass