### PR TITLE
ci: run e2e on PRs targeting release branches

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -2,7 +2,7 @@ name: E2E Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
   merge_group:
     types: [checks_requested]
   workflow_dispatch:


### PR DESCRIPTION
## Summary

- The repo ruleset requires the `e2e-smoke / e2e-rbac` status check on `release-*` branches as well as `main`, but this workflow only triggered on PRs targeting `main`. PRs against release branches never run e2e, so they sit blocked on an "Expected" check that never starts (currently biting #646).
- Widens the `pull_request` trigger to `[main, 'release-*']` so branches cut from `main` run e2e on their PRs.

Note: this does not retroactively fix `release-0.4`, whose `e2e.yaml` predates the `e2e-smoke`/`e2e-common` structure.

## Test evidence

- `yq '.on.pull_request.branches'` parses the workflow and returns `[main, 'release-*']`
- Trigger change only, no job changes

Relates to #646


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * End-to-end checks now run for pull requests targeting both the `main` branch and `release-*` branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->