### PR TITLE
v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kuadrant-console-plugin",
-  "version": "0.5.1-dev",
+  "version": "0.6.0",
   "description": "Kuadrant OpenShift Console plugin",
   "private": true,
   "license": "Apache-2.0",
@@ -82,7 +82,7 @@
   },
   "consolePlugin": {
     "name": "kuadrant-console-plugin",
-    "version": "0.5.1-dev",
+    "version": "0.6.0",
     "displayName": "Kuadrant OpenShift Console Plugin",
     "description": "Kuadrant OpenShift Console Plugin",
     "latestSupportedOpenshiftVersion": "4.19",


### PR DESCRIPTION
Release v0.6.0

Last release before the SDK 4.22 migration (#651). This version supports OCP <=4.21.