### PR TITLE
Upgrade tar to 7.5.19 via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
   "resolutions": {
     "fast-uri": "^3.1.3",
     "follow-redirects": "^1.16.0",
+    "tar": "^7.5.19",
     "http-proxy-middleware": "2.0.7",
     "immutable": "3.8.3",
     "lodash": "4.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16956,16 +16956,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tar@npm:^7.5.2":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+"tar@npm:^7.5.19":
+  version: 7.5.19
+  resolution: "tar@npm:7.5.19"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
+  checksum: 10c0/7022e8cb04a8ceccc0689f2c731743fa2aab2e3c3f559f7dbc37b65ef7d5913049b427284eded2ec0765c5db5ff72dd7939fe2ae15785ff422cef2116c95d798
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Upgrade tar from 7.5.16 to 7.5.19 via a yarn resolution. Fixes two DoS vulnerabilities in node-tar:

- **CVE-2026-59874**: malformed tar archive header causes infinite loop (fixed in 7.5.18)
- **CVE-2026-59873**: missing decompression bounds enables gzip bomb DoS (fixed in 7.5.19)

tar is a transitive dependency. Adding a yarn resolution forces the patched version across all consumers.

## Changes

- `package.json`: add `"tar": "^7.5.19"` to resolutions
- `yarn.lock`: regenerated (tar 7.5.16 → 7.5.19)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated an underlying package version constraint to improve dependency consistency and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->