### PR TITLE
fix: prevent status legend popover flicker on data refresh

### DIFF
--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -2,8 +2,44 @@ import { Page, expect } from '@playwright/test';
 
 const TEST_NAMESPACE = 'kuadrant-test';
 
+// the guided tour can render after dismissConsoleTour has returned (slow console
+// boot, retries). its backdrop blocks clicks and aria-hides the nav, so getByRole
+// waits never match. a locator handler dismisses the tour whenever it blocks a
+// later action or auto-retrying assertion. registration is per-page, idempotent.
+const tourHandlerPages = new WeakSet<Page>();
+
+async function registerTourDismissalHandler(page: Page): Promise<void> {
+  if (tourHandlerPages.has(page)) {
+    return;
+  }
+  tourHandlerPages.add(page);
+
+  // scoped to tour modals only (skip/get started buttons) so genuine dialogs
+  // such as delete confirmations are never dismissed
+  const tourModal = page
+    .locator('.pf-v6-c-modal-box, .pf-c-modal-box')
+    .filter({
+      has: page.locator(
+        'button:has-text("Skip"), button:has-text("Get started"), button:has-text("Launch tour")',
+      ),
+    })
+    .first();
+
+  await page.addLocatorHandler(tourModal, async (modal) => {
+    await modal
+      .locator(
+        'button:has-text("Skip"), button:has-text("Get started"), button[aria-label="Close"]',
+      )
+      .first()
+      .click({ timeout: 5_000 })
+      .catch(() => undefined);
+  });
+}
+
 // dismiss any console welcome/tour modals that block interaction
 export async function dismissConsoleTour(page: Page): Promise<void> {
+  await registerTourDismissalHandler(page);
+
   const backdrop = page.locator('.pf-v6-c-backdrop');
 
   try {
@@ -89,12 +125,19 @@ export async function stopImpersonation(page: Page): Promise<void> {
 
 // Wait for Kuadrant plugin to load by checking for sidebar menu item
 async function waitForKuadrantPlugin(page: Page): Promise<void> {
-  await page.getByRole('button', { name: 'Kuadrant', exact: true }).waitFor({ state: 'visible', timeout: 30_000 });
+  // expect rather than waitFor: locator handlers only run before actions and
+  // auto-retrying assertion checks, so a late tour modal (which aria-hides the
+  // nav) can be dismissed while this wait is in progress
+  await expect(page.getByRole('button', { name: 'Kuadrant', exact: true })).toBeVisible({
+    timeout: 30_000,
+  });
 }
 
 // SPA navigation using pushState - preserves redux state (including impersonation)
 // page.goto() causes a full reload which destroys impersonation state
 export async function spaNavigate(page: Page, path: string): Promise<void> {
+  await registerTourDismissalHandler(page);
+
   // Wait for plugin to be ready before navigating to plugin routes
   await waitForKuadrantPlugin(page);
 

--- a/src/components/KuadrantOverviewPage.test.tsx
+++ b/src/components/KuadrantOverviewPage.test.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import '@testing-library/jest-dom';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatusLegend, ErrorCodeLabel, Distribution } from './KuadrantOverviewPage';
+
+jest.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    // key passthrough with basic {{var}} interpolation
+    t: (key: string, opts?: Record<string, unknown>) =>
+      opts ? key.replace(/{{(\w+)}}/g, (_, name) => String(opts[name])) : key,
+  }),
+}));
+
+// regression tests for #631: popovers must survive parent re-renders
+// triggered by background data refreshes
+
+describe('StatusLegend', () => {
+  it('keeps the popover open across parent re-renders', async () => {
+    const Wrapper: React.FC<{ tick: number }> = ({ tick }) => (
+      <div data-tick={tick}>
+        <StatusLegend />
+      </div>
+    );
+    const { rerender } = render(<Wrapper tick={0} />);
+
+    fireEvent.mouseEnter(screen.getByLabelText('Status help'));
+    expect(await screen.findByText('Enforced')).toBeInTheDocument();
+
+    rerender(<Wrapper tick={1} />);
+
+    expect(screen.getByText('Enforced')).toBeInTheDocument();
+  });
+});
+
+describe('ErrorCodeLabel', () => {
+  const initialDistribution: Array<[string, Distribution]> = [
+    ['404', { total: 3, percent: 75 }],
+    ['403', { total: 1, percent: 25 }],
+  ];
+  const updatedDistribution: Array<[string, Distribution]> = [
+    ['404', { total: 6, percent: 60 }],
+    ['410', { total: 4, percent: 40 }],
+  ];
+
+  it('keeps the popover open and shows refreshed data across parent re-renders', async () => {
+    const Wrapper: React.FC<{ distribution: Array<[string, Distribution]> }> = ({
+      distribution,
+    }) => (
+      <div>
+        <ErrorCodeLabel codeGroup="4xx" distribution={distribution} />
+      </div>
+    );
+    const { rerender } = render(<Wrapper distribution={initialDistribution} />);
+
+    fireEvent.click(screen.getByText(/4xx/));
+    expect(await screen.findByText('Error Code')).toBeInTheDocument();
+    expect(screen.getByText('Code: 404')).toBeInTheDocument();
+    expect(screen.getByText('3 requests')).toBeInTheDocument();
+    expect(screen.getByText('Code: 403')).toBeInTheDocument();
+
+    rerender(<Wrapper distribution={updatedDistribution} />);
+
+    expect(screen.getByText('Error Code')).toBeInTheDocument();
+    expect(screen.getByText('6 requests')).toBeInTheDocument();
+    expect(screen.getByText('Code: 410')).toBeInTheDocument();
+    expect(screen.queryByText('Code: 403')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -109,6 +109,156 @@ interface Gateway extends K8sResourceCommon {
   };
 }
 
+// module scope: components defined inside a render function get a new identity
+// on every re-render, remounting and flickering open popovers (#631)
+export const StatusLegend: React.FC = () => {
+  const { t } = useTranslation('plugin__kuadrant-console-plugin');
+  return (
+    <Popover
+      headerContent={t('Status')}
+      bodyContent={
+        <>
+          <Content component={ContentVariants.p}>
+            {t(
+              'It indicates the current operational state of the Gateway and reflects whether its configuration is applied and functioning correctly.',
+            )}
+          </Content>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: 'auto 1fr',
+              columnGap: 8,
+              rowGap: 8,
+              alignItems: 'center',
+              justifyItems: 'start',
+            }}
+          >
+            <Label isCompact color="green" icon={<CheckCircleIcon />}>
+              {' '}
+              {t('Enforced')}{' '}
+            </Label>
+            <span style={{ fontSize: 12 }}>
+              {t('Resource is accepted, configured, and all policies are enforced.')}
+            </span>
+
+            <Label isCompact color="purple" icon={<UploadIcon />}>
+              {' '}
+              {t('Accepted ')}{' '}
+            </Label>
+            <span style={{ fontSize: 12 }}>
+              {t('Resource is accepted, but not all policies are enforced.')}
+            </span>
+
+            <Label isCompact color="blue" icon={<BuildIcon />}>
+              {' '}
+              {t('Programmed')}{' '}
+            </Label>
+            <span style={{ fontSize: 12 }}>
+              {t('Resource is being configured but not yet enforced.')}
+            </span>
+
+            <Label isCompact color="red" icon={<ExclamationCircleIcon />}>
+              {' '}
+              {t('Conflicted')}{' '}
+            </Label>
+            <span style={{ fontSize: 12 }}>
+              {t('Resource has conflicts, possibly due to policies or configuration issues.')}
+            </span>
+
+            <Label isCompact color="red" icon={<ExclamationCircleIcon />}>
+              {' '}
+              {t('Resolved')}{' '}
+            </Label>
+            <span style={{ fontSize: 12 }}>
+              {t('All dependencies for the policy are successfully resolved.')}
+            </span>
+          </div>
+        </>
+      }
+      triggerAction="hover"
+      position="top"
+    >
+      <QuestionCircleIcon style={{ marginLeft: 6, cursor: 'help' }} aria-label="Status help" />
+    </Popover>
+  );
+};
+
+export interface Distribution {
+  total: number;
+  percent: number;
+}
+
+export const ErrorCodeLabel: React.FC<{
+  codeGroup: string;
+  distribution: Array<[string, Distribution]>;
+}> = ({ codeGroup, distribution }) => {
+  const { t } = useTranslation('plugin__kuadrant-console-plugin');
+  const [isOpen, setIsOpen] = React.useState(false);
+  let lastCode = '';
+  return (
+    <Popover
+      className="kuadrant-custom-rounded-popover"
+      headerContent={t('Error Code')}
+      bodyContent={
+        <>
+          <Content component={ContentVariants.p}>
+            {t('Displays the distribution of error codes for request failures.')}
+          </Content>
+          <div className="kuadrant-popover-codes">
+            {distribution.map(([code, dist]) => {
+              lastCode = code;
+              return (
+                <div key={code} style={{ marginBottom: '8px' }}>
+                  <Progress
+                    value={dist.percent}
+                    title={
+                      <Flex
+                        justifyContent={{ default: 'justifyContentSpaceBetween' }}
+                        alignItems={{ default: 'alignItemsCenter' }}
+                      >
+                        <FlexItem>
+                          <strong>{t('Code: {{code}}', { code })}</strong>
+                        </FlexItem>
+                        <FlexItem align={{ default: 'alignRight' }}>
+                          {dist.total.toFixed(0) === '1'
+                            ? t('1 request')
+                            : t('{{value}} requests', { value: dist.total.toFixed(0) })}
+                        </FlexItem>
+                      </Flex>
+                    }
+                    measureLocation={ProgressMeasureLocation.outside}
+                  />
+                  <Divider style={{ margin: '12px 0' }} />
+                </div>
+              );
+            })}
+          </div>
+        </>
+      }
+      footerContent={
+        <>
+          <span>{t('Last 24h overview')}</span>
+        </>
+      }
+      isVisible={isOpen}
+      shouldClose={() => setIsOpen(false)}
+      position="top"
+    >
+      <Label
+        variant="outline"
+        onClick={() => setIsOpen(!isOpen)}
+        style={{
+          marginRight: '0.5em',
+          textDecoration: 'underline',
+          textDecorationStyle: 'dotted',
+        }}
+      >
+        &nbsp;{distribution.length === 1 ? lastCode : codeGroup}&nbsp;
+      </Label>
+    </Popover>
+  );
+};
+
 const KuadrantOverviewPage: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
@@ -226,77 +376,6 @@ const KuadrantOverviewPage: React.FC = () => {
     setHideCard(true);
     sessionStorage.setItem('hideGettingStarted', 'true');
     setIsGettingStartedMenuOpen(false);
-  };
-
-  const StatusLegend: React.FC = () => {
-    return (
-      <Popover
-        headerContent={t('Status')}
-        bodyContent={
-          <>
-            <Content component={ContentVariants.p}>
-              {t(
-                'It indicates the current operational state of the Gateway and reflects whether its configuration is applied and functioning correctly.',
-              )}
-            </Content>
-            <div
-              style={{
-                display: 'grid',
-                gridTemplateColumns: 'auto 1fr',
-                columnGap: 8,
-                rowGap: 8,
-                alignItems: 'center',
-                justifyItems: 'start',
-              }}
-            >
-              <Label isCompact color="green" icon={<CheckCircleIcon />}>
-                {' '}
-                {t('Enforced')}{' '}
-              </Label>
-              <span style={{ fontSize: 12 }}>
-                {t('Resource is accepted, configured, and all policies are enforced.')}
-              </span>
-
-              <Label isCompact color="purple" icon={<UploadIcon />}>
-                {' '}
-                {t('Accepted ')}{' '}
-              </Label>
-              <span style={{ fontSize: 12 }}>
-                {t('Resource is accepted, but not all policies are enforced.')}
-              </span>
-
-              <Label isCompact color="blue" icon={<BuildIcon />}>
-                {' '}
-                {t('Programmed')}{' '}
-              </Label>
-              <span style={{ fontSize: 12 }}>
-                {t('Resource is being configured but not yet enforced.')}
-              </span>
-
-              <Label isCompact color="red" icon={<ExclamationCircleIcon />}>
-                {' '}
-                {t('Conflicted')}{' '}
-              </Label>
-              <span style={{ fontSize: 12 }}>
-                {t('Resource has conflicts, possibly due to policies or configuration issues.')}
-              </span>
-
-              <Label isCompact color="red" icon={<ExclamationCircleIcon />}>
-                {' '}
-                {t('Resolved')}{' '}
-              </Label>
-              <span style={{ fontSize: 12 }}>
-                {t('All dependencies for the policy are successfully resolved.')}
-              </span>
-            </div>
-          </>
-        }
-        triggerAction="hover"
-        position="top"
-      >
-        <QuestionCircleIcon style={{ marginLeft: 6, cursor: 'help' }} aria-label="Status help" />
-      </Popover>
-    );
   };
 
   const columns = [
@@ -516,10 +595,6 @@ const KuadrantOverviewPage: React.FC = () => {
   };
 
   // Metrics columns rendering
-  interface Distribution {
-    total: number;
-    percent: number;
-  }
   const getErrorCodeDistribution = (
     obj: { metadata: { namespace: string; name: string } },
     prefix: string,
@@ -549,77 +624,6 @@ const KuadrantOverviewPage: React.FC = () => {
 
     return sortedDistribution;
   };
-  const ErrorCodeLabel: React.FC<{
-    obj: { metadata: { namespace: string; name: string } };
-    codeGroup: string;
-  }> = ({ obj, codeGroup }) => {
-    const [isOpen, setIsOpen] = React.useState(false);
-    const distribution = getErrorCodeDistribution(obj, codeGroup[0]);
-    let lastCode = '';
-    return (
-      <Popover
-        className="kuadrant-custom-rounded-popover"
-        headerContent={t('Error Code')}
-        bodyContent={
-          <>
-            <Content component={ContentVariants.p}>
-              {t('Displays the distribution of error codes for request failures.')}
-            </Content>
-            <div className="kuadrant-popover-codes">
-              {distribution.map(([code, dist]) => {
-                lastCode = code;
-                return (
-                  <div key={code} style={{ marginBottom: '8px' }}>
-                    <Progress
-                      value={dist.percent}
-                      title={
-                        <Flex
-                          justifyContent={{ default: 'justifyContentSpaceBetween' }}
-                          alignItems={{ default: 'alignItemsCenter' }}
-                        >
-                          <FlexItem>
-                            <strong>{t('Code: {{code}}', { code })}</strong>
-                          </FlexItem>
-                          <FlexItem align={{ default: 'alignRight' }}>
-                            {dist.total.toFixed(0) === '1'
-                              ? t('1 request')
-                              : t('{{value}} requests', { value: dist.total.toFixed(0) })}
-                          </FlexItem>
-                        </Flex>
-                      }
-                      measureLocation={ProgressMeasureLocation.outside}
-                    />
-                    <Divider style={{ margin: '12px 0' }} />
-                  </div>
-                );
-              })}
-            </div>
-          </>
-        }
-        footerContent={
-          <>
-            <span>{t('Last 24h overview')}</span>
-          </>
-        }
-        isVisible={isOpen}
-        shouldClose={() => setIsOpen(false)}
-        position="top"
-      >
-        <Label
-          variant="outline"
-          onClick={() => setIsOpen(!isOpen)}
-          style={{
-            marginRight: '0.5em',
-            textDecoration: 'underline',
-            textDecorationStyle: 'dotted',
-          }}
-        >
-          &nbsp;{distribution.length === 1 ? lastCode : codeGroup}&nbsp;
-        </Label>
-      </Popover>
-    );
-  };
-
   const gatewayTrafficRenders = {
     totalRequests: (column, obj, activeColumnIDs) => {
       return (
@@ -652,7 +656,13 @@ const KuadrantOverviewPage: React.FC = () => {
             </Label>
           ) : (
             errorCodes.map((code) => {
-              return <ErrorCodeLabel key={code} obj={obj} codeGroup={code} />;
+              return (
+                <ErrorCodeLabel
+                  key={code}
+                  codeGroup={code}
+                  distribution={getErrorCodeDistribution(obj, code[0])}
+                />
+              );
             })
           )}
         </TableData>


### PR DESCRIPTION
## Summary

- `StatusLegend` and `ErrorCodeLabel` were defined inside `KuadrantOverviewPage`'s render function, giving them a new component identity on every `useK8sWatchResource`/metrics refresh. React remounted them each time, flickering the status legend popover mid-hover and resetting `ErrorCodeLabel`'s open state.
- Moved both to module scope (each calls `useTranslation` itself; `ErrorCodeLabel` now takes the error code distribution as a prop). Behaviour otherwise unchanged; the large diff in `KuadrantOverviewPage.tsx` is indentation shift from the move (`git diff -w` shows the real delta).
- Added regression tests asserting both popovers stay open across parent re-renders, and that `ErrorCodeLabel` reflects updated distribution data while open.
- Second commit hardens e2e helpers against the console guided tour appearing after `dismissConsoleTour` returns (aria-hides the nav, times out navigation waits): a `page.addLocatorHandler` scoped to tour modals now dismisses it whenever it blocks a wait. Complements the pagination fix from #630.

## Test evidence

- `yarn test`: 14 suites / 120 tests pass (2 new)
- `yarn lint`: clean
- `yarn build`: compiles
- e2e: helpers change exercised in CI (tour handler fired correctly on the previous run's retry)

Closes #631

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented status and error-code popovers from closing or flickering when overview data refreshes.
  - Updated error-code popovers to display refreshed distribution data accurately, including newly added and removed codes.
  - Improved navigation reliability when guided-tour prompts appear during page loading.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->