### PR TITLE
ci: skip add-to-project workflow for dependabot PRs

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -14,7 +14,7 @@ jobs:
     # Only run jobs if the feature branch is in your repo (not in a fork)
     # OR
     # it is an issue
-    if: github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != ''
+    if: github.actor != 'dependabot[bot]' && (github.event.pull_request.head.repo.full_name == github.repository || github.event.issue.number != '')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/add-to-project@v0.5.0


### PR DESCRIPTION
## Summary
- Dependabot PRs don't have access to repo secrets, so `ADD_ISSUES_TOKEN` is always empty and the "Add issue to project" job always fails
- Adds `github.actor != 'dependabot[bot]'` condition to skip the job for dependabot PRs

## Test plan
- [x] Verified the workflow file change is correct
- [ ] Next dependabot PR should no longer show a failed check for this job

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented automated dependency update actions from adding issues or pull requests to projects.
  * Preserved project updates for eligible repository and issue events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->