### PR TITLE
fix: wire clearAllFilters in API Product list toolbar

### DIFF
--- a/e2e/tests/api-product-list.spec.ts
+++ b/e2e/tests/api-product-list.spec.ts
@@ -5,6 +5,7 @@ import {
   waitForPermissionsLoaded,
   navigateToAPIProducts,
   dismissConsoleTour,
+  findRowWithPagination,
 } from './helpers';
 
 test.describe('APIProduct List Page - Display and Filters', () => {
@@ -49,20 +50,16 @@ test.describe('APIProduct List Page - Display and Filters', () => {
     for (const row of await page.locator('[data-test-rows="resource-row"]').all())
       await expect(row).toBeVisible({ timeout: 15_000 });
 
-    // Verify our test API Products are displayed
-    await expect(
-      page.locator('div.kuadrant-resource-table a:has-text("gamestore-api")'),
-    ).toBeVisible({ timeout: 10_000 });
-    await expect(page.locator('div.kuadrant-resource-table a:has-text("payment-api")')).toBeVisible(
-      { timeout: 10_000 },
-    );
-    await expect(page.locator('div.kuadrant-resource-table a:has-text("draft-api")')).toBeVisible({
-      timeout: 10_000,
-    });
+    // Verify our test API Products are displayed (paginating if needed)
+    expect(await findRowWithPagination(page, 'gamestore-api')).toBe(true);
+    expect(await findRowWithPagination(page, 'payment-api')).toBe(true);
+    expect(await findRowWithPagination(page, 'draft-api')).toBe(true);
 
-    // Verify we have at least 4 API Products
-    const rows = await page.locator('tbody tr[data-key]').all();
-    expect(rows.length).toBeGreaterThan(4);
+    // Verify we have more than 4 API Products total (check pagination text)
+    await expect(page.locator('.pf-v6-c-pagination')).toBeVisible();
+    const paginationText = await page.locator('.pf-v6-c-pagination__nav-page-select').textContent();
+    const totalPages = parseInt(paginationText?.match(/of\s+(\d+)/)?.[1] ?? '1');
+    expect(totalPages).toBeGreaterThan(1);
   });
 
   test('displays correct status labels', { tag: '@nightly' }, async ({ page }) => {
@@ -127,8 +124,8 @@ test.describe('APIProduct List Page - Status Filter', () => {
   test('filters by Published status', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
-    // Wait for initial data to load
-    await expect(page.locator('a:has-text("draft-api")')).toBeVisible({ timeout: 15_000 });
+    // Wait for initial data to load (paginating if needed)
+    expect(await findRowWithPagination(page, 'draft-api')).toBe(true);
 
     // Open status filter dropdown
     const statusToggle = page
@@ -218,8 +215,8 @@ test.describe('APIProduct List Page - Status Filter', () => {
     // Wait for filter to clear
     await page.waitForTimeout(1000);
 
-    // Verify all products are shown again
-    await expect(page.locator('a:has-text("draft-api")')).toBeVisible();
+    // Verify all products are shown again (paginating if needed)
+    expect(await findRowWithPagination(page, 'draft-api')).toBe(true);
 
     // Verify filter label is gone
     await expect(filterLabel).not.toBeVisible();
@@ -268,8 +265,8 @@ test.describe('APIProduct List Page - Name Filter', () => {
   test('filters by name (case insensitive)', { tag: '@nightly' }, async ({ page }) => {
     await waitForPermissionsLoaded(page);
 
-    // Wait for initial data to load
-    await expect(page.locator('a:has-text("payment-api")')).toBeVisible({ timeout: 15_000 });
+    // Wait for initial data to load (paginating if needed)
+    expect(await findRowWithPagination(page, 'payment-api')).toBe(true);
 
     // Type uppercase into search input
     const searchInput = page.locator('input[aria-label="Resource search"]');
@@ -318,10 +315,10 @@ test.describe('APIProduct List Page - Name Filter', () => {
     await searchInput.clear();
     await page.waitForTimeout(1000);
 
-    // Verify all products are shown again
-    await expect(page.locator('a:has-text("draft-api")')).toBeVisible();
-    await expect(page.locator('a:has-text("gamestore-api")')).toBeVisible();
-    await expect(page.locator('a:has-text("payment-api")')).toBeVisible();
+    // Verify all products are shown again (paginating if needed)
+    expect(await findRowWithPagination(page, 'draft-api')).toBe(true);
+    expect(await findRowWithPagination(page, 'gamestore-api')).toBe(true);
+    expect(await findRowWithPagination(page, 'payment-api')).toBe(true);
   });
 });
 
@@ -383,7 +380,7 @@ test.describe('APIProduct List Page - Namespace Filter', () => {
     await namespaceOption.click();
 
     // Type into search input
-    const searchInput = page.locator('input#composite-filter-search-by-input');
+    const searchInput = page.locator('input[aria-label="Resource search"]');
     await searchInput.fill('kuadrant-test');
     await page.waitForTimeout(1000);
 
@@ -411,7 +408,7 @@ test.describe('APIProduct List Page - Namespace Filter', () => {
     );
     await namespaceOption.click();
 
-    const searchInput = page.locator('input#composite-filter-search-by-input');
+    const searchInput = page.locator('input[aria-label="Resource search"]');
     await searchInput.fill('somenamespace');
     await page.waitForTimeout(1000);
 
@@ -612,7 +609,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Apply name filter (partial match "store")
-    const searchInput = page.locator('input#composite-filter-search-by-input');
+    const searchInput = page.locator('input[aria-label="Resource search"]');
     await searchInput.fill('store');
     await page.waitForTimeout(1000);
 
@@ -658,7 +655,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await namespaceOption.click();
 
     // Apply namespace filter
-    const searchInput = page.locator('input#composite-filter-search-by-input');
+    const searchInput = page.locator('input[aria-label="Resource search"]');
     await searchInput.fill('kuadrant-test');
     await page.waitForTimeout(1000);
 
@@ -731,12 +728,50 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Apply name filter that won't match the draft product
-    const searchInput = page.locator('input#composite-filter-search-by-input');
+    const searchInput = page.locator('input[aria-label="Resource search"]');
     await searchInput.fill('nonexistent');
     await page.waitForTimeout(1000);
 
     // Verify empty state is shown
     await expect(page.locator('text=No API Products found')).toBeVisible();
     await expect(page.locator('text=No API Products match the filter criteria.')).toBeVisible();
+  });
+
+  test('clear all filters restores full list', { tag: '@nightly' }, async ({ page }) => {
+    await waitForPermissionsLoaded(page);
+
+    // Wait for initial data to load
+    await expect(page.locator('a:has-text("gamestore-api")')).toBeVisible({ timeout: 15_000 });
+
+    // Apply status filter (Published)
+    const statusToggle = page
+      .locator('button#status-filter-menu-toggle:has-text("Status")')
+      .first();
+    await statusToggle.click();
+    const publishedOption = page.locator(
+      'ul#status-filter-select-list [role="menuitem"]:has-text("Published")',
+    );
+    await publishedOption.click();
+    await page.waitForTimeout(500);
+
+    // Apply name filter
+    const searchInput = page.locator('input[aria-label="Resource search"]');
+    await searchInput.fill('game');
+    await page.waitForTimeout(500);
+
+    // Verify both filter chips are shown
+    await expect(page.locator('.pf-m-outline:has-text("Published")')).toBeVisible();
+    await expect(page.locator('.pf-m-outline:has-text("game")')).toBeVisible();
+
+    // Click "Clear all filters"
+    await page.locator('button:has-text("Clear all filters")').click();
+    await page.waitForTimeout(1000);
+
+    // Verify filter chips are gone
+    await expect(page.locator('.pf-m-outline:has-text("Published")')).not.toBeVisible();
+    await expect(page.locator('.pf-m-outline:has-text("game")')).not.toBeVisible();
+
+    // Verify full list restored (draft-api visible, paginating if needed)
+    expect(await findRowWithPagination(page, 'draft-api')).toBe(true);
   });
 });

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -1,33 +1,12 @@
 import { test, expect, Page } from '@playwright/test';
 import { execSync } from 'child_process';
-import { TEST_NAMESPACE, dismissConsoleTour, spaNavigate, navigateToAPIProducts } from './helpers';
+import { TEST_NAMESPACE, dismissConsoleTour, spaNavigate, navigateToAPIProducts, findRowWithPagination } from './helpers';
 
 async function navigateToAPIProductCreate(page: Page, namespace = 'kuadrant-test'): Promise<void> {
   await spaNavigate(page, `/kuadrant/apiproducts/ns/${namespace}/~new`);
   await dismissConsoleTour(page);
 }
 
-// Scroll through all pagination pages looking for a row matching `text`.
-// Retries up to `maxAttempts` times, waiting for the watch stream between pages.
-async function findRowWithPagination(page: Page, text: string, maxAttempts = 10): Promise<boolean> {
-  const row = page.locator(`tr:has-text("${text}")`);
-  for (let attempt = 0; attempt < maxAttempts; attempt++) {
-    if (await row.isVisible()) return true;
-    const nextBtn = page.locator('button[aria-label="Go to next page"]');
-    if ((await nextBtn.count()) > 0 && !(await nextBtn.isDisabled())) {
-      await nextBtn.click();
-      await page.waitForTimeout(500);
-    } else {
-      await page.waitForTimeout(1000);
-      const firstBtn = page.locator('button[aria-label="Go to first page"]');
-      if ((await firstBtn.count()) > 0) {
-        await firstBtn.click();
-        await page.waitForTimeout(500);
-      }
-    }
-  }
-  return false;
-}
 // Note: Tests rely on test-httproute HTTPRoute existing in the test namespace
 // This is created by applying e2e/manifests/test-apiproduct-fixtures.yaml before running tests
 

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -148,6 +148,28 @@ export async function spaNavigate(page: Page, path: string): Promise<void> {
   await page.waitForLoadState('networkidle');
 }
 
+// Scroll through all pagination pages looking for a row matching `text`.
+// Retries up to `maxAttempts` times, waiting for the watch stream between pages.
+export async function findRowWithPagination(page: Page, text: string, maxAttempts = 10): Promise<boolean> {
+  const row = page.locator(`tr:has-text("${text}")`);
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (await row.isVisible()) return true;
+    const nextBtn = page.locator('button[aria-label="Go to next page"]');
+    if ((await nextBtn.count()) > 0 && !(await nextBtn.isDisabled())) {
+      await nextBtn.click();
+      await page.waitForTimeout(500);
+    } else {
+      await page.waitForTimeout(1000);
+      const firstBtn = page.locator('button[aria-label="Go to first page"]');
+      if ((await firstBtn.count()) > 0 && !(await firstBtn.isDisabled())) {
+        await firstBtn.click();
+        await page.waitForTimeout(500);
+      }
+    }
+  }
+  return false;
+}
+
 export async function navigateToPolicies(page: Page): Promise<void> {
   await spaNavigate(page, `/kuadrant/policies/ns/${TEST_NAMESPACE}`);
 }

--- a/src/components/apiproduct/APIProductsListPage.tsx
+++ b/src/components/apiproduct/APIProductsListPage.tsx
@@ -20,7 +20,7 @@ import {
   MenuToggleElement,
   Popper,
   InputGroup,
-  TextInput,
+  SearchInput,
   Pagination,
   EmptyState,
   EmptyStateBody,
@@ -696,7 +696,15 @@ const APIProductsListPage: React.FC = () => {
             </AlertGroup>
           )}
           <ListPageBody>
-            <Toolbar>
+            <Toolbar
+              clearAllFilters={() => {
+                setSelectedStatuses([]);
+                setNameFilter('');
+                setNamespaceFilter('');
+                setSelectedHTTPRoutes([]);
+                setCurrentPage(1);
+              }}
+            >
               <ToolbarContent>
                 <ToolbarGroup variant="filter-group">
                   <ToolbarFilter
@@ -871,14 +879,14 @@ const APIProductsListPage: React.FC = () => {
                         />
                       </div>
                     ) : (
-                      <TextInput
-                        type="text"
+                      <SearchInput
                         id="composite-filter-search-by-input"
                         placeholder={t('Search by {{filterValue}}...', {
                           filterValue: filterLabels[filterSelected],
                         })}
                         value={filterSelected === 'name' ? nameFilter : namespaceFilter}
                         onChange={(_event, value) => handleFilterChange(value)}
+                        onClear={() => handleFilterChange('')}
                         aria-label={t('Resource search')}
                       />
                     )}


### PR DESCRIPTION
## Description
Wires the `clearAllFilters` prop on the `Toolbar` component in the API Product list page so that clicking "Clear all filters" actually resets all active filters (status, name, namespace, HTTPRoute) and returns to page 1.

Also switches `TextInput` to `SearchInput` to provide a built-in clear button on the name/namespace filter input.

## Changes
- Wire `clearAllFilters` callback on `Toolbar` in `APIProductsListPage`
- Replace `TextInput` with `SearchInput` for name/namespace filter input
- Export `findRowWithPagination` helper to `helpers.ts` for reuse across specs
- Update `api-product-list.spec.ts` to use pagination-aware assertions and updated locators

## Testing
- All 23 `api-product-list` e2e tests pass
- Manually verified "Clear all filters" restores the full list

```bash
npx playwright test --config=e2e/playwright.config.ts e2e/tests/api-product-list.spec.ts
```

Closes #662

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a clear-all option to reset all API product filters and return to the first page.
  - Added a dedicated clear action for name and namespace searches.

- **Bug Fixes**
  - Improved API product filtering to use the resource search control consistently.
  - Updated product list checks to work reliably across multiple pages.
  - Improved handling of empty results when combined filters return no matches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->