### PR TITLE
Type-to-confirm APIProduct Actions Menu

### DIFF
--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -496,31 +496,19 @@ EOF`, { stdio: 'inherit' });
     await expect(deleteItem).toBeVisible({ timeout: 5000 });
     await deleteItem.click();
 
-    // K8s delete modal should appear - look for visible delete button in modal
-    // Use >> to pierce shadow DOM if needed
+    // Type-to-confirm delete modal should appear
+    const confirmInput = page.locator('#confirm-delete');
+    await expect(confirmInput).toBeVisible({ timeout: 10000 });
+
+    // Type the resource name to enable the Delete button
+    await confirmInput.fill(testProductName);
+
     const deleteButton = page
-      .locator('button')
+      .locator('[role="dialog"] button')
       .filter({ hasText: 'Delete' })
-      .and(
-        page.locator('[role="dialog"] button, .pf-v6-c-modal-box button, .pf-c-modal-box button'),
-      );
-
-    // If that doesn't work, just find any visible Delete button
-    const fallbackButton = page.locator('button:has-text("Delete")').first();
-
-    // Try primary selector first
-    const buttonToClick = (await deleteButton.count()) > 0 ? deleteButton.first() : fallbackButton;
-
-    await expect(buttonToClick).toBeVisible({ timeout: 10000 });
-
-    // May need to check a confirmation checkbox first
-    const checkbox = page.locator('[role="dialog"] input[type="checkbox"]').first();
-    if ((await checkbox.count()) > 0 && (await checkbox.isVisible())) {
-      await checkbox.check();
-    }
-
-    await expect(buttonToClick).toBeEnabled({ timeout: 5000 });
-    await buttonToClick.click();
+      .first();
+    await expect(deleteButton).toBeEnabled({ timeout: 5000 });
+    await deleteButton.click();
 
     // Verify product removed from list (navigate to list if not there already)
     if (!page.url().includes('/apiproducts/ns/')) {

--- a/src/components/apiproduct/APIProductDeleteModal.tsx
+++ b/src/components/apiproduct/APIProductDeleteModal.tsx
@@ -19,12 +19,14 @@ import '../kuadrant.css';
 interface APIProductDeleteModalProps {
   isOpen: boolean;
   onClose: () => void;
+  onDeleteSuccess?: () => void;
   resource: K8sResourceCommon;
 }
 
 const APIProductDeleteModal: React.FC<APIProductDeleteModalProps> = ({
   isOpen,
   onClose,
+  onDeleteSuccess,
   resource,
 }) => {
   const { t } = useTranslation('plugin__kuadrant-console-plugin');
@@ -45,10 +47,13 @@ const APIProductDeleteModal: React.FC<APIProductDeleteModalProps> = ({
         model,
         resource,
       });
-      onClose();
+      if (onDeleteSuccess) {
+        onDeleteSuccess();
+      } else {
+        onClose();
+      }
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to delete APIProduct');
-    } finally {
       setIsDeleting(false);
     }
   };

--- a/src/components/apiproduct/useAPIProductActions.tsx
+++ b/src/components/apiproduct/useAPIProductActions.tsx
@@ -10,9 +10,30 @@ import {
 import { AccessReviewResourceAttributes } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/console-types';
 import {
   useAnnotationsModal,
-  useDeleteModal,
   useLabelsModal,
+  useModal,
 } from '@openshift-console/dynamic-plugin-sdk';
+import APIProductDeleteModal from './APIProductDeleteModal';
+
+const APIProductDeleteModalWrapper: React.FC<{
+  closeModal: () => void;
+  resource: K8sResourceCommon;
+}> = ({ closeModal, resource }) => {
+  const navigate = useNavigate();
+
+  return (
+    <APIProductDeleteModal
+      isOpen={true}
+      onClose={closeModal}
+      onDeleteSuccess={() => {
+        const namespace = resource.metadata?.namespace || 'default';
+        closeModal();
+        navigate(`/kuadrant/apiproducts/ns/${namespace}`);
+      }}
+      resource={resource}
+    />
+  );
+};
 
 const useAPIProductActions = (obj: K8sResourceCommon): ExtensionHookResult<Action[]> => {
   const navigate = useNavigate();
@@ -22,7 +43,7 @@ const useAPIProductActions = (obj: K8sResourceCommon): ExtensionHookResult<Actio
       ? { group: gvk.group, version: gvk.version, kind: gvk.kind }
       : { group: '', version: '', kind: '' },
   );
-  const launchDeleteModal = useDeleteModal(obj);
+  const launchModal = useModal();
   const launchLabelsModal = useLabelsModal(obj);
   const launchAnnotationsModal = useAnnotationsModal(obj);
 
@@ -77,20 +98,13 @@ const useAPIProductActions = (obj: K8sResourceCommon): ExtensionHookResult<Actio
       {
         id: 'delete-apiproduct',
         label: 'Delete APIProduct',
-        cta: launchDeleteModal,
+        cta: () => launchModal(APIProductDeleteModalWrapper, { resource: obj }),
         accessReview: deleteAccess,
       },
     ];
 
     return actionsList;
-  }, [
-    navigate,
-    obj,
-    apiProductModel,
-    launchAnnotationsModal,
-    launchDeleteModal,
-    launchLabelsModal,
-  ]);
+  }, [navigate, obj, apiProductModel, launchAnnotationsModal, launchModal, launchLabelsModal]);
 
   return [actions, true, undefined];
 };


### PR DESCRIPTION
## Description

  - APIProduct detail page Actions dropdown used the SDK's built-in useDeleteModal for deletion, which shows a simple "Are you sure?" checkbox confirmation.
  - The list page kebab menu already uses the custom type-to-confirm APIProductDeleteModal (enhanced in PR #609), creating an inconsistent delete experience across the two views.
  - Replaced useDeleteModal with the SDK's useModal hook to launch APIProductDeleteModal from the Actions dropdown, matching PatternFly design guidelines for "Confirm a destructive action".
  - Detail page now navigates back to the APIProducts list after successful deletion.

  Fixes #614

  ## Type of change

  - [x] [fix] Bug fix (non-breaking change that fixes an issue)

  ## Changes made

  **Modal Lifecycle**

  - onDeleteSuccess callback: Added optional prop to APIProductDeleteModal to distinguish successful deletion from cancel — detail page navigates away, list page behaviour unchanged
  - setIsDeleting cleanup: Moved out of finally block and into catch only, preventing React setState-on-unmount warnings when the modal is closed after deletion

  **Actions Hook**

  - Replaced useDeleteModal with useModal: Switched from the SDK's built-in delete confirmation to the generic modal launcher in useAPIProductActions
  - APIProductDeleteModalWrapper: Added wrapper component that bridges the Console ModalProvider API (closeModal prop) with APIProductDeleteModal, handling post-delete navigation to /kuadrant/apiproducts/ns/{namespace}

  **E2E Test**

  - Updated delete confirmation flow: Test now types the resource name into #confirm-delete input instead of checking a checkbox, matching the new type-to-confirm behaviour

  ## Test plan

  - [x] yarn lint passes (no changes after running)
  - [x] Tested in both light and dark themes
  - [x] Tested in all-namespaces and single namespace mode
  - [x] Delete from detail page Actions dropdown shows type-to-confirm modal
  - [x] Cancel on the modal stays on the detail page
  - [x] Successful delete navigates to the APIProducts list
  - [x] Delete from list page kebab menu still works as before

  ## Screenshots

  

https://github.com/user-attachments/assets/40c50bf9-5c37-4429-bcc3-b5858db8b7b3



  ## Checklist

  - [x] All user-facing strings use t() and are added to locales/en/plugin__kuadrant-console-plugin.json
  - [x] CSS classes are prefixed with kuadrant- — no bare .pf-* or .co-* selectors, no hex colors
  - [x] No console.log statements left in
  - [x] Commits include Signed-off-by line (git commit -s)