### PR TITLE
ci: add paths-filter and promote gateway CRUD to smoke

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,32 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if echo "$FILES" | grep -qvE '(\.md$|^docs/|^\.github/|^LICENSE$|^charts/|^config/|^kuadrant-dev-setup/|^\.devcontainer/)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   build:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
 

--- a/.github/workflows/i18n.yaml
+++ b/.github/workflows/i18n.yaml
@@ -9,7 +9,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if echo "$FILES" | grep -qvE '(\.md$|^docs/|^\.github/|^LICENSE$|^charts/|^config/|^kuadrant-dev-setup/|^\.devcontainer/)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   i18n:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -9,7 +9,32 @@ on:
   workflow_dispatch:
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      src: ${{ steps.filter.outputs.src }}
+    steps:
+      - id: filter
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          if [ "${{ github.event_name }}" != "pull_request" ]; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+          if echo "$FILES" | grep -qvE '(\.md$|^docs/|^\.github/|^LICENSE$|^charts/|^config/|^kuadrant-dev-setup/|^\.devcontainer/)'; then
+            echo "src=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "src=false" >> "$GITHUB_OUTPUT"
+          fi
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -235,6 +235,7 @@ test('validate empty title shows error', { tag: '@nightly' }, async ({ page }) =
 **Rules:**
 - Every test must have exactly one tag (`@smoke` or `@nightly`) — untagged tests are skipped in smoke runs but do run in nightly (full suite has no `--grep` filter)
 - When adding a new test, default to `@nightly`; only use `@smoke` for critical, reliable flows
+- CRUD tests should be `@smoke` — they cover critical user paths
 - When adding a new spec file, add it to the mapping in `build/suite-router.sh` (see below)
 
 ### Suite Router (`build/suite-router.sh`)

--- a/e2e/tests/gateway-crud.spec.ts
+++ b/e2e/tests/gateway-crud.spec.ts
@@ -117,7 +117,7 @@ test.describe('Gateway CRUD', () => {
     deleteNamespace(namespace);
   });
 
-  test('creates a Gateway via the form', { tag: '@nightly' }, async ({ page }) => {
+  test('creates a Gateway via the form', { tag: '@smoke' }, async ({ page }) => {
     const gatewayName = `e2e-gateway-${uid()}`;
     await gotoPage(page, `/k8s/ns/${namespace}/gateway.networking.k8s.io~v1~Gateway/~new`);
 
@@ -162,7 +162,7 @@ test.describe('Gateway CRUD', () => {
     ).toBe('istio');
   });
 
-  test('edits an existing Gateway', { tag: '@nightly' }, async ({ page }) => {
+  test('edits an existing Gateway', { tag: '@smoke' }, async ({ page }) => {
     const gatewayName = `e2e-gateway-${uid()}`;
     applyResource(`
 apiVersion: gateway.networking.k8s.io/v1
@@ -255,7 +255,7 @@ spec:
     ).toBe('8080');
   });
 
-  test('form↔YAML sync preserves data', { tag: '@nightly' }, async ({ page }) => {
+  test('form↔YAML sync preserves data', { tag: '@smoke' }, async ({ page }) => {
     const gatewayName = `e2e-gateway-${uid()}`;
     await gotoPage(page, `/k8s/ns/${namespace}/gateway.networking.k8s.io~v1~Gateway/~new`);
 

--- a/e2e/tests/httproute-crud.spec.ts
+++ b/e2e/tests/httproute-crud.spec.ts
@@ -114,7 +114,7 @@ spec:
     deleteNamespace(namespace);
   });
 
-  test('creates an HTTPRoute via the form', { tag: '@nightly' }, async ({ page }) => {
+  test('creates an HTTPRoute via the form', { tag: '@smoke' }, async ({ page }) => {
     const routeName = `e2e-httproute-${uid()}`;
     await gotoPage(page, `/k8s/ns/${namespace}/gateway.networking.k8s.io~v1~HTTPRoute/~new`);
 
@@ -167,7 +167,7 @@ spec:
     ).toBe(gateway);
   });
 
-  test('edits an existing HTTPRoute', { tag: '@nightly' }, async ({ page }) => {
+  test('edits an existing HTTPRoute', { tag: '@smoke' }, async ({ page }) => {
     const routeName = `e2e-httproute-${uid()}`;
     applyResource(`
 apiVersion: gateway.networking.k8s.io/v1
@@ -250,7 +250,7 @@ spec:
     ).toBe('/v2/api');
   });
 
-  test('form↔YAML sync preserves data', { tag: '@nightly' }, async ({ page }) => {
+  test('form↔YAML sync preserves data', { tag: '@smoke' }, async ({ page }) => {
     const routeName = `e2e-httproute-${uid()}`;
     await gotoPage(page, `/k8s/ns/${namespace}/gateway.networking.k8s.io~v1~HTTPRoute/~new`);
 


### PR DESCRIPTION
## Summary
- Add a `changes` job to build, lint, and i18n workflows that skips work for docs-only PRs — the job shows as "Skipped" for required checks
- Promote gateway-crud and httproute-crud tests from `@nightly` to `@smoke` for consistency with other CRUD tests
- Add "CRUD tests should be @smoke" rule to docs

## How it works

**Workflows**: A lightweight `changes` job uses the GitHub API to check the PR file list. If only non-code files changed (docs, CI config, charts, etc.), the build/lint/i18n job skips. The suite router already handles test isolation by mapping changed files to spec files.

EXAMPLE PR https://github.com/R-Lawton/kuadrant-console-plugin/pull/3

## Test plan
- [ ] verify `check:spec-map` passes
- [ ] verify existing e2e smoke suite runs unchanged
- [Test PR (docs-only skip)](https://github.com/R-Lawton/kuadrant-console-plugin/pull/3)

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)