### PR TITLE
v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuadrant-console-plugin",
-  "version": "0.5.0-dev",
+  "version": "0.5.0",
   "description": "Kuadrant OpenShift Console plugin",
   "private": true,
   "license": "Apache-2.0",
@@ -82,7 +82,7 @@
   },
   "consolePlugin": {
     "name": "kuadrant-console-plugin",
-    "version": "0.5.0-dev",
+    "version": "0.5.0",
     "displayName": "Kuadrant OpenShift Console Plugin",
     "description": "Kuadrant OpenShift Console Plugin",
     "latestSupportedOpenshiftVersion": "4.19",


### PR DESCRIPTION
Release v0.5.0 — bumps version in package.json (both top-level and consolePlugin.version) from `0.5.0-dev` to `0.5.0`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release**
  * Promoted the plugin from the development version to the stable 0.5.0 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->