### PR TITLE
fix(e2e): fix apiproduct-crud intermittent failures

### DIFF
--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -7,6 +7,27 @@ async function navigateToAPIProductCreate(page: Page, namespace = 'kuadrant-test
   await dismissConsoleTour(page);
 }
 
+// Scroll through all pagination pages looking for a row matching `text`.
+// Retries up to `maxAttempts` times, waiting for the watch stream between pages.
+async function findRowWithPagination(page: Page, text: string, maxAttempts = 10): Promise<boolean> {
+  const row = page.locator(`tr:has-text("${text}")`);
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (await row.isVisible()) return true;
+    const nextBtn = page.locator('button[aria-label="Go to next page"]');
+    if ((await nextBtn.count()) > 0 && !(await nextBtn.isDisabled())) {
+      await nextBtn.click();
+      await page.waitForTimeout(500);
+    } else {
+      await page.waitForTimeout(1000);
+      const firstBtn = page.locator('button[aria-label="Go to first page"]');
+      if ((await firstBtn.count()) > 0) {
+        await firstBtn.click();
+        await page.waitForTimeout(500);
+      }
+    }
+  }
+  return false;
+}
 // Note: Tests rely on test-httproute HTTPRoute existing in the test namespace
 // This is created by applying e2e/manifests/test-apiproduct-fixtures.yaml before running tests
 
@@ -133,32 +154,9 @@ test.describe('APIProduct CRUD Operations', () => {
     });
 
     // The new product may land on any pagination page; iterate until found or exhausted.
-    await expect(page.locator('table').first()).toBeVisible({ timeout: 15000 });
-    const row = page.locator(`tr:has-text("${generatedResourceName}")`);
-
-    let found = false;
-    for (let attempt = 0; attempt < 10 && !found; attempt++) {
-      if (await row.isVisible()) {
-        found = true;
-        break;
-      }
-      const nextBtn = page.locator('button[aria-label="Go to next page"]');
-      if ((await nextBtn.count()) > 0 && !(await nextBtn.isDisabled())) {
-        await nextBtn.click();
-        await page.waitForTimeout(500);
-      } else {
-        // No further pages — wait for watch stream then retry from page 1
-        await page.waitForTimeout(1000);
-        const firstBtn = page.locator('button[aria-label="Go to first page"]');
-        if ((await firstBtn.count()) > 0) {
-          await firstBtn.click();
-          await page.waitForTimeout(500);
-        }
-      }
-    }
-    expect(found, `"${generatedResourceName}" not found in any page of the API Products list`).toBe(
-      true,
-    );
+    await expect(page.locator('table').first()).toBeVisible({ timeout: 10000 });
+    const found = await findRowWithPagination(page, generatedResourceName);
+    expect(found, `"${generatedResourceName}" not found in any page of the API Products list`).toBe(true);
   });
 
   test('should validate resource name format', { tag: '@nightly' }, async ({ page }) => {
@@ -498,11 +496,10 @@ EOF`, { stdio: 'inherit' });
     // Wait for table to load
     await expect(page.locator('table').first()).toBeVisible({ timeout: 10000 });
 
-    // Find the product row
+    // The new product may land on any pagination page; iterate until found or exhausted.
+    const found = await findRowWithPagination(page, testProductName);
+    expect(found, `"${testProductName}" not found in any page of the API Products list`).toBe(true);
     const row = page.locator(`tr:has-text("${testProductName}")`);
-
-    // Verify product exists
-    await expect(row).toBeVisible({ timeout: 10000 });
 
     // Navigate to K8s resource details page via product name link
     // (kebab menu column exists on list page but may be off-screen at test viewport width)


### PR DESCRIPTION
## Description

`should delete APIProduct with confirmation` was failing intermittently in CI. The resource row was looked up with a single `toBeVisible` call, which fails if the resource lands on a pagination page other than the first - which happens when other tests have already created products. The create test already had pagination retry logic; this PR extracts it into a `findRowWithPagination` helper and applies it to the delete test too. As a side effect, the retry loop (up to 10 attempts with 1s waits) also gives the OpenShift watch stream time to deliver the `kubectl apply` event before giving up.

## Changes

- Add `findRowWithPagination` helper that iterates through all pagination pages, waiting between attempts for the watch stream to deliver the event
- Use it in both the delete test (replacing the broken `toBeVisible` timeout) and the create test (deduplicating the existing inline loop)

Closes #626

## Testing

- All 12 `apiproduct-crud.spec.ts` tests pass locally with `workers: 3`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end coverage for API Product creation and deletion across paginated product lists.
  * Added more reliable validation that products can be found regardless of which page they appear on.
  * Enhanced deletion workflow checks by consistently locating the relevant product before confirmation steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->