### PR TITLE
fix: use compatible console image on Apple Silicon

### DIFF
--- a/start-console.sh
+++ b/start-console.sh
@@ -2,8 +2,14 @@
 
 set -euo pipefail
 
-CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}
 CONSOLE_PORT=${CONSOLE_PORT:=9000}
+
+# The latest origin-console image requires x86-64-v3, which can't be emulated on Apple Silicon.
+if [ "$(uname -m)" = "arm64" ]; then
+    CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:4.21"}
+else
+    CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}
+fi
 CONSOLE_IMAGE_PLATFORM=${CONSOLE_IMAGE_PLATFORM:="linux/amd64"}
 
 # Plugin metadata is declared in package.json

--- a/start-console.sh
+++ b/start-console.sh
@@ -4,8 +4,12 @@ set -euo pipefail
 
 CONSOLE_PORT=${CONSOLE_PORT:=9000}
 
-# The latest origin-console image requires x86-64-v3, which can't be emulated on Apple Silicon.
-if [ "$(uname -m)" = "arm64" ]; then
+# The latest origin-console image requires x86-64-v3, which can't be emulated on ARM hosts.
+ARCH=$(uname -m)
+if [ "$ARCH" = "x86_64" ] && [ "$(uname -s)" = "Darwin" ] && sysctl -n hw.optional.arm64 2>/dev/null | grep -q 1; then
+    ARCH="arm64"
+fi
+if [ "$ARCH" = "arm64" ] || [ "$ARCH" = "aarch64" ]; then
     CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:4.21"}
 else
     CONSOLE_IMAGE=${CONSOLE_IMAGE:="quay.io/openshift/origin-console:latest"}


### PR DESCRIPTION
## Summary
- The latest `origin-console:latest` image requires x86-64-v3 CPU instructions, which can't be emulated on Apple Silicon Macs (`Fatal glibc error: CPU does not support x86-64-v3`)
- Defaults to `origin-console:4.21` on arm64 hosts while keeping `:latest` on native x86-64 machines
- The `CONSOLE_IMAGE` env var override still works for both platforms

## Test plan
- [ ] Run `yarn start-console` on an Apple Silicon Mac — should pull and run `4.21` successfully
- [ ] Verify `CONSOLE_IMAGE=quay.io/openshift/origin-console:latest yarn start-console` still overrides the default

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved console startup compatibility across different CPU architectures.
  * Apple Silicon systems now use a compatible console image automatically, while other systems continue using the latest image by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->