### PR TITLE
test: verify status change after approve/reject actions

### DIFF
--- a/e2e/tests/apikey-approvals.spec.ts
+++ b/e2e/tests/apikey-approvals.spec.ts
@@ -155,6 +155,9 @@ EOF
       await expect(page.locator('.pf-v6-c-alert:has-text("approved successfully")')).toBeVisible({
         timeout: 30_000,
       });
+
+      const updatedAliceApproveRow = page.locator(`tr:has-text("${aliceEmail}")`);
+      await expect(updatedAliceApproveRow.locator('text=Active')).toBeVisible({ timeout: 10_000 });
     });
   });
 });
@@ -229,6 +232,9 @@ EOF
     await expect(page.locator('.pf-v6-c-alert:has-text("denied")')).toBeVisible({
       timeout: 30_000,
     });
+
+    const updatedBobRow = page.locator(`tr:has-text("${bobEmail}")`);
+    await expect(updatedBobRow.locator('text=Denied')).toBeVisible({ timeout: 10_000 });
   });
 });
 
@@ -302,6 +308,9 @@ EOF
     await expect(page.locator('.pf-v6-c-alert:has-text("denied")')).toBeVisible({
       timeout: 30_000,
     });
+
+    const updatedBob2Row = page.locator(`tr:has-text("${bob2Email}")`);
+    await expect(updatedBob2Row.locator('text=Denied')).toBeVisible({ timeout: 10_000 });
   });
 });
 
@@ -409,6 +418,9 @@ EOF
     await expect(page.locator('.pf-v6-c-alert:has-text("approved successfully")')).toBeVisible({
       timeout: 30_000,
     });
+
+    await expect(page.locator(`tr:has-text("${carolEmail}")`).locator('text=Active')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(`tr:has-text("${daveEmail}")`).locator('text=Active')).toBeVisible({ timeout: 10_000 });
   });
 });
 
@@ -516,6 +528,9 @@ EOF
     await expect(page.locator('.pf-v6-c-alert:has-text("denied")')).toBeVisible({
       timeout: 30_000,
     });
+
+    await expect(page.locator(`tr:has-text("${ellenEmail}")`).locator('text=Denied')).toBeVisible({ timeout: 10_000 });
+    await expect(page.locator(`tr:has-text("${frankEmail}")`).locator('text=Denied')).toBeVisible({ timeout: 10_000 });
   });
 });
 


### PR DESCRIPTION
## Description

Five tests in `apikey-approvals.spec.ts` only checked for a success toast but never verified that the row status actually changed in the UI. This meant the tests could pass even if the approval/rejection status update was broken.

Added status assertions after each toast following the pattern already established in `should deny an active API key`.

## Changes
- `approve single request` — assert row shows `Active` after approve
- `reject request with reason` — assert row shows `Denied` after reject
- `reject request without reason` — assert row shows `Denied` after reject
- `bulk approve` — assert carol and dave rows show `Active`
- `bulk reject` — assert ellen and frank rows show `Denied`

## Testing
1. Run `npx playwright test --config=e2e/playwright.config.ts e2e/tests/apikey-approvals.spec.ts`
2. Verify all 8 tests pass

Closes #581

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced approval and rejection workflow coverage by verifying that affected API key requests display the correct post-action status.
  * Added checks for `Active` and `Denied` statuses after individual and bulk actions.
  * Improved test reliability by removing unnecessary fixed delays from the denial workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->