### PR TITLE
feat: add MCP Gateway installation to OCP dev setup

### DIFF
--- a/kuadrant-dev-setup/Makefile
+++ b/kuadrant-dev-setup/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help local-setup
+.PHONY: help local-setup mcp-gateway-install
 
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
@@ -17,10 +17,13 @@ local-setup:
 	@echo "installing kuadrant..."
 	@$(MAKE) kuadrant-install
 	@echo ""
+	@echo "installing MCP Gateway..."
+	@$(MAKE) mcp-gateway-install
+	@echo ""
 	@echo "installing demo resources..."
 	@$(MAKE) demo-install
 	@echo ""
-	@echo "cluster ready! kuadrant and demo resources installed."
+	@echo "cluster ready! kuadrant, MCP Gateway, and demo resources installed."
 	@echo ""
 
 cert-manager-install:
@@ -56,6 +59,29 @@ kuadrant-install:
 	@echo ""
 	@echo "kuadrant installed!"
 
+MCP_GATEWAY_VERSION ?= 0.7.1
+MCP_GATEWAY_REPO := https://github.com/Kuadrant/mcp-gateway
+
+mcp-gateway-install:
+	@echo ""
+	@echo "installing MCP Gateway CRDs (v$(MCP_GATEWAY_VERSION))..."
+	@kubectl apply -k "$(MCP_GATEWAY_REPO)/config/crd?ref=v$(MCP_GATEWAY_VERSION)"
+	@echo ""
+	@echo "creating MCP Gateway infrastructure..."
+	@kubectl apply -k "$(MCP_GATEWAY_REPO)/config/istio/gateway?ref=v$(MCP_GATEWAY_VERSION)"
+	@echo ""
+	@echo "deploying MCP Gateway controller..."
+	@kubectl apply -k "$(MCP_GATEWAY_REPO)/config/mcp-gateway/overlays/mcp-system?ref=v$(MCP_GATEWAY_VERSION)"
+	@echo ""
+	@echo "waiting for MCP Gateway controller..."
+	@kubectl wait --for=condition=available --timeout=120s deployment/mcp-gateway-controller -n mcp-system
+	@echo "waiting for MCP broker-router..."
+	@kubectl wait --for=condition=available --timeout=120s deployment/mcp-gateway -n mcp-system
+	@echo "waiting for MCP gateway pod..."
+	@kubectl wait --for=condition=ready --timeout=120s pod -l gateway.networking.k8s.io/gateway-name=mcp-gateway -n gateway-system
+	@echo ""
+	@echo "MCP Gateway installed!"
+
 demo-install:
 	@echo "installing demo resources..."
 	@echo ""
@@ -75,6 +101,9 @@ demo-install:
 	@kubectl apply -f demo/toystore-demo.yaml
 	@kubectl apply -f demo/gamestore-demo.yaml
 	@kubectl apply -f demo/additional-demos.yaml
+	@echo ""
+	@echo "creating demo MCP resources..."
+	@kubectl apply -f demo/mcp-demo.yaml
 	@echo ""
 	@echo "Creating rejection for rejected-shipping-apikey..."
 	@bash $(PROJECT_PATH)/demo/reject-shipping-apikey.sh

--- a/kuadrant-dev-setup/demo/mcp-demo.yaml
+++ b/kuadrant-dev-setup/demo/mcp-demo.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-test-server
+  namespace: toystore
+  labels:
+    app: mcp-test-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-test-server
+  template:
+    metadata:
+      labels:
+        app: mcp-test-server
+    spec:
+      containers:
+        - name: mcp-test-server
+          image: ghcr.io/kuadrant/mcp-gateway/test-server1:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/mcp-test-server"]
+          args: ["--http", "0.0.0.0:9090"]
+          ports:
+            - containerPort: 9090
+              name: http
+          env:
+            - name: LOG_LEVEL
+              value: "info"
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-test-server
+  namespace: toystore
+  labels:
+    app: mcp-test-server
+spec:
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+  selector:
+    app: mcp-test-server
+  type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-test-server-route
+  namespace: toystore
+  labels:
+    mcp-server: "true"
+spec:
+  parentRefs:
+    - name: mcp-gateway
+      namespace: gateway-system
+  hostnames:
+    - "mcp-test-server.mcp.local"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mcp-test-server
+          port: 9090
+---
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: toystore-mcp-server
+  namespace: toystore
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  prefix: toystore_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: mcp-test-server-route


### PR DESCRIPTION
## Summary
- adds `mcp-gateway-install` Makefile target to `kuadrant-dev-setup/` that installs MCP Gateway CRDs, infrastructure (Gateway, NodePort, ReferenceGrant), and controller via kustomize from the upstream [mcp-gateway](https://github.com/Kuadrant/mcp-gateway) repo
- adds demo MCP test server (Deployment, Service, HTTPRoute) and MCPServerRegistration in the `toystore` namespace
- version pinned to `0.7.1`, overridable via `MCP_GATEWAY_VERSION`

## Test plan
- [x] tested `mcp-gateway-install` target against live OCP cluster — CRDs, controller, and broker-router all deployed successfully
- [x] tested demo resources — MCPServerRegistration reached `Ready: True` with 5 tools discovered
- [ ] test full `make local-setup` flow end-to-end on a fresh cluster

🤖 Generated with [Claude Code](https://claude.com/claude-code)