### PR TITLE
E2E suite router

### DIFF
--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -7,6 +7,11 @@ on:
         description: 'Test suite to run: smoke or full'
         required: true
         type: string
+      specs:
+        description: 'Space-separated spec file paths to run (empty = all)'
+        required: false
+        type: string
+        default: ''
 
 jobs:
   e2e-rbac:
@@ -69,7 +74,13 @@ jobs:
 
       - name: Run E2E tests (smoke)
         if: inputs.suite == 'smoke'
-        run: npx playwright test --config=e2e/playwright.config.ts --grep @smoke
+        run: |
+          SPEC_FILTER="${{ inputs.specs }}"
+          if [ -n "$SPEC_FILTER" ]; then
+            npx playwright test --config=e2e/playwright.config.ts --grep @smoke $SPEC_FILTER
+          else
+            npx playwright test --config=e2e/playwright.config.ts --grep @smoke
+          fi
 
       - name: Run E2E tests (full)
         if: inputs.suite == 'full'

--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -74,8 +74,9 @@ jobs:
 
       - name: Run E2E tests (smoke)
         if: inputs.suite == 'smoke'
+        env:
+          SPEC_FILTER: ${{ inputs.specs }}
         run: |
-          SPEC_FILTER="${{ inputs.specs }}"
           if [ -n "$SPEC_FILTER" ]; then
             npx playwright test --config=e2e/playwright.config.ts --grep @smoke $SPEC_FILTER
           else

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -14,12 +14,15 @@ concurrency:
 jobs:
   route:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     outputs:
       specs: ${{ steps.router.outputs.specs }}
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Run suite router
         id: router

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -12,7 +12,25 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  route:
+    runs-on: ubuntu-latest
+    outputs:
+      specs: ${{ steps.router.outputs.specs }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run suite router
+        id: router
+        run: |
+          chmod +x build/suite-router.sh
+          SPECS=$(bash build/suite-router.sh)
+          echo "specs=${SPECS}" >> $GITHUB_OUTPUT
+
   e2e-smoke:
+    needs: route
     uses: ./.github/workflows/e2e-common.yaml
     with:
       suite: smoke
+      specs: ${{ needs.route.outputs.specs }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -233,7 +233,7 @@ test('validate empty title shows error', { tag: '@nightly' }, async ({ page }) =
 ```
 
 **Rules:**
-- Every test must have exactly one tag (`@smoke` or `@nightly`) — untagged tests are skipped in both runs
+- Every test must have exactly one tag (`@smoke` or `@nightly`) — untagged tests are skipped in smoke runs but do run in nightly (full suite has no `--grep` filter)
 - When adding a new test, default to `@nightly`; only use `@smoke` for critical, reliable flows
 - When adding a new spec file, add it to the mapping in `build/suite-router.sh` (see below)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -217,6 +217,51 @@ E2E tests cover key workflows including:
 - Gateway and policy management
 - Topology visualization
 
+### E2E Test Tags
+
+Every test must be tagged with exactly one of:
+
+- **`@smoke`** — fast, critical path tests; run on every PR (~11 min total). Tag tests that cover the most important user flows and are reliable.
+- **`@nightly`** — slower or edge-case tests; run on a nightly schedule. Tag validation edge cases, duplicate coverage, and slower flows.
+
+```typescript
+// smoke — runs on every PR
+test('approve request', { tag: '@smoke' }, async ({ page }) => { ... })
+
+// nightly — runs on schedule only
+test('validate empty title shows error', { tag: '@nightly' }, async ({ page }) => { ... })
+```
+
+**Rules:**
+- Every test must have exactly one tag (`@smoke` or `@nightly`) — untagged tests are skipped in both runs
+- When adding a new test, default to `@nightly`; only use `@smoke` for critical, reliable flows
+- When adding a new spec file, add it to the mapping in `build/suite-router.sh` (see below)
+
+### Suite Router (`build/suite-router.sh`)
+
+The suite router maps changed source files to relevant e2e spec files so PRs only run tests for the components they touch.
+
+**How it works:**
+1. Runs `git diff origin/main...HEAD` to get the list of changed files
+2. If any **shared file** changed (`src/utils/`, `src/hooks/`, `src/constants/`, `e2e/tests/helpers.ts`, workflow files, etc.) → runs all `@smoke` tests (safe fallback)
+3. Otherwise, matches changed paths against `COMPONENT_MAP` → runs only the relevant spec files with `--grep @smoke`
+4. If no mapping matches → runs all `@smoke` tests (safe fallback)
+
+**Fallback behaviour:**
+
+| Changed files | Tests run |
+|---|---|
+| `src/components/apikey/` | 3 apikey spec files × @smoke |
+| `src/utils/` (shared) | all @smoke |
+| Unrecognised path | all @smoke |
+
+**When adding a new spec file**, update `COMPONENT_MAP` in `build/suite-router.sh`:
+```bash
+COMPONENT_MAP["^src/components/myfeature/"]="myfeature.spec.ts"
+```
+
+If you forget, the suite router falls back to running all smoke tests — no tests will be skipped incorrectly, but the optimisation won't apply.
+
 ## Important Notes
 
 1. **Real-time Updates**: Always use `useK8sWatchResource` instead of `k8sList` for resources that need to update automatically

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,9 +255,11 @@ The suite router maps changed source files to relevant e2e spec files so PRs onl
 | `src/utils/` (shared) | all @smoke |
 | Unrecognised path | all @smoke |
 
-**When adding a new spec file**, update `COMPONENT_MAP` in `build/suite-router.sh`:
+**When adding a new spec file**, add an `if` block in `build/suite-router.sh`:
 ```bash
-COMPONENT_MAP["^src/components/myfeature/"]="myfeature.spec.ts"
+if echo "$CHANGED" | grep -qE "^src/components/myfeature/"; then
+  SPECS="$SPECS myfeature.spec.ts"
+fi
 ```
 
 If you forget, the suite router falls back to running all smoke tests — no tests will be skipped incorrectly, but the optimisation won't apply.

--- a/build/suite-router.sh
+++ b/build/suite-router.sh
@@ -60,7 +60,7 @@ if echo "$CHANGED" | grep -qE "^src/components/apiproduct/(APIProductOverviewTab
 fi
 
 if echo "$CHANGED" | grep -qE "^src/components/apiproduct/"; then
-  SPECS="$SPECS apiproduct-crud.spec.ts apiproduct-overview-tab.spec.ts api-product-list.spec.ts"
+  SPECS="$SPECS apiproduct-crud.spec.ts apiproduct-overview-tab.spec.ts api-product-list.spec.ts apiproduct-rbac.spec.ts"
 fi
 
 if echo "$CHANGED" | grep -qE "^src/components/NoPermissionsView"; then

--- a/build/suite-router.sh
+++ b/build/suite-router.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# Maps changed source files to relevant e2e spec files.
+# Outputs space-separated spec paths relative to repo root, or empty string for full smoke fallback.
+# Compatible with bash 3.2+ (macOS default).
+
+set -euo pipefail
+
+SPEC_DIR="e2e/tests"
+
+# Get changed files — in CI GITHUB_BASE_REF is set; locally fall back to HEAD~1
+BASE="${GITHUB_BASE_REF:-main}"
+CHANGED=$(git diff --name-only "origin/${BASE}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
+
+if [ -z "$CHANGED" ]; then
+  echo ""
+  exit 0
+fi
+
+# Changes to these paths affect all tests → fall back to full smoke suite
+for pattern in \
+  "^src/utils/" \
+  "^src/hooks/" \
+  "^src/constants/" \
+  "^e2e/tests/helpers\.ts" \
+  "^e2e/manifests/" \
+  "^e2e/setup\.sh" \
+  "^e2e/teardown\.sh" \
+  "^scripts/" \
+  "^package\.json" \
+  "^yarn\.lock" \
+  "^\.github/workflows/"
+do
+  if echo "$CHANGED" | grep -qE "$pattern"; then
+    echo ""
+    exit 0
+  fi
+done
+
+# Collect matching spec files
+SPECS=""
+
+if echo "$CHANGED" | grep -qE "^src/components/apikey/"; then
+  SPECS="$SPECS apikey-lifecycle.spec.ts apikey-approvals.spec.ts apiproduct-apikeys-tab.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/apiproduct/APIProductsListPage"; then
+  SPECS="$SPECS api-product-list.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/apiproduct/APIProductAPIKeysTab"; then
+  SPECS="$SPECS apiproduct-apikeys-tab.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/apiproduct/APIProductDefinitionTab|^src/components/apiproduct/APIProductPoliciesTab"; then
+  SPECS="$SPECS apiproduct-details-tabs.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/apiproduct/(APIProductOverviewTab|ContactInfoEdit|PublishStatusEdit|DocumentationEdit|TagsEdit)"; then
+  SPECS="$SPECS apiproduct-overview-tab.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/apiproduct/"; then
+  SPECS="$SPECS apiproduct-crud.spec.ts apiproduct-overview-tab.spec.ts api-product-list.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/NoPermissionsView"; then
+  SPECS="$SPECS apiproduct-rbac.spec.ts rbac.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/(topology|gateway|KuadrantOverview|KuadrantPolicies|ResourceList|DropdownWithKebab)"; then
+  SPECS="$SPECS rbac.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/(dnspolicy|tlspolicy|ratelimitpolicy|authpolicy|httproute|issuer)/"; then
+  SPECS="$SPECS rbac.spec.ts"
+fi
+
+# No mapping matched → fall back to full smoke
+if [ -z "$SPECS" ]; then
+  echo ""
+  exit 0
+fi
+
+# Deduplicate and prefix with SPEC_DIR
+RESULT=$(echo "$SPECS" | tr ' ' '\n' | grep -v '^$' | sort -u | sed "s|^|${SPEC_DIR}/|" | tr '\n' ' ')
+echo "${RESULT% }"


### PR DESCRIPTION
## Description

Adds a changed-file inference suite router that maps source file changes to relevant e2e spec files. Instead of running all smoke tests on every PR (~11 min), the CI now detects which components changed and runs only the relevant spec files 

Fixes #587

## Type of change

- [ ] `[fix]` Bug fix
- [x] `[feat]` New feature
- [ ] `[refactor]` Refactor (no functional changes)
- [ ] `[test]` Test updates
- [ ] `[chore]` Dependency / config update

## Changes made

- Add `build/suite-router.sh` — bash script that maps changed source paths to relevant e2e spec files; outputs space-separated paths or empty string for full smoke fallback
- Add `route` job to `e2e.yaml` that runs the suite-router and passes its output to the smoke job
- Add optional `specs` input to `e2e-common.yaml` — if non-empty, runs only the specified spec files with `--grep @smoke`; falls back to all smoke tests when empty

## Test plan

- [x] Tested `build/suite-router.sh` locally — correct spec files returned for apikey component changes
- [x] Tested fallback — empty output for `src/utils/` and unknown paths
- [ ] Verified `route` job output in GitHub Actions

## Screenshots

i crated test pr in fork for show how its work

https://github.com/Anton-Fil/kuadrant-console-plugin/pull/5

<img width="2509" height="1242" alt="image" src="https://github.com/user-attachments/assets/055c95ca-6110-4c2b-aebf-da929ec2e310" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end smoke testing now selects only the relevant test specifications for each change, helping reduce validation time.
  * Changes affecting shared infrastructure or with no clear test mapping continue to run the complete smoke suite.
  * Nightly and full test runs remain unchanged.

* **Documentation**
  * Added guidance on assigning smoke and nightly tags to end-to-end tests.
  * Documented how test selection is determined for pull requests and how new tests should be registered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->