### PR TITLE
Add tests for gateway-api merged components

### DIFF
--- a/src/components/gateway/GatewaySingleOverview.tsx
+++ b/src/components/gateway/GatewaySingleOverview.tsx
@@ -22,7 +22,7 @@ const GatewaySingleOverview: React.FC = () => {
     gateway: {
       groupVersionKind: RESOURCES.Gateway.gvk,
       namespace: activeNamespace,
-      name: routeName,
+      name: routeName ?? undefined,
       isList: false,
     },
   };

--- a/src/components/httproute/HTTPRouteCreatePage.test.ts
+++ b/src/components/httproute/HTTPRouteCreatePage.test.ts
@@ -1,0 +1,485 @@
+import {
+  generateMatchesForYAML,
+  parseMatchesFromYAML,
+  validateMatchesInRule,
+  formatMatchesForDisplay,
+} from './HTTPRouteCreatePage';
+import type { HTTPRouteMatch } from './types';
+
+// ── generateMatchesForYAML ───────────────────────────────────────────────────
+
+describe('generateMatchesForYAML', () => {
+  it('returns an empty array when matches is an empty array', () => {
+    expect(generateMatchesForYAML([])).toEqual([]);
+  });
+
+  it('converts a single match with path only', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/api',
+        method: 'GET',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    const result = generateMatchesForYAML(matches);
+
+    expect(result).toEqual([
+      {
+        path: {
+          type: 'PathPrefix',
+          value: '/api',
+        },
+      },
+    ]);
+  });
+
+  it('includes method when it is not GET', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'Exact',
+        pathValue: '/users',
+        method: 'POST',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    const result = generateMatchesForYAML(matches);
+
+    expect(result).toEqual([
+      {
+        path: {
+          type: 'Exact',
+          value: '/users',
+        },
+        method: 'POST',
+      },
+    ]);
+  });
+
+  it('includes headers when present with valid name and value', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/',
+        method: 'GET',
+        headers: [
+          { id: 'h1', type: 'Exact', name: 'X-Custom', value: 'val1' },
+          { id: 'h2', type: 'RegularExpression', name: 'X-Regex', value: '.*' },
+        ],
+        queryParams: [],
+      },
+    ];
+
+    const result = generateMatchesForYAML(matches);
+
+    expect(result).toEqual([
+      {
+        path: {
+          type: 'PathPrefix',
+          value: '/',
+        },
+        headers: [
+          { type: 'Exact', name: 'X-Custom', value: 'val1' },
+          { type: 'RegularExpression', name: 'X-Regex', value: '.*' },
+        ],
+      },
+    ]);
+  });
+
+  it('filters out headers with empty name or value', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/',
+        method: 'GET',
+        headers: [
+          { id: 'h1', type: 'Exact', name: 'Valid', value: 'val' },
+          { id: 'h2', type: 'Exact', name: '', value: 'no-name' },
+          { id: 'h3', type: 'Exact', name: 'No-Val', value: '  ' },
+        ],
+        queryParams: [],
+      },
+    ];
+
+    const result = generateMatchesForYAML(matches);
+
+    expect(result).toEqual([
+      {
+        path: {
+          type: 'PathPrefix',
+          value: '/',
+        },
+        headers: [{ type: 'Exact', name: 'Valid', value: 'val' }],
+      },
+    ]);
+  });
+
+  it('includes queryParams when present with valid name and value', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/',
+        method: 'GET',
+        headers: [],
+        queryParams: [
+          { id: 'q1', type: 'Exact', name: 'user', value: 'alice' },
+          { id: 'q2', type: 'RegularExpression', name: 'pattern', value: '[a-z]+' },
+        ],
+      },
+    ];
+
+    const result = generateMatchesForYAML(matches);
+
+    expect(result).toEqual([
+      {
+        path: {
+          type: 'PathPrefix',
+          value: '/',
+        },
+        queryParams: [
+          { type: 'Exact', name: 'user', value: 'alice' },
+          { type: 'RegularExpression', name: 'pattern', value: '[a-z]+' },
+        ],
+      },
+    ]);
+  });
+
+  it('filters out queryParams with empty name or value', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/',
+        method: 'GET',
+        headers: [],
+        queryParams: [
+          { id: 'q1', type: 'Exact', name: 'valid', value: 'val' },
+          { id: 'q2', type: 'Exact', name: '', value: 'no-name' },
+          { id: 'q3', type: 'Exact', name: 'no-val', value: '' },
+        ],
+      },
+    ];
+
+    const result = generateMatchesForYAML(matches);
+
+    expect(result).toEqual([
+      {
+        path: {
+          type: 'PathPrefix',
+          value: '/',
+        },
+        queryParams: [{ type: 'Exact', name: 'valid', value: 'val' }],
+      },
+    ]);
+  });
+
+  it('converts multiple matches', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/api',
+        method: 'GET',
+        headers: [],
+        queryParams: [],
+      },
+      {
+        id: 'match-2',
+        pathType: 'Exact',
+        pathValue: '/users',
+        method: 'POST',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    const result = generateMatchesForYAML(matches);
+
+    expect(result).toEqual([
+      {
+        path: {
+          type: 'PathPrefix',
+          value: '/api',
+        },
+      },
+      {
+        path: {
+          type: 'Exact',
+          value: '/users',
+        },
+        method: 'POST',
+      },
+    ]);
+  });
+});
+
+// ── parseMatchesFromYAML ─────────────────────────────────────────────────────
+
+describe('parseMatchesFromYAML', () => {
+  it('returns an empty array when yamlMatches is undefined', () => {
+    expect(parseMatchesFromYAML(undefined as any)).toEqual([]);
+  });
+
+  it('returns an empty array when yamlMatches is not an array', () => {
+    expect(parseMatchesFromYAML({} as any)).toEqual([]);
+  });
+
+  it('parses a match with path only', () => {
+    const yamlMatches = [
+      {
+        path: { type: 'PathPrefix', value: '/api' },
+      },
+    ];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].pathType).toBe('PathPrefix');
+    expect(result[0].pathValue).toBe('/api');
+    expect(result[0].method).toBe('GET');
+    expect(result[0].headers).toEqual([]);
+    expect(result[0].queryParams).toEqual([]);
+  });
+
+  it('parses a match with method', () => {
+    const yamlMatches = [
+      {
+        path: { type: 'Exact', value: '/users' },
+        method: 'POST',
+      },
+    ];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result[0].method).toBe('POST');
+  });
+
+  it('parses a match with headers', () => {
+    const yamlMatches = [
+      {
+        path: { type: 'PathPrefix', value: '/' },
+        headers: [
+          { type: 'Exact', name: 'X-Custom', value: 'val1' },
+          { type: 'RegularExpression', name: 'X-Regex', value: '.*' },
+        ],
+      },
+    ];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result[0].headers).toHaveLength(2);
+    expect(result[0].headers?.[0].type).toBe('Exact');
+    expect(result[0].headers?.[0].name).toBe('X-Custom');
+    expect(result[0].headers?.[0].value).toBe('val1');
+    expect(result[0].headers?.[0].id).toBeDefined();
+  });
+
+  it('parses a match with queryParams', () => {
+    const yamlMatches = [
+      {
+        path: { type: 'PathPrefix', value: '/' },
+        queryParams: [
+          { type: 'Exact', name: 'user', value: 'alice' },
+          { type: 'RegularExpression', name: 'pattern', value: '[a-z]+' },
+        ],
+      },
+    ];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result[0].queryParams).toHaveLength(2);
+    expect(result[0].queryParams?.[0].type).toBe('Exact');
+    expect(result[0].queryParams?.[0].name).toBe('user');
+    expect(result[0].queryParams?.[0].value).toBe('alice');
+    expect(result[0].queryParams?.[0].id).toBeDefined();
+  });
+
+  it('provides default values for missing path fields', () => {
+    const yamlMatches = [{}];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result[0].pathType).toBe('PathPrefix');
+    expect(result[0].pathValue).toBe('/');
+  });
+
+  it('provides default type for headers missing type', () => {
+    const yamlMatches = [
+      {
+        path: { type: 'PathPrefix', value: '/' },
+        headers: [{ name: 'X-Custom', value: 'val' }],
+      },
+    ];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result[0].headers?.[0].type).toBe('Exact');
+  });
+
+  it('provides default type for queryParams missing type', () => {
+    const yamlMatches = [
+      {
+        path: { type: 'PathPrefix', value: '/' },
+        queryParams: [{ name: 'user', value: 'alice' }],
+      },
+    ];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result[0].queryParams?.[0].type).toBe('Exact');
+  });
+
+  it('parses multiple matches', () => {
+    const yamlMatches = [
+      {
+        path: { type: 'PathPrefix', value: '/api' },
+      },
+      {
+        path: { type: 'Exact', value: '/users' },
+        method: 'POST',
+      },
+    ];
+
+    const result = parseMatchesFromYAML(yamlMatches);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].pathValue).toBe('/api');
+    expect(result[1].pathValue).toBe('/users');
+    expect(result[1].method).toBe('POST');
+  });
+});
+
+// ── validateMatchesInRule ────────────────────────────────────────────────────
+
+describe('validateMatchesInRule', () => {
+  it('returns true when matches array is empty', () => {
+    expect(validateMatchesInRule([])).toBe(true);
+  });
+
+  it('returns true when all matches have pathType, pathValue, and method', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/api',
+        method: 'GET',
+        headers: [],
+        queryParams: [],
+      },
+      {
+        id: 'match-2',
+        pathType: 'Exact',
+        pathValue: '/users',
+        method: 'POST',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    expect(validateMatchesInRule(matches)).toBe(true);
+  });
+
+  it('returns false when any match is missing pathType', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: '',
+        pathValue: '/api',
+        method: 'GET',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    expect(validateMatchesInRule(matches)).toBe(false);
+  });
+
+  it('returns false when any match is missing pathValue', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '',
+        method: 'GET',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    expect(validateMatchesInRule(matches)).toBe(false);
+  });
+
+  it('returns false when any match is missing method', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/api',
+        method: '',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    expect(validateMatchesInRule(matches)).toBe(false);
+  });
+});
+
+// ── formatMatchesForDisplay ──────────────────────────────────────────────────
+
+describe('formatMatchesForDisplay', () => {
+  it('returns "—" when matches is undefined', () => {
+    expect(formatMatchesForDisplay(undefined as any)).toBe('—');
+  });
+
+  it('returns "—" when matches is an empty array', () => {
+    expect(formatMatchesForDisplay([])).toBe('—');
+  });
+
+  it('formats a single match as "pathType pathValue / method"', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/api',
+        method: 'GET',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    expect(formatMatchesForDisplay(matches)).toBe('PathPrefix /api / GET');
+  });
+
+  it('formats multiple matches separated by commas', () => {
+    const matches: HTTPRouteMatch[] = [
+      {
+        id: 'match-1',
+        pathType: 'PathPrefix',
+        pathValue: '/api',
+        method: 'GET',
+        headers: [],
+        queryParams: [],
+      },
+      {
+        id: 'match-2',
+        pathType: 'Exact',
+        pathValue: '/users',
+        method: 'POST',
+        headers: [],
+        queryParams: [],
+      },
+    ];
+
+    expect(formatMatchesForDisplay(matches)).toBe('PathPrefix /api / GET, Exact /users / POST');
+  });
+});

--- a/src/components/httproute/HTTPRouteSingleOverview.tsx
+++ b/src/components/httproute/HTTPRouteSingleOverview.tsx
@@ -22,7 +22,7 @@ const HTTPRouteSingleOverview: React.FC = () => {
     httpRoute: {
       groupVersionKind: RESOURCES.HTTPRoute.gvk,
       namespace: activeNamespace,
-      name: httpRouteName,
+      name: httpRouteName ?? undefined,
       isList: false,
     },
   };

--- a/src/components/httproute/filters/filterUtils.test.ts
+++ b/src/components/httproute/filters/filterUtils.test.ts
@@ -224,7 +224,7 @@ describe('generateFiltersForYAML', () => {
     ]);
   });
 
-  it('returns type-only object when RequestHeaderModifier has no valid data', () => {
+  it('omits filter when RequestHeaderModifier has no valid data', () => {
     const filters: HTTPRouteFilter[] = [
       {
         type: 'RequestHeaderModifier',
@@ -234,11 +234,7 @@ describe('generateFiltersForYAML', () => {
 
     const result = generateFiltersForYAML(filters);
 
-    expect(result).toEqual([
-      {
-        type: 'RequestHeaderModifier',
-      },
-    ]);
+    expect(result).toEqual([]);
   });
 });
 

--- a/src/components/httproute/filters/filterUtils.test.ts
+++ b/src/components/httproute/filters/filterUtils.test.ts
@@ -1,0 +1,723 @@
+import {
+  createDefaultFilter,
+  generateFiltersForYAML,
+  parseFiltersFromYAML,
+  getFilterSummary,
+  isFilterConfigValid,
+  validateFiltersStep,
+} from './filterUtils';
+import type { HTTPRouteFilter } from './filterTypes';
+
+// ── createDefaultFilter ──────────────────────────────────────────────────────
+
+describe('createDefaultFilter', () => {
+  it('creates a default RequestHeaderModifier filter', () => {
+    const filter = createDefaultFilter('RequestHeaderModifier');
+    expect(filter).toEqual({
+      type: 'RequestHeaderModifier',
+      requestHeaderModifier: {},
+    });
+  });
+
+  it('creates a default ResponseHeaderModifier filter', () => {
+    const filter = createDefaultFilter('ResponseHeaderModifier');
+    expect(filter).toEqual({
+      type: 'ResponseHeaderModifier',
+      responseHeaderModifier: {},
+    });
+  });
+
+  it('creates a default URLRewrite filter', () => {
+    const filter = createDefaultFilter('URLRewrite');
+    expect(filter).toEqual({
+      type: 'URLRewrite',
+      urlRewrite: {},
+    });
+  });
+
+  it('creates a default RequestRedirect filter with scheme and statusCode', () => {
+    const filter = createDefaultFilter('RequestRedirect');
+    expect(filter).toEqual({
+      type: 'RequestRedirect',
+      requestRedirect: { scheme: 'https', statusCode: 301 },
+    });
+  });
+
+  it('creates a default RequestMirror filter with empty backendRef name', () => {
+    const filter = createDefaultFilter('RequestMirror');
+    expect(filter).toEqual({
+      type: 'RequestMirror',
+      requestMirror: { backendRef: { name: '' } },
+    });
+  });
+});
+
+// ── generateFiltersForYAML ───────────────────────────────────────────────────
+
+describe('generateFiltersForYAML', () => {
+  it('returns an empty array when filters is an empty array', () => {
+    expect(generateFiltersForYAML([])).toEqual([]);
+  });
+
+  it('serializes a RequestHeaderModifier with add/set/remove', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {
+          add: [{ id: 'a1', name: 'X-Add', value: 'val1' }],
+          set: [{ id: 's1', name: 'X-Set', value: 'val2' }],
+          remove: ['X-Remove'],
+        },
+      },
+    ];
+
+    const result = generateFiltersForYAML(filters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {
+          add: [{ name: 'X-Add', value: 'val1' }],
+          set: [{ name: 'X-Set', value: 'val2' }],
+          remove: ['X-Remove'],
+        },
+      },
+    ]);
+  });
+
+  it('serializes a ResponseHeaderModifier with add/set/remove', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'ResponseHeaderModifier',
+        responseHeaderModifier: {
+          add: [{ id: 'a1', name: 'X-Response', value: 'rval' }],
+          set: [],
+          remove: ['X-Resp-Remove'],
+        },
+      },
+    ];
+
+    const result = generateFiltersForYAML(filters);
+
+    expect(result).toEqual([
+      {
+        type: 'ResponseHeaderModifier',
+        responseHeaderModifier: {
+          add: [{ name: 'X-Response', value: 'rval' }],
+          remove: ['X-Resp-Remove'],
+        },
+      },
+    ]);
+  });
+
+  it('serializes a RequestRedirect with all fields', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestRedirect',
+        requestRedirect: {
+          scheme: 'https',
+          hostname: 'example.com',
+          port: 8443,
+          statusCode: 302,
+          path: {
+            type: 'ReplaceFullPath',
+            replaceFullPath: '/new',
+          },
+        },
+      },
+    ];
+
+    const result = generateFiltersForYAML(filters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestRedirect',
+        requestRedirect: {
+          scheme: 'https',
+          hostname: 'example.com',
+          port: 8443,
+          statusCode: 302,
+          path: {
+            type: 'ReplaceFullPath',
+            replaceFullPath: '/new',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('serializes a URLRewrite with hostname and path', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'URLRewrite',
+        urlRewrite: {
+          hostname: 'rewritten.com',
+          path: {
+            type: 'ReplacePrefixMatch',
+            replacePrefixMatch: '/api',
+          },
+        },
+      },
+    ];
+
+    const result = generateFiltersForYAML(filters);
+
+    expect(result).toEqual([
+      {
+        type: 'URLRewrite',
+        urlRewrite: {
+          hostname: 'rewritten.com',
+          path: {
+            type: 'ReplacePrefixMatch',
+            replacePrefixMatch: '/api',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('serializes a RequestMirror with backendRef name and port', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestMirror',
+        requestMirror: {
+          backendRef: { name: 'mirror-svc', port: 9000 },
+        },
+      },
+    ];
+
+    const result = generateFiltersForYAML(filters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestMirror',
+        requestMirror: {
+          backendRef: { name: 'mirror-svc', port: 9000 },
+        },
+      },
+    ]);
+  });
+
+  it('strips empty/whitespace-only header values from add/set/remove', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {
+          add: [
+            { name: 'Valid', value: 'ok' },
+            { name: '', value: 'empty-name' },
+            { name: 'Empty-Val', value: '  ' },
+          ],
+        },
+      },
+    ];
+
+    const result = generateFiltersForYAML(filters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {
+          add: [{ name: 'Valid', value: 'ok' }],
+        },
+      },
+    ]);
+  });
+
+  it('returns type-only object when RequestHeaderModifier has no valid data', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {},
+      },
+    ];
+
+    const result = generateFiltersForYAML(filters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestHeaderModifier',
+      },
+    ]);
+  });
+});
+
+// ── parseFiltersFromYAML ─────────────────────────────────────────────────────
+
+describe('parseFiltersFromYAML', () => {
+  it('returns an empty array when filters is undefined', () => {
+    expect(parseFiltersFromYAML(undefined)).toEqual([]);
+  });
+
+  it('returns an empty array when filters is an empty array', () => {
+    expect(parseFiltersFromYAML([])).toEqual([]);
+  });
+
+  it('parses a RequestHeaderModifier and adds IDs to header arrays', () => {
+    const yamlFilters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {
+          add: [{ name: 'X-Add', value: 'val1' }],
+          set: [{ name: 'X-Set', value: 'val2' }],
+          remove: ['X-Remove'],
+        },
+      },
+    ];
+
+    const result = parseFiltersFromYAML(yamlFilters);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('RequestHeaderModifier');
+    if (result[0].type === 'RequestHeaderModifier') {
+      expect(result[0].requestHeaderModifier?.add).toHaveLength(1);
+      expect(result[0].requestHeaderModifier?.add?.[0].name).toBe('X-Add');
+      expect(result[0].requestHeaderModifier?.add?.[0].id).toBeDefined();
+      expect(result[0].requestHeaderModifier?.remove).toEqual(['X-Remove']);
+    }
+  });
+
+  it('parses a ResponseHeaderModifier and adds IDs to header arrays', () => {
+    const yamlFilters: HTTPRouteFilter[] = [
+      {
+        type: 'ResponseHeaderModifier',
+        responseHeaderModifier: {
+          add: [{ name: 'X-Response', value: 'rval' }],
+          remove: ['X-Resp-Remove'],
+        },
+      },
+    ];
+
+    const result = parseFiltersFromYAML(yamlFilters);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].type).toBe('ResponseHeaderModifier');
+    if (result[0].type === 'ResponseHeaderModifier') {
+      expect(result[0].responseHeaderModifier?.add).toHaveLength(1);
+      expect(result[0].responseHeaderModifier?.add?.[0].id).toBeDefined();
+    }
+  });
+
+  it('parses a RequestRedirect with all fields', () => {
+    const yamlFilters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestRedirect',
+        requestRedirect: {
+          scheme: 'https',
+          hostname: 'example.com',
+          port: 8443,
+          statusCode: 302,
+          path: {
+            type: 'ReplaceFullPath',
+            replaceFullPath: '/new',
+          },
+        },
+      },
+    ];
+
+    const result = parseFiltersFromYAML(yamlFilters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestRedirect',
+        requestRedirect: {
+          scheme: 'https',
+          hostname: 'example.com',
+          port: 8443,
+          statusCode: 302,
+          path: {
+            type: 'ReplaceFullPath',
+            replaceFullPath: '/new',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('parses a URLRewrite with hostname and path', () => {
+    const yamlFilters: HTTPRouteFilter[] = [
+      {
+        type: 'URLRewrite',
+        urlRewrite: {
+          hostname: 'rewritten.com',
+          path: {
+            type: 'ReplacePrefixMatch',
+            replacePrefixMatch: '/api',
+          },
+        },
+      },
+    ];
+
+    const result = parseFiltersFromYAML(yamlFilters);
+
+    expect(result).toEqual([
+      {
+        type: 'URLRewrite',
+        urlRewrite: {
+          hostname: 'rewritten.com',
+          path: {
+            type: 'ReplacePrefixMatch',
+            replacePrefixMatch: '/api',
+          },
+        },
+      },
+    ]);
+  });
+
+  it('parses a RequestMirror with backendRef', () => {
+    const yamlFilters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestMirror',
+        requestMirror: {
+          backendRef: { name: 'mirror-svc', port: 9000 },
+        },
+      },
+    ];
+
+    const result = parseFiltersFromYAML(yamlFilters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestMirror',
+        requestMirror: {
+          backendRef: { name: 'mirror-svc', port: 9000 },
+        },
+      },
+    ]);
+  });
+
+  it('handles missing optional fields in RequestRedirect', () => {
+    const yamlFilters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestRedirect',
+        requestRedirect: {},
+      },
+    ];
+
+    const result = parseFiltersFromYAML(yamlFilters);
+
+    expect(result).toEqual([
+      {
+        type: 'RequestRedirect',
+        requestRedirect: {},
+      },
+    ]);
+  });
+});
+
+// ── getFilterSummary ─────────────────────────────────────────────────────────
+
+describe('getFilterSummary', () => {
+  it('returns empty string when filter is null', () => {
+    expect(getFilterSummary(null as unknown as HTTPRouteFilter)).toBe('');
+  });
+
+  it('returns summary for RequestHeaderModifier with add/set/remove counts', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestHeaderModifier',
+      requestHeaderModifier: {
+        add: [{ name: 'X-Add', value: 'val1' }],
+        set: [{ name: 'X-Set', value: 'val2' }],
+        remove: ['X-Remove'],
+      },
+    };
+
+    const summary = getFilterSummary(filter);
+
+    expect(summary).toBe('RequestHeaderModifier — add:1 | set:1 | remove:1');
+  });
+
+  it('returns summary for ResponseHeaderModifier with add count only', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'ResponseHeaderModifier',
+      responseHeaderModifier: {
+        add: [{ name: 'X-Response', value: 'rval' }],
+      },
+    };
+
+    const summary = getFilterSummary(filter);
+
+    expect(summary).toBe('ResponseHeaderModifier — add:1');
+  });
+
+  it('returns summary for URLRewrite with hostname and path', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'URLRewrite',
+      urlRewrite: {
+        hostname: 'rewritten.com',
+        path: {
+          type: 'ReplaceFullPath',
+          replaceFullPath: '/new',
+        },
+      },
+    };
+
+    const summary = getFilterSummary(filter);
+
+    expect(summary).toBe('URLRewrite — host → rewritten.com | ReplaceFullPath → /new');
+  });
+
+  it('returns summary for RequestRedirect with scheme, hostname, port, statusCode', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestRedirect',
+      requestRedirect: {
+        scheme: 'https',
+        hostname: 'example.com',
+        port: 8443,
+        statusCode: 302,
+      },
+    };
+
+    const summary = getFilterSummary(filter);
+
+    expect(summary).toBe('RequestRedirect — https | example.com | 8443 | 302');
+  });
+
+  it('returns summary for RequestMirror with backendRef name and port', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestMirror',
+      requestMirror: {
+        backendRef: { name: 'mirror-svc', port: 9000 },
+      },
+    };
+
+    const summary = getFilterSummary(filter);
+
+    expect(summary).toBe('RequestMirror — mirror-svc | 9000');
+  });
+
+  it('returns type only when RequestHeaderModifier has no data', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestHeaderModifier',
+      requestHeaderModifier: {},
+    };
+
+    const summary = getFilterSummary(filter);
+
+    expect(summary).toBe('RequestHeaderModifier');
+  });
+});
+
+// ── isFilterConfigValid ──────────────────────────────────────────────────────
+
+describe('isFilterConfigValid', () => {
+  it('returns true for RequestHeaderModifier with add items', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestHeaderModifier',
+      requestHeaderModifier: {
+        add: [{ name: 'X-Add', value: 'val1' }],
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns true for RequestHeaderModifier with set items', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestHeaderModifier',
+      requestHeaderModifier: {
+        set: [{ name: 'X-Set', value: 'val2' }],
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns true for RequestHeaderModifier with remove items', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestHeaderModifier',
+      requestHeaderModifier: {
+        remove: ['X-Remove'],
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns false for RequestHeaderModifier with no data', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestHeaderModifier',
+      requestHeaderModifier: {},
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(false);
+  });
+
+  it('returns true for ResponseHeaderModifier with remove items', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'ResponseHeaderModifier',
+      responseHeaderModifier: {
+        remove: ['X-Response'],
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns false for ResponseHeaderModifier with no data', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'ResponseHeaderModifier',
+      responseHeaderModifier: {},
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(false);
+  });
+
+  it('returns true for RequestRedirect with scheme only', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestRedirect',
+      requestRedirect: {
+        scheme: 'https',
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns true for RequestRedirect with hostname only', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestRedirect',
+      requestRedirect: {
+        hostname: 'example.com',
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns true for RequestRedirect with path', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestRedirect',
+      requestRedirect: {
+        path: {
+          type: 'ReplaceFullPath',
+          replaceFullPath: '/new',
+        },
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns false for RequestRedirect with no data', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestRedirect',
+      requestRedirect: {},
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(false);
+  });
+
+  it('returns true for URLRewrite with hostname', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'URLRewrite',
+      urlRewrite: {
+        hostname: 'rewritten.com',
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns true for URLRewrite with path', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'URLRewrite',
+      urlRewrite: {
+        path: {
+          type: 'ReplacePrefixMatch',
+          replacePrefixMatch: '/api',
+        },
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns false for URLRewrite with no data', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'URLRewrite',
+      urlRewrite: {},
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(false);
+  });
+
+  it('returns true for RequestMirror with valid backendRef name', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestMirror',
+      requestMirror: {
+        backendRef: { name: 'mirror-svc' },
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(true);
+  });
+
+  it('returns false for RequestMirror with empty backendRef name', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestMirror',
+      requestMirror: {
+        backendRef: { name: '' },
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(false);
+  });
+
+  it('returns false for RequestMirror with whitespace-only backendRef name', () => {
+    const filter: HTTPRouteFilter = {
+      type: 'RequestMirror',
+      requestMirror: {
+        backendRef: { name: '   ' },
+      },
+    };
+
+    expect(isFilterConfigValid(filter)).toBe(false);
+  });
+});
+
+// ── validateFiltersStep ──────────────────────────────────────────────────────
+
+describe('validateFiltersStep', () => {
+  it('returns true when filters array is empty', () => {
+    expect(validateFiltersStep([])).toBe(true);
+  });
+
+  it('returns true when all filters are valid', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {
+          add: [{ name: 'X-Add', value: 'val1' }],
+        },
+      },
+      {
+        type: 'RequestMirror',
+        requestMirror: {
+          backendRef: { name: 'mirror-svc' },
+        },
+      },
+    ];
+
+    expect(validateFiltersStep(filters)).toBe(true);
+  });
+
+  it('returns false when any filter is invalid', () => {
+    const filters: HTTPRouteFilter[] = [
+      {
+        type: 'RequestHeaderModifier',
+        requestHeaderModifier: {
+          add: [{ name: 'X-Add', value: 'val1' }],
+        },
+      },
+      {
+        type: 'RequestMirror',
+        requestMirror: {
+          backendRef: { name: '' },
+        },
+      },
+    ];
+
+    expect(validateFiltersStep(filters)).toBe(false);
+  });
+});

--- a/src/components/httproute/matchUtils.test.ts
+++ b/src/components/httproute/matchUtils.test.ts
@@ -3,7 +3,7 @@ import {
   parseMatchesFromYAML,
   validateMatchesInRule,
   formatMatchesForDisplay,
-} from './HTTPRouteCreatePage';
+} from './matchUtils';
 import type { HTTPRouteMatch } from './types';
 
 // ── generateMatchesForYAML ───────────────────────────────────────────────────
@@ -13,7 +13,7 @@ describe('generateMatchesForYAML', () => {
     expect(generateMatchesForYAML([])).toEqual([]);
   });
 
-  it('converts a single match with path only', () => {
+  it('converts a single match with path and method', () => {
     const matches: HTTPRouteMatch[] = [
       {
         id: 'match-1',
@@ -33,17 +33,18 @@ describe('generateMatchesForYAML', () => {
           type: 'PathPrefix',
           value: '/api',
         },
+        method: 'GET',
       },
     ]);
   });
 
-  it('includes method when it is not GET', () => {
+  it('omits method when it is empty', () => {
     const matches: HTTPRouteMatch[] = [
       {
         id: 'match-1',
         pathType: 'Exact',
         pathValue: '/users',
-        method: 'POST',
+        method: '',
         headers: [],
         queryParams: [],
       },
@@ -57,7 +58,6 @@ describe('generateMatchesForYAML', () => {
           type: 'Exact',
           value: '/users',
         },
-        method: 'POST',
       },
     ]);
   });
@@ -85,6 +85,7 @@ describe('generateMatchesForYAML', () => {
           type: 'PathPrefix',
           value: '/',
         },
+        method: 'GET',
         headers: [
           { type: 'Exact', name: 'X-Custom', value: 'val1' },
           { type: 'RegularExpression', name: 'X-Regex', value: '.*' },
@@ -117,6 +118,7 @@ describe('generateMatchesForYAML', () => {
           type: 'PathPrefix',
           value: '/',
         },
+        method: 'GET',
         headers: [{ type: 'Exact', name: 'Valid', value: 'val' }],
       },
     ]);
@@ -145,6 +147,7 @@ describe('generateMatchesForYAML', () => {
           type: 'PathPrefix',
           value: '/',
         },
+        method: 'GET',
         queryParams: [
           { type: 'Exact', name: 'user', value: 'alice' },
           { type: 'RegularExpression', name: 'pattern', value: '[a-z]+' },
@@ -177,6 +180,7 @@ describe('generateMatchesForYAML', () => {
           type: 'PathPrefix',
           value: '/',
         },
+        method: 'GET',
         queryParams: [{ type: 'Exact', name: 'valid', value: 'val' }],
       },
     ]);
@@ -210,6 +214,7 @@ describe('generateMatchesForYAML', () => {
           type: 'PathPrefix',
           value: '/api',
         },
+        method: 'GET',
       },
       {
         path: {
@@ -226,10 +231,12 @@ describe('generateMatchesForYAML', () => {
 
 describe('parseMatchesFromYAML', () => {
   it('returns an empty array when yamlMatches is undefined', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(parseMatchesFromYAML(undefined as any)).toEqual([]);
   });
 
   it('returns an empty array when yamlMatches is not an array', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(parseMatchesFromYAML({} as any)).toEqual([]);
   });
 
@@ -245,7 +252,7 @@ describe('parseMatchesFromYAML', () => {
     expect(result).toHaveLength(1);
     expect(result[0].pathType).toBe('PathPrefix');
     expect(result[0].pathValue).toBe('/api');
-    expect(result[0].method).toBe('GET');
+    expect(result[0].method).toBe('');
     expect(result[0].headers).toEqual([]);
     expect(result[0].queryParams).toEqual([]);
   });
@@ -418,7 +425,7 @@ describe('validateMatchesInRule', () => {
     expect(validateMatchesInRule(matches)).toBe(false);
   });
 
-  it('returns false when any match is missing method', () => {
+  it('returns true when method is empty (method is optional)', () => {
     const matches: HTTPRouteMatch[] = [
       {
         id: 'match-1',
@@ -430,7 +437,7 @@ describe('validateMatchesInRule', () => {
       },
     ];
 
-    expect(validateMatchesInRule(matches)).toBe(false);
+    expect(validateMatchesInRule(matches)).toBe(true);
   });
 });
 
@@ -438,6 +445,7 @@ describe('validateMatchesInRule', () => {
 
 describe('formatMatchesForDisplay', () => {
   it('returns "—" when matches is undefined', () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     expect(formatMatchesForDisplay(undefined as any)).toBe('—');
   });
 

--- a/src/utils/gatewayCreateEditHelpers.test.ts
+++ b/src/utils/gatewayCreateEditHelpers.test.ts
@@ -1,4 +1,7 @@
-import { generateUniqueId, removeCertsAndTlsOptionsForPassthrough } from './gatewayCreateEditHelpers';
+import {
+  generateUniqueId,
+  removeCertsAndTlsOptionsForPassthrough,
+} from './gatewayCreateEditHelpers';
 
 describe('generateUniqueId', () => {
   it('returns a string with the default prefix when no prefix is provided', () => {

--- a/src/utils/gatewayCreateEditHelpers.test.ts
+++ b/src/utils/gatewayCreateEditHelpers.test.ts
@@ -1,0 +1,102 @@
+import { generateUniqueId, removeCertsAndTlsOptionsForPassthrough } from './gatewayCreateEditHelpers';
+
+describe('generateUniqueId', () => {
+  it('returns a string with the default prefix when no prefix is provided', () => {
+    const id = generateUniqueId();
+    expect(id).toMatch(/^item_\d+_\d+_[a-z0-9]+$/);
+  });
+
+  it('returns a string with the provided prefix', () => {
+    const id = generateUniqueId('listener');
+    expect(id).toMatch(/^listener_\d+_\d+_[a-z0-9]+$/);
+  });
+
+  it('produces different IDs on successive calls', () => {
+    const id1 = generateUniqueId('test');
+    const id2 = generateUniqueId('test');
+    expect(id1).not.toBe(id2);
+  });
+});
+
+describe('removeCertsAndTlsOptionsForPassthrough', () => {
+  it('clears certificateRefs and tlsOptions for HTTPS + Passthrough', () => {
+    const listener = {
+      protocol: 'HTTPS' as const,
+      tlsMode: 'Passthrough' as const,
+      certificateRefs: [{ name: 'cert1' }],
+      tlsOptions: [{ key: 'val' }],
+    };
+
+    const result = removeCertsAndTlsOptionsForPassthrough(listener);
+
+    expect(result.certificateRefs).toEqual([]);
+    expect(result.tlsOptions).toEqual([]);
+  });
+
+  it('clears certificateRefs and tlsOptions for TLS + Passthrough', () => {
+    const listener = {
+      protocol: 'TLS' as const,
+      tlsMode: 'Passthrough' as const,
+      certificateRefs: [{ name: 'cert1' }],
+      tlsOptions: [{ key: 'val' }],
+    };
+
+    const result = removeCertsAndTlsOptionsForPassthrough(listener);
+
+    expect(result.certificateRefs).toEqual([]);
+    expect(result.tlsOptions).toEqual([]);
+  });
+
+  it('leaves certificateRefs and tlsOptions unchanged for HTTPS + Terminate', () => {
+    const listener = {
+      protocol: 'HTTPS' as const,
+      tlsMode: 'Terminate' as const,
+      certificateRefs: [{ name: 'cert1' }],
+      tlsOptions: [{ key: 'val' }],
+    };
+
+    const result = removeCertsAndTlsOptionsForPassthrough(listener);
+
+    expect(result.certificateRefs).toEqual([{ name: 'cert1' }]);
+    expect(result.tlsOptions).toEqual([{ key: 'val' }]);
+  });
+
+  it('leaves listener unchanged for HTTP protocol', () => {
+    const listener = {
+      protocol: 'HTTP' as const,
+      tlsMode: 'Terminate' as const,
+      certificateRefs: [{ name: 'cert1' }],
+      tlsOptions: [{ key: 'val' }],
+    };
+
+    const result = removeCertsAndTlsOptionsForPassthrough(listener);
+
+    expect(result).toEqual(listener);
+  });
+
+  it('leaves listener unchanged for TCP protocol', () => {
+    const listener = {
+      protocol: 'TCP' as const,
+      tlsMode: 'Terminate' as const,
+      certificateRefs: [{ name: 'cert1' }],
+      tlsOptions: [{ key: 'val' }],
+    };
+
+    const result = removeCertsAndTlsOptionsForPassthrough(listener);
+
+    expect(result).toEqual(listener);
+  });
+
+  it('leaves listener unchanged for UDP protocol', () => {
+    const listener = {
+      protocol: 'UDP' as const,
+      tlsMode: 'Terminate' as const,
+      certificateRefs: [{ name: 'cert1' }],
+      tlsOptions: [{ key: 'val' }],
+    };
+
+    const result = removeCertsAndTlsOptionsForPassthrough(listener);
+
+    expect(result).toEqual(listener);
+  });
+});


### PR DESCRIPTION
## Summary
follow-up to #690, #696, and #697 — adds unit tests for the merged gateway-api-console-plugin components.

depends on #697

## What this adds
- Unit tests for gatewayCreateEditHelpers (generateUniqueId, removeCertsAndTlsOptionsForPassthrough)
- Unit tests for filterUtils (createDefaultFilter, generateFiltersForYAML, parseFiltersFromYAML, getFilterSummary, isFilterConfigValid, validateFiltersStep)
- Unit tests for HTTPRoute match YAML generation/parsing/validation/formatting (generateMatchesForYAML, parseMatchesFromYAML, validateMatchesInRule, formatMatchesForDisplay)

## Testing
- [x] `yarn test` passes (all 198 unit tests)
- [x] `yarn i18n` generates no changes
- [x] lint passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved handling of undefined route names when observing resource changes in gateway and HTTP route configurations, ensuring proper undefined values are passed instead of potentially absent values.

* **Tests**
  * Added comprehensive test coverage for HTTP route filters, including YAML serialisation, filter validation, and step-level validation across all supported filter types.
  * Added tests for gateway utility functions, covering unique identifier generation and TLS option handling.
  * Added extensive tests for HTTP route match utilities, including YAML generation, parsing, validation, and display formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->