### PR TITLE
test: add @smoke/@nightly tags and suite-router mapping for topology,…

### DIFF
--- a/build/suite-router.sh
+++ b/build/suite-router.sh
@@ -67,11 +67,23 @@ if echo "$CHANGED" | grep -qE "^src/components/NoPermissionsView"; then
   SPECS="$SPECS apiproduct-rbac.spec.ts rbac.spec.ts"
 fi
 
-if echo "$CHANGED" | grep -qE "^src/components/(topology|gateway|KuadrantOverview|KuadrantPolicies|ResourceList|DropdownWithKebab)"; then
-  SPECS="$SPECS rbac.spec.ts"
+if echo "$CHANGED" | grep -qE "^src/components/topology/"; then
+  SPECS="$SPECS topology.spec.ts rbac.spec.ts"
 fi
 
-if echo "$CHANGED" | grep -qE "^src/components/(dnspolicy|tlspolicy|ratelimitpolicy|authpolicy|httproute|issuer)/"; then
+if echo "$CHANGED" | grep -qE "^src/components/(gateway|KuadrantOverview|KuadrantPolicies|ResourceList|DropdownWithKebab)"; then
+  SPECS="$SPECS overview.spec.ts rbac.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/(dnspolicy|tlspolicy)/"; then
+  SPECS="$SPECS policy-forms.spec.ts rbac.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/(ratelimitpolicy|authpolicy)/"; then
+  SPECS="$SPECS policy-forms.spec.ts rbac.spec.ts"
+fi
+
+if echo "$CHANGED" | grep -qE "^src/components/(httproute|issuer)/"; then
   SPECS="$SPECS rbac.spec.ts"
 fi
 

--- a/e2e/tests/overview.spec.ts
+++ b/e2e/tests/overview.spec.ts
@@ -18,7 +18,7 @@ test.describe('Overview dashboard', () => {
     await waitForPermissionsLoaded(page);
   });
 
-  test('renders the dashboard cards', async ({ page }) => {
+  test('renders the dashboard cards', { tag: '@smoke' }, async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Kuadrant Overview' })).toBeVisible({
       timeout: 15_000,
     });
@@ -31,7 +31,7 @@ test.describe('Overview dashboard', () => {
     await expect(page.getByRole('heading', { name: 'GRPCRoutes', exact: true })).toBeVisible();
   });
 
-  test('gateway summary shows health stats', async ({ page }) => {
+  test('gateway summary shows health stats', { tag: '@smoke' }, async ({ page }) => {
     await expect(page.locator('span:text-is("Total Gateways")')).toBeVisible({
       timeout: 15_000,
     });
@@ -45,7 +45,7 @@ test.describe('Overview dashboard', () => {
     await expect(totalCount).toHaveText(/^[1-9]\d*$/, { timeout: 15_000 });
   });
 
-  test('traffic analysis card lists gateways with metric columns', async ({ page }) => {
+  test('traffic analysis card lists gateways with metric columns', { tag: '@nightly' }, async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Gateways - Traffic Analysis' })).toBeVisible({
       timeout: 15_000,
     });
@@ -59,14 +59,14 @@ test.describe('Overview dashboard', () => {
     });
   });
 
-  test('policies card lists fixture policies', async ({ page }) => {
+  test('policies card lists fixture policies', { tag: '@smoke' }, async ({ page }) => {
     await expect(page.locator('a[data-test="test-auth-policy"]').first()).toBeVisible({
       timeout: 15_000,
     });
     await expect(page.locator('a[data-test="test-plan-policy"]').first()).toBeVisible();
   });
 
-  test('navigates to gateway details from the traffic analysis card', async ({ page }) => {
+  test('navigates to gateway details from the traffic analysis card', { tag: '@smoke' }, async ({ page }) => {
     const gatewayLink = page.locator('a[data-test="test-gateway"]').first();
     await expect(gatewayLink).toBeVisible({ timeout: 15_000 });
     await gatewayLink.click();
@@ -77,7 +77,7 @@ test.describe('Overview dashboard', () => {
     );
   });
 
-  test('navigates to policy details from the policies card', async ({ page }) => {
+  test('navigates to policy details from the policies card', { tag: '@smoke' }, async ({ page }) => {
     const policyLink = page.locator('a[data-test="test-auth-policy"]').first();
     await expect(policyLink).toBeVisible({ timeout: 15_000 });
     await policyLink.click();
@@ -88,7 +88,7 @@ test.describe('Overview dashboard', () => {
     );
   });
 
-  test('navigates to HTTPRoute details from the routes card', async ({ page }) => {
+  test('navigates to HTTPRoute details from the routes card', { tag: '@smoke' }, async ({ page }) => {
     const routeLink = page.locator('a[data-test="test-route"]').first();
     await expect(routeLink).toBeVisible({ timeout: 15_000 });
     await routeLink.click();

--- a/e2e/tests/overview.spec.ts
+++ b/e2e/tests/overview.spec.ts
@@ -23,7 +23,7 @@ test.describe('Overview dashboard', () => {
       timeout: 15_000,
     });
 
-    await expect(page.locator('text=Getting started resources')).toBeVisible();
+    await expect(page.locator('text=Getting started with')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Gateways', exact: true })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Gateways - Traffic Analysis' })).toBeVisible();
     await expect(page.getByRole('heading', { name: 'Policies', exact: true })).toBeVisible();

--- a/e2e/tests/policy-forms.spec.ts
+++ b/e2e/tests/policy-forms.spec.ts
@@ -59,7 +59,7 @@ async function gotoPage(page: Page, path: string): Promise<void> {
 const createPagePath = (namespace: string, gvk: string) => `/k8s/ns/${namespace}/${gvk}/~new`;
 
 test.describe('DNSPolicy form', () => {
-  test('create form renders with required fields', async ({ page }) => {
+  test('create form renders with required fields', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~DNSPolicy'));
 
     await expect(page.getByRole('heading', { name: 'Create DNS Policy' })).toBeVisible({
@@ -77,7 +77,7 @@ test.describe('DNSPolicy form', () => {
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
   });
 
-  test('create button enables only when required fields are set', async ({ page }) => {
+  test('create button enables only when required fields are set', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~DNSPolicy'));
 
     const createButton = page.getByRole('button', { name: 'Create', exact: true });
@@ -117,7 +117,7 @@ test.describe('DNSPolicy form', () => {
       deleteNamespace(namespace);
     });
 
-    test('creates a DNSPolicy via the form', async ({ page }) => {
+    test('creates a DNSPolicy via the form', { tag: '@smoke' }, async ({ page }) => {
       const policyName = `e2e-dns-${uid()}`;
       await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~DNSPolicy'));
 
@@ -150,7 +150,7 @@ test.describe('DNSPolicy form', () => {
       });
     });
 
-    test('edits an existing DNSPolicy (name immutable, provider ref persisted)', async ({
+    test('edits an existing DNSPolicy (name immutable, provider ref persisted)', { tag: '@smoke' }, async ({
       page,
     }) => {
       const policyName = `e2e-dns-${uid()}`;
@@ -208,7 +208,7 @@ spec:
 });
 
 test.describe('TLSPolicy form', () => {
-  test('create form renders with required fields', async ({ page }) => {
+  test('create form renders with required fields', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~TLSPolicy'));
 
     await expect(page.getByRole('heading', { name: 'Create TLS Policy' })).toBeVisible({
@@ -226,7 +226,7 @@ test.describe('TLSPolicy form', () => {
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
   });
 
-  test('create button enables only when required fields are set', async ({ page }) => {
+  test('create button enables only when required fields are set', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~TLSPolicy'));
 
     const createButton = page.getByRole('button', { name: 'Create', exact: true });
@@ -264,7 +264,7 @@ test.describe('TLSPolicy form', () => {
       deleteNamespace(namespace);
     });
 
-    test('creates a TLSPolicy via the form', async ({ page }) => {
+    test('creates a TLSPolicy via the form', { tag: '@smoke' }, async ({ page }) => {
       const policyName = `e2e-tls-${uid()}`;
       await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~TLSPolicy'));
 
@@ -304,7 +304,7 @@ test.describe('TLSPolicy form', () => {
       ).toBe('test-selfsigned');
     });
 
-    test('edits an existing TLSPolicy (retarget gateway persisted)', async ({ page }) => {
+    test('edits an existing TLSPolicy (retarget gateway persisted)', { tag: '@smoke' }, async ({ page }) => {
       const policyName = `e2e-tls-${uid()}`;
       const secondGateway = `e2e-gw-b-${uid()}`;
       applyManifest(gatewayManifest(secondGateway, namespace));
@@ -384,7 +384,7 @@ test.describe('YAML-based policy create pages', () => {
     );
   }
 
-  test('AuthPolicy create page renders YAML editor with example resource', async ({ page }) => {
+  test('AuthPolicy create page renders YAML editor with example resource', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~AuthPolicy'));
 
     await expect(page.locator('text=Create AuthPolicy').first()).toBeVisible({ timeout: 15_000 });
@@ -393,7 +393,7 @@ test.describe('YAML-based policy create pages', () => {
     await expect(page.getByRole('button', { name: 'Cancel' })).toBeVisible();
   });
 
-  test('RateLimitPolicy create page renders YAML editor with example resource', async ({
+  test('RateLimitPolicy create page renders YAML editor with example resource', { tag: '@smoke' }, async ({
     page,
   }) => {
     await gotoPage(page, createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1~RateLimitPolicy'));
@@ -417,7 +417,7 @@ test.describe('YAML-based policy create pages', () => {
       deleteNamespace(namespace);
     });
 
-    test('creates an AuthPolicy from the default YAML', async ({ page }) => {
+    test('creates an AuthPolicy from the default YAML', { tag: '@smoke' }, async ({ page }) => {
       await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~AuthPolicy'));
 
       await expect(page.locator('text=Create AuthPolicy').first()).toBeVisible({
@@ -435,7 +435,7 @@ test.describe('YAML-based policy create pages', () => {
         .toBe(true);
     });
 
-    test('creates a RateLimitPolicy from the default YAML', async ({ page }) => {
+    test('creates a RateLimitPolicy from the default YAML', { tag: '@smoke' }, async ({ page }) => {
       await gotoPage(page, createPagePath(namespace, 'kuadrant.io~v1~RateLimitPolicy'));
 
       await expect(page.locator('text=Create RateLimit Policy').first()).toBeVisible({
@@ -455,7 +455,7 @@ test.describe('YAML-based policy create pages', () => {
 });
 
 test.describe('other policy create pages render', () => {
-  test('OIDCPolicy create form renders', async ({ page }) => {
+  test('OIDCPolicy create form renders', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(
       page,
       createPagePath(TEST_NAMESPACE, 'extensions.kuadrant.io~v1alpha1~OIDCPolicy'),
@@ -469,7 +469,7 @@ test.describe('other policy create pages render', () => {
     await expect(page.locator('#issuer-url')).toBeVisible();
   });
 
-  test('PlanPolicy create page renders YAML editor', async ({ page }) => {
+  test('PlanPolicy create page renders YAML editor', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(
       page,
       createPagePath(TEST_NAMESPACE, 'extensions.kuadrant.io~v1alpha1~PlanPolicy'),
@@ -481,7 +481,7 @@ test.describe('other policy create pages render', () => {
     await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 15_000 });
   });
 
-  test('TokenRateLimitPolicy create page renders YAML editor', async ({ page }) => {
+  test('TokenRateLimitPolicy create page renders YAML editor', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(
       page,
       createPagePath(TEST_NAMESPACE, 'kuadrant.io~v1alpha1~TokenRateLimitPolicy'),
@@ -495,7 +495,7 @@ test.describe('other policy create pages render', () => {
 });
 
 test.describe('policies page create dropdown', () => {
-  test('lists all policy types and navigates to the DNSPolicy form', async ({ page }) => {
+  test('lists all policy types and navigates to the DNSPolicy form', { tag: '@smoke' }, async ({ page }) => {
     await gotoPage(page, `/kuadrant/policies/ns/${TEST_NAMESPACE}`);
 
     const createButton = page.locator('button:has-text("Create Policy")');

--- a/e2e/tests/policy-forms.spec.ts
+++ b/e2e/tests/policy-forms.spec.ts
@@ -490,6 +490,7 @@ test.describe('other policy create pages render', () => {
     await expect(page.locator('text=Create TokenRateLimit Policy').first()).toBeVisible({
       timeout: 15_000,
     });
+    await page.locator('#create-type-radio-yaml').click();
     await expect(page.locator('.monaco-editor').first()).toBeVisible({ timeout: 15_000 });
   });
 });

--- a/e2e/tests/topology.spec.ts
+++ b/e2e/tests/topology.spec.ts
@@ -45,12 +45,12 @@ test.describe('Policy Topology', () => {
     await expect(page.getByRole('button', { name: 'Fit to Screen' })).toBeVisible();
 
     // fixture gateway and route nodes are rendered by default
-    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL).first()).toBeVisible({ timeout: 20_000 });
     await expect.poll(() => page.locator(NODE_SELECTOR).count()).toBeGreaterThan(1);
   });
 
   test('filters nodes by resource type', { tag: '@smoke' }, async ({ page }) => {
-    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL).first()).toBeVisible({ timeout: 20_000 });
 
     // deselect Gateway (selected by default)
     await openResourceFilter(page);
@@ -59,7 +59,7 @@ test.describe('Policy Topology', () => {
 
     await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeHidden({ timeout: 15_000 });
     // other resource types remain visible
-    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible();
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL).first()).toBeVisible();
 
     // reselect Gateway restores the nodes
     await openResourceFilter(page);
@@ -93,7 +93,7 @@ test.describe('Policy Topology', () => {
     // only kuadrant-test resources and their connected infrastructure remain
     await expect(nodeByLabel(page, SECOND_GATEWAY_NODE_LABEL)).toBeHidden({ timeout: 15_000 });
     await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible();
-    await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible();
+    await expect(nodeByLabel(page, ROUTE_NODE_LABEL).first()).toBeVisible();
   });
 
   test('node context menu navigates to the resource details page', { tag: '@smoke' }, async ({ page }) => {

--- a/e2e/tests/topology.spec.ts
+++ b/e2e/tests/topology.spec.ts
@@ -35,7 +35,7 @@ test.describe('Policy Topology', () => {
     await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
   });
 
-  test('renders the topology graph with fixture resources', async ({ page }) => {
+  test('renders the topology graph with fixture resources', { tag: '@smoke' }, async ({ page }) => {
     await expect(page.getByRole('heading', { name: 'Policy Topology' })).toBeVisible();
 
     // filter toolbar and control bar are present
@@ -49,7 +49,7 @@ test.describe('Policy Topology', () => {
     await expect.poll(() => page.locator(NODE_SELECTOR).count()).toBeGreaterThan(1);
   });
 
-  test('filters nodes by resource type', async ({ page }) => {
+  test('filters nodes by resource type', { tag: '@smoke' }, async ({ page }) => {
     await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
 
     // deselect Gateway (selected by default)
@@ -69,7 +69,7 @@ test.describe('Policy Topology', () => {
     await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 15_000 });
   });
 
-  test('clearing all resource filters empties the graph', async ({ page }) => {
+  test('clearing all resource filters empties the graph', { tag: '@nightly' }, async ({ page }) => {
     // remove the whole Resource filter group via its close button
     await page.getByRole('button', { name: /close label group resource/i }).click();
 
@@ -83,7 +83,7 @@ test.describe('Policy Topology', () => {
     await expect(nodeByLabel(page, GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 15_000 });
   });
 
-  test('filters nodes by namespace', async ({ page }) => {
+  test('filters nodes by namespace', { tag: '@smoke' }, async ({ page }) => {
     // both fixture gateways visible before filtering
     await expect(nodeByLabel(page, SECOND_GATEWAY_NODE_LABEL)).toBeVisible({ timeout: 20_000 });
 
@@ -96,7 +96,7 @@ test.describe('Policy Topology', () => {
     await expect(nodeByLabel(page, ROUTE_NODE_LABEL)).toBeVisible();
   });
 
-  test('node context menu navigates to the resource details page', async ({ page }) => {
+  test('node context menu navigates to the resource details page', { tag: '@smoke' }, async ({ page }) => {
     const gatewayNode = nodeByLabel(page, GATEWAY_NODE_LABEL);
     await gatewayNode.click({ button: 'right' });
 


### PR DESCRIPTION
## Description

Adds `@smoke`/`@nightly` tags to three new spec files added by @jasonmadigan and updates `build/suite-router.sh` to map their source components.

Fixes #634

## Type of change

- [ ] `[fix]` Bug fix
- [ ] `[feat]` New feature
- [ ] `[refactor]` Refactor (no functional changes)
- [x] `[test]` Test updates
- [ ] `[chore]` Dependency / config update

## Changes made

- Tag all tests in `e2e/tests/topology.spec.ts` — 4 `@smoke`, 1 `@nightly`
- Tag all tests in `e2e/tests/overview.spec.ts` — 6 `@smoke`, 1 `@nightly`
- Tag all tests in `e2e/tests/policy-forms.spec.ts` — 16 `@smoke`
- Update `build/suite-router.sh` — add mappings for `topology/`, `KuadrantOverview/`, `dnspolicy/`, `tlspolicy/`, `ratelimitpolicy/`, `authpolicy/` → relevant spec files


## Test plan

- [x] Tags verified by reading each test — no untagged tests remain in the three files
- [x] Suite-router mapping tested locally


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added explicit `@smoke` and `@nightly` tag metadata across Overview, policy-form, and topology end-to-end scenarios.
  - Updated a few assertions/locators to better match expected text and ensure node visibility is scoped consistently.
  - Enhanced a TokenRateLimitPolicy YAML editor case by switching to YAML mode before checking the editor.

- **Test Suite Selection**
  - Refined how component-change paths map to the most relevant e2e spec files, adding more targeted coverage beyond the prior fallback behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->