### PR TITLE
fix(e2e): fix nightly failures in httproute-crud and attached-tab tests

### DIFF
--- a/e2e/tests/attached-tab.spec.ts
+++ b/e2e/tests/attached-tab.spec.ts
@@ -95,8 +95,11 @@ spec:
     name: ${gateway}
   rules:
     authentication:
-      apiKey:
-        allNamespaces: true
+      "api-key-auth":
+        apiKey:
+          selector:
+            matchLabels:
+              app: test
 `);
   });
 
@@ -114,10 +117,10 @@ spec:
       await expect(attachedTab).toBeVisible({ timeout: 15_000 });
       await attachedTab.click();
 
-      await expect(page.getByRole('heading', { name: 'Attached Resources' })).toBeVisible({
+      await expect(page.getByText('Attached Resources')).toBeVisible({
         timeout: 15_000,
       });
-      await expect(page.getByRole('heading', { name: 'Attached Policies' })).toBeVisible();
+      await expect(page.getByText('Attached Policies')).toBeVisible();
 
       await expect(page.locator(`a[data-test="${httproute}"]`).first()).toBeVisible({
         timeout: 15_000,
@@ -131,7 +134,9 @@ spec:
       await expect(httprouteRow.locator('text=HTTPRoute')).toBeVisible();
 
       const authpolicyRow = page.locator(`tr:has(a[data-test="${authpolicy}"])`);
-      await expect(authpolicyRow.locator('text=AuthPolicy')).toBeVisible();
+      await expect(
+        authpolicyRow.getByRole('gridcell', { name: 'AuthPolicy', exact: true }),
+      ).toBeVisible();
     },
   );
 
@@ -145,10 +150,10 @@ spec:
     await expect(attachedTab).toBeVisible({ timeout: 15_000 });
     await attachedTab.click();
 
-    await expect(page.getByRole('heading', { name: 'Attached Resources' })).toBeVisible({
+    await expect(page.getByText('Attached Resources')).toBeVisible({
       timeout: 15_000,
     });
-    await expect(page.getByRole('heading', { name: 'Attached Policies' })).toBeVisible();
+    await expect(page.getByText('Attached Policies')).toBeVisible();
 
     await expect(page.locator(`a[data-test="${gateway}"]`).first()).toBeVisible({
       timeout: 15_000,

--- a/e2e/tests/httproute-crud.spec.ts
+++ b/e2e/tests/httproute-crud.spec.ts
@@ -42,6 +42,24 @@ async function expectEditorContains(page: Page, text: string): Promise<void> {
   });
   await page.waitForFunction(
     (expected) => {
+      try {
+        type MonacoType = {
+          editor?: {
+            getEditors?: () => Array<{ getValue: () => string; getDomNode: () => Element | null }>;
+          };
+        };
+        const monaco = (window as unknown as { monaco?: MonacoType }).monaco;
+        const editorEl = document.querySelector('.monaco-editor');
+        if (monaco?.editor?.getEditors && editorEl) {
+          const editors = monaco.editor.getEditors();
+          const visible = editors.find(
+            (e) => e.getDomNode() === editorEl || editorEl.contains(e.getDomNode()),
+          );
+          if (visible) return visible.getValue().includes(expected);
+        }
+      } catch {
+        // fallthrough
+      }
       const lines = document.querySelector('.monaco-editor .view-lines');
       return (lines?.textContent || '').includes(expected);
     },
@@ -184,6 +202,7 @@ spec:
     - path:
         type: PathPrefix
         value: /api
+      method: GET
     backendRefs:
     - name: example-svc
       port: 8080
@@ -267,16 +286,23 @@ spec:
     await expect(gatewayOption).toBeAttached({ timeout: 15_000 });
     await page.locator('#parent-gateway-0').selectOption(gateway);
 
+    const sectionOption = page.locator('#parent-section-0 option[value="http"]');
+    await expect(sectionOption).toBeAttached({ timeout: 15_000 });
+    await page.locator('#parent-section-0').selectOption('http');
+
     // Add rule via wizard
     await page.getByRole('button', { name: 'Add rule' }).click();
     await addRuleViaWizard(page, { pathValue: '/test', serviceName: 'test-svc' });
 
-    // Switch to YAML
+    // Wait for rule to appear in table before switching views
+    await expect(page.getByText('/test')).toBeVisible({ timeout: 5_000 });
+
+    // Switch to YAML and verify data is synced
     await page.locator('#create-type-radio-yaml').click();
+    await expectEditorContains(page, '/test');
 
     await expectEditorContains(page, routeName);
     await expectEditorContains(page, gateway);
-    await expectEditorContains(page, '/test');
 
     // Switch back to form
     await page.locator('#create-type-radio-form').click();


### PR DESCRIPTION
 ## Summary
  Fix 6 nightly test failures in `httproute-crud.spec.ts` and `attached-tab.spec.ts`.
closes #709 
  ### httproute-crud
  - **YAML sync test**: `expectEditorContains` used `textContent` on `.view-lines` which misses content outside Monaco's virtual viewport — switched to `getEditors()` API (same fix as gateway-crud)
  - **Edit test**: test resource had no `method` in match, causing wizard validation to block the Next button — added `method: GET`
  - **YAML sync test**: missing section selection for parentRef caused `parentRefs: []` in YAML — added section selection and sync point

  ### attached-tab
  - **AuthPolicy manifest**: used removed `allNamespaces` field with wrong structure — replaced with valid named authentication entry
  - **Heading locators**: PF6 `CardTitle` doesn't have heading role — switched to `getByText()`
  - **Strict mode violation**: `text=AuthPolicy` matched 2 elements in row — switched to `getByRole('gridcell')`

  ## Test plan
  - [x] `npx playwright test --config=e2e/playwright.config.ts e2e/tests/httproute-crud.spec.ts e2e/tests/attached-tab.spec.ts` — 7/7 passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved end-to-end test reliability when validating attached tabs and AuthPolicy entries.
  - Enhanced HTTPRoute editing checks across form and YAML views.
  - Added more robust handling for Monaco editor content and explicit HTTP methods.
  - Updated synchronisation checks to wait for routing rules before verifying YAML output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->