### PR TITLE
Upgrade brace-expansion to 5.0.7 via yarn resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "immutable": "3.8.3",
     "lodash": "4.18.0",
     "node-forge": "^1.3.2",
-    "qs": "6.14.1"
+    "qs": "6.14.1",
+    "brace-expansion@^5": "^5.0.7"
   },
   "devDependencies": {
     "@openshift-console/dynamic-plugin-sdk": "^1.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6150,30 +6150,30 @@ __metadata:
   linkType: hard
 
 "brace-expansion@npm:^1.1.7":
-  version: 1.1.15
-  resolution: "brace-expansion@npm:1.1.15"
+  version: 1.1.16
+  resolution: "brace-expansion@npm:1.1.16"
   dependencies:
     balanced-match: "npm:^1.0.0"
     concat-map: "npm:0.0.1"
-  checksum: 10c0/648e273f57cfa9ed67d8a77bdb15b408205465d33da9331808ee3c188d8b55674c9cdbf1f320b65bc562e485e1263360ae62ad355e128e0435891f6430e795d7
+  checksum: 10c0/b2a915bbedbf4e45840d1fb9a4d391bbf26a79475bd134714d3cee34f1f0edb0ce982738028843be5fbaf8039429f71fa487df8c915b6065ced542c83e58fae6
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^2.0.2":
-  version: 2.1.1
-  resolution: "brace-expansion@npm:2.1.1"
+  version: 2.1.2
+  resolution: "brace-expansion@npm:2.1.2"
   dependencies:
     balanced-match: "npm:^1.0.0"
-  checksum: 10c0/63b5ddce608b70b50a76817c0526faf8ea67a9180073d88bb402f6bbc22a22da6b1dfac4f65efc53e5faa80222fb7d44bbf2fc638c3f55365975573f671d0ccb
+  checksum: 10c0/5442ecab84045d21826268bc56c81a6ef4215327ee1f5ee153f67928e93f7a915d130ecec9966623143277fa3cce036ebb50020024bcc4d78853cdd6af9a19f8
   languageName: node
   linkType: hard
 
 "brace-expansion@npm:^5.0.5":
-  version: 5.0.5
-  resolution: "brace-expansion@npm:5.0.5"
+  version: 5.0.7
+  resolution: "brace-expansion@npm:5.0.7"
   dependencies:
     balanced-match: "npm:^4.0.2"
-  checksum: 10c0/4d238e14ed4f5cc9c07285550a41cef23121ca08ba99fa9eb5b55b580dcb6bf868b8210aa10526bdc9f8dc97f33ca2a7259039c4cc131a93042beddb424c48e3
+  checksum: 10c0/4769109c3c082de178e449a371bcad50d51ab468f644bce2dd9188efe0cf0a080ed102105d7fc8577382cedc45bad7e6443a91bf3d8102264ee8cf927dbaf205
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrade `brace-expansion` 5.x from 5.0.5 to 5.0.7 via a scoped yarn resolution
- Fixes exponential-time complexity DoS in the `expand()` function with consecutive non-expanding `{}` brace groups (CVSS 7.5)
- The 1.x and 2.x branches of `brace-expansion` are not affected by this resolution

## Test plan

- [ ] `yarn install` completes without errors
- [ ] `yarn build` succeeds
- [ ] `yarn test` passes