### PR TITLE
ci: run nightly tests for changed components and add spec map coverag…

### DIFF
--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -12,6 +12,11 @@ on:
         required: false
         type: string
         default: ''
+      test_specs:
+        description: 'Space-separated spec file paths that changed directly (run all tags)'
+        required: false
+        type: string
+        default: ''
     outputs:
       failure-type:
         description: 'Type of failure: none, infrastructure, or test'
@@ -82,7 +87,7 @@ jobs:
 
       - name: Run E2E tests (smoke)
         id: tests
-        if: inputs.suite == 'smoke'
+        if: inputs.suite == 'smoke' && (inputs.specs != '' || inputs.test_specs == '')
         env:
           SPEC_FILTER: ${{ inputs.specs }}
         run: |
@@ -91,6 +96,13 @@ jobs:
           else
             npx playwright test --config=e2e/playwright.config.ts --grep @smoke
           fi
+
+      - name: Run E2E tests (changed test files, all tags)
+        id: tests-changed
+        if: inputs.suite == 'smoke' && inputs.test_specs != ''
+        env:
+          TEST_SPEC_FILTER: ${{ inputs.test_specs }}
+        run: npx playwright test --config=e2e/playwright.config.ts $TEST_SPEC_FILTER
 
       - name: Run E2E tests (full)
         id: tests-full
@@ -103,7 +115,7 @@ jobs:
         run: |
           if [[ "${{ steps.setup.outcome }}" == "failure" || "${{ steps.wait-server.outcome }}" == "failure" ]]; then
             echo "type=infrastructure" >> "$GITHUB_OUTPUT"
-          elif [[ "${{ steps.tests.outcome }}" == "failure" || "${{ steps.tests-full.outcome }}" == "failure" ]]; then
+          elif [[ "${{ steps.tests.outcome }}" == "failure" || "${{ steps.tests-full.outcome }}" == "failure" || "${{ steps.tests-changed.outcome }}" == "failure" ]]; then
             echo "type=test" >> "$GITHUB_OUTPUT"
           else
             echo "type=none" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -18,6 +18,7 @@ jobs:
       contents: read
     outputs:
       specs: ${{ steps.router.outputs.specs }}
+      test_specs: ${{ steps.router.outputs.test_specs }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -28,8 +29,18 @@ jobs:
         id: router
         run: |
           chmod +x build/suite-router.sh
-          SPECS=$(bash build/suite-router.sh)
-          echo "specs=${SPECS}" >> $GITHUB_OUTPUT
+          bash build/suite-router.sh >> $GITHUB_OUTPUT
+
+  check-spec-map:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Validate spec map coverage
+        run: bash build/check-spec-map.sh
 
   e2e-smoke:
     needs: route
@@ -37,3 +48,4 @@ jobs:
     with:
       suite: smoke
       specs: ${{ needs.route.outputs.specs }}
+      test_specs: ${{ needs.route.outputs.test_specs }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -242,24 +242,43 @@ test('validate empty title shows error', { tag: '@nightly' }, async ({ page }) =
 The suite router maps changed source files to relevant e2e spec files so PRs only run tests for the components they touch.
 
 **How it works:**
+
+The router emits two separate lists and CI runs them with different filters:
+
+1. **`specs`** — spec files mapped from changed source components → always run with `--grep @smoke`
+2. **`test_specs`** — spec files that were directly edited → run without `--grep @smoke` (all tags: `@smoke` + `@nightly`)
+
+Steps:
 1. Runs `git diff origin/main...HEAD` to get the list of changed files
 2. If any **shared file** changed (`src/utils/`, `src/hooks/`, `src/constants/`, `e2e/tests/helpers.ts`, workflow files, etc.) → runs all `@smoke` tests (safe fallback)
-3. Otherwise, matches changed paths against `COMPONENT_MAP` → runs only the relevant spec files with `--grep @smoke`
-4. If no mapping matches → runs all `@smoke` tests (safe fallback)
+3. Matches changed component paths against the mapping → populates `specs`
+4. Detects any directly edited `e2e/tests/*.spec.ts` files → populates `test_specs`
+5. Files in both lists are removed from `specs` (to avoid running the same file twice)
+6. If both lists are empty → runs all `@smoke` tests (safe fallback)
 
-**Fallback behaviour:**
+**Behaviour by scenario:**
 
-| Changed files | Tests run |
-|---|---|
-| `src/components/apikey/` | 3 apikey spec files × @smoke |
-| `src/utils/` (shared) | all @smoke |
-| Unrecognised path | all @smoke |
+| Changed files | `specs` | `test_specs` | Tests run |
+|---|---|---|---|
+| `src/components/apikey/` | 3 apikey files | — | 3 files × @smoke only |
+| `e2e/tests/apikey-lifecycle.spec.ts` | — | 1 file | all tags in that file |
+| both above | 2 apikey files | 1 file | 2 files × @smoke + 1 file × all tags |
+| `src/utils/` (shared) | — | — | all @smoke (fallback) |
+| Unrecognised path | — | — | all @smoke (fallback) |
 
-**When adding a new spec file**, add an `if` block in `build/suite-router.sh`:
+**When adding a new spec file** you must do two things:
+
+1. Add an `if` block in `build/suite-router.sh` to map the relevant component:
 ```bash
 if echo "$CHANGED" | grep -qE "^src/components/myfeature/"; then
   SPECS="$SPECS myfeature.spec.ts"
 fi
+```
+
+2. Run `yarn check:spec-map` locally to verify the mapping is complete — CI will also block the PR if any spec file is missing from the mapping:
+```bash
+yarn check:spec-map
+# all specs mapped ✓
 ```
 
 If you forget, the suite router falls back to running all smoke tests — no tests will be skipped incorrectly, but the optimisation won't apply.

--- a/build/check-spec-map.sh
+++ b/build/check-spec-map.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SPECS=$(ls e2e/tests/*.spec.ts | xargs -n1 basename | LC_ALL=C sort)
+[ -n "$SPECS" ] || { echo "error: no spec files found in e2e/tests/"; exit 1; }
+
+MAPPED=$(grep -oE '[a-z0-9-]+\.spec\.ts' build/suite-router.sh | LC_ALL=C sort -u)
+
+MISSING=$(comm -23 <(echo "$SPECS") <(echo "$MAPPED"))
+
+if [ -n "$MISSING" ]; then
+  echo "some spec not mapped in suite-router.sh:"
+  echo "$MISSING"
+  exit 1
+fi
+
+echo "all specs mapped"

--- a/build/suite-router.sh
+++ b/build/suite-router.sh
@@ -12,7 +12,8 @@ BASE="${GITHUB_BASE_REF:-main}"
 CHANGED=$(git diff --name-only "origin/${BASE}...HEAD" 2>/dev/null || git diff --name-only HEAD~1 2>/dev/null || echo "")
 
 if [ -z "$CHANGED" ]; then
-  echo ""
+  echo "specs="
+  echo "test_specs="
   exit 0
 fi
 
@@ -31,7 +32,8 @@ for pattern in \
   "^\.github/workflows/"
 do
   if echo "$CHANGED" | grep -qE "$pattern"; then
-    echo ""
+    echo "specs="
+    echo "test_specs="
     exit 0
   fi
 done
@@ -87,12 +89,41 @@ if echo "$CHANGED" | grep -qE "^src/components/(httproute|issuer)/"; then
   SPECS="$SPECS rbac.spec.ts"
 fi
 
-# No mapping matched → fall back to full smoke
-if [ -z "$SPECS" ]; then
-  echo ""
+# Detect test files that changed → run all tags (smoke + nightly) for those files only
+TEST_SPECS=""
+CHANGED_SPECS=$(echo "$CHANGED" | grep -E "^e2e/tests/[a-z0-9-]+\.spec\.ts$" || true)
+if [ -n "$CHANGED_SPECS" ]; then
+  for spec_path in $CHANGED_SPECS; do
+    TEST_SPECS="$TEST_SPECS $(basename "$spec_path")"
+  done
+fi
+
+# No component mapping matched and no test files changed → fall back to full smoke
+if [ -z "$SPECS" ] && [ -z "$TEST_SPECS" ]; then
+  echo "specs="
+  echo "test_specs="
   exit 0
 fi
 
-# Deduplicate and prefix with SPEC_DIR
-RESULT=$(echo "$SPECS" | tr ' ' '\n' | grep -v '^$' | sort -u | sed "s|^|${SPEC_DIR}/|" | tr '\n' ' ')
-echo "${RESULT% }"
+# Remove from SPECS any files already in TEST_SPECS (they will run unfiltered in step 2)
+if [ -n "$TEST_SPECS" ]; then
+  for test_spec in $TEST_SPECS; do
+    SPECS=$(echo "$SPECS" | tr ' ' '\n' | grep -v "^${test_spec}$" | tr '\n' ' ')
+  done
+fi
+
+# Deduplicate component specs and prefix with SPEC_DIR
+if [ -n "$(echo "$SPECS" | tr -d ' ')" ]; then
+  RESULT=$(echo "$SPECS" | tr ' ' '\n' | grep -v '^$' | sort -u | sed "s|^|${SPEC_DIR}/|" | tr '\n' ' ')
+  echo "specs=${RESULT% }"
+else
+  echo "specs="
+fi
+
+# Deduplicate test specs and prefix with SPEC_DIR
+if [ -n "$TEST_SPECS" ]; then
+  TEST_RESULT=$(echo "$TEST_SPECS" | tr ' ' '\n' | grep -v '^$' | sort -u | sed "s|^|${SPEC_DIR}/|" | tr '\n' ' ')
+  echo "test_specs=${TEST_RESULT% }"
+else
+  echo "test_specs="
+fi

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "lint": "yarn eslint src --fix && stylelint 'src/**/*.css' --allow-empty-input --fix",
     "test": "jest",
     "test:e2e": "npx playwright test --config=e2e/playwright.config.ts",
+    "check:spec-map": "bash build/check-spec-map.sh",
     "test:e2e:setup": "./e2e/setup.sh",
     "test:e2e:teardown": "./e2e/teardown.sh",
     "webpack": "node -r ts-node/register ./node_modules/.bin/webpack",


### PR DESCRIPTION
## Description

Improves the e2e suite-router in three ways:

1. **Two-list routing** — the router now emits two separate spec lists (`specs` for component-mapped files, `test_specs` for directly edited test files) and runs them as two separate Playwright invocations with different filters. Component changes still gate on `@smoke` only. Directly edited test files run all tags (`@smoke` + `@nightly`) so developers can verify nightly test fixes in a PR without waiting for the next scheduled run.

2. **Spec map coverage check** — adds `build/check-spec-map.sh` and a `check-spec-map` CI job that blocks PRs if a new spec file is added without a corresponding entry in `suite-router.sh`. Also available locally via `yarn check:spec-map`.

3. **CLAUDE.md updated** — documents the new two-list behaviour, scenarios table, and the rule that new spec files must be added to the mapping.

Closes #657 

## Type of change

- [x] `[feat]` New feature

## Changes made

- `build/suite-router.sh` — emits `specs` and `test_specs` outputs; deduplicates files between lists
- `build/check-spec-map.sh` — validates all spec files are mapped in suite-router.sh
- `.github/workflows/e2e.yaml` — adds `check-spec-map` job; passes both outputs to `e2e-smoke`
- `.github/workflows/e2e-common.yaml` — adds `test_specs` input; two separate Playwright run steps
- `package.json` — adds `yarn check:spec-map` command
- `CLAUDE.md` — documents new routing behaviour and spec map rules

## Behaviour after this change

| Changed files | Tests run |
|---|---|
| `src/components/apikey/` | 3 apikey spec files × @smoke |
| `e2e/tests/apikey-lifecycle.spec.ts` | all 4 tests (smoke + nightly) |
| both above | 2 files × @smoke + 1 file × all tags |
| `src/utils/` (shared) | all @smoke (fallback) |
| New spec file without mapping | CI blocks PR |

## Test runs in fork

- Two-list routing (component + test file): https://github.com/Anton-Fil/kuadrant-console-plugin/pull/11
- Test file only (all tags): https://github.com/Anton-Fil/kuadrant-console-plugin/pull/12
- Spec map check (unmapped file blocks PR): https://github.com/Anton-Fil/kuadrant-console-plugin/pull/13

## Test plan

- [x] `yarn check:spec-map` passes locally
- [x] All three scenarios verified in fork CI

## Checklist

- [x] No `console.log` statements left in
- [x] Commits include `Signed-off-by` line (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - End-to-end test runs can now target changed test files while covering all applicable tags.
  - Test selection automatically separates component-related tests from directly changed test specifications and avoids duplicate runs.
- **Bug Fixes**
  - Improved test failure reporting for newly targeted test runs.
- **Documentation**
  - Expanded guidance explaining test selection scenarios and how to verify specification mappings.
- **Chores**
  - Added a validation command to identify unmapped end-to-end test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->