### PR TITLE
feat: use oinc mcp-gateway addon and bump OCP to 4.22

### DIFF
--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install oinc
         run: |
-          OINC_VERSION="${OINC_VERSION:-v0.2.3}"
+          OINC_VERSION="${OINC_VERSION:-v0.4.2}"
           curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
           chmod +x oinc
           sudo mv oinc /usr/local/bin/

--- a/.github/workflows/e2e-common.yaml
+++ b/.github/workflows/e2e-common.yaml
@@ -41,9 +41,11 @@ jobs:
 
       - name: Install oinc
         run: |
-          OINC_VERSION="${OINC_VERSION:-v0.4.2}"
-          curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
+          OINC_VERSION="${OINC_VERSION:-v0.4.3}"
+          curl -fL -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
           chmod +x oinc
+          file oinc | grep -q ELF || { echo "downloaded file is not a valid binary"; exit 1; }
+          ./oinc version
           sudo mv oinc /usr/local/bin/
 
       - name: Install Helm

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -10,9 +10,10 @@
 
 ### Install oinc
 ```bash
-OINC_VERSION="v0.2.2"
-curl -L -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
+OINC_VERSION="v0.4.3"
+curl -fL -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
 chmod +x oinc
+./oinc version
 sudo mv oinc /usr/local/bin/
 ```
 

--- a/e2e/tests/httproute-crud.spec.ts
+++ b/e2e/tests/httproute-crud.spec.ts
@@ -104,28 +104,12 @@ async function addRuleViaWizard(
 
 test.describe('HTTPRoute CRUD', () => {
   let namespace = '';
-  let gateway = '';
+  const gateway = 'kuadrant-ingressgateway';
+  const gatewayNamespace = 'gateway-system';
 
   test.beforeEach(async () => {
     namespace = `e2e-route-${uid()}`;
-    gateway = `e2e-gw-${uid()}`;
     kubectl(['create', 'namespace', namespace]);
-    applyResource(`
-apiVersion: gateway.networking.k8s.io/v1
-kind: Gateway
-metadata:
-  name: ${gateway}
-  namespace: ${namespace}
-spec:
-  gatewayClassName: istio
-  listeners:
-  - name: http
-    port: 80
-    protocol: HTTP
-    allowedRoutes:
-      namespaces:
-        from: Same
-`);
   });
 
   test.afterEach(async () => {
@@ -150,6 +134,7 @@ spec:
 
     const gatewayOption = page.locator(`#parent-gateway-0 option[value="${gateway}"]`);
     await expect(gatewayOption).toBeAttached({ timeout: 15_000 });
+    await expect(gatewayOption).not.toBeDisabled({ timeout: 15_000 });
     await page.locator('#parent-gateway-0').selectOption(gateway);
 
     const sectionOption = page.locator('#parent-section-0 option[value="http"]');
@@ -196,6 +181,7 @@ metadata:
 spec:
   parentRefs:
   - name: ${gateway}
+    namespace: ${gatewayNamespace}
     sectionName: http
   rules:
   - matches:
@@ -284,6 +270,7 @@ spec:
 
     const gatewayOption = page.locator(`#parent-gateway-0 option[value="${gateway}"]`);
     await expect(gatewayOption).toBeAttached({ timeout: 15_000 });
+    await expect(gatewayOption).not.toBeDisabled({ timeout: 15_000 });
     await page.locator('#parent-gateway-0').selectOption(gateway);
 
     const sectionOption = page.locator('#parent-section-0 option[value="http"]');

--- a/scripts/cluster-setup.sh
+++ b/scripts/cluster-setup.sh
@@ -17,8 +17,8 @@ PLUGIN_PORT="${PLUGIN_PORT:-9001}"
 # if a latest release breaks plugin development or CI.
 KUADRANT_VERSION="${KUADRANT_VERSION:-latest}"
 
-# pin to a published, soaked image; oinc v0.2.3 defaults to 4.22
-OCP_VERSION="${OCP_VERSION:-4.21}"
+# default to 4.22; override with OCP_VERSION to pin to a different version
+OCP_VERSION="${OCP_VERSION:-4.22}"
 
 check_command oinc "Install from https://github.com/jasonmadigan/oinc"
 check_command kubectl "Install from https://kubernetes.io/docs/tasks/tools/"
@@ -51,7 +51,8 @@ dump_kuadrant_diagnostics() {
 log "creating oinc cluster with addons (kuadrant@${KUADRANT_VERSION})..."
 if ! oinc create \
 	--version "${OCP_VERSION}" \
-	--addons "gateway-api,cert-manager,metallb,istio,kuadrant@${KUADRANT_VERSION}" \
+	--addons "gateway-api,cert-manager,metallb,istio,kuadrant@${KUADRANT_VERSION},mcp-gateway" \
+	--metallb-address-pool auto \
 	--console-plugin "${PLUGIN_NAME}=http://${HOST}:${PLUGIN_PORT}"; then
 	dump_kuadrant_diagnostics
 	exit 1
@@ -59,31 +60,6 @@ fi
 
 log "patch kuadrant to enable developer portal controller..."
 kubectl patch kuadrant kuadrant -n kuadrant-system --type merge --patch '{"spec": {"components": {"developerPortal": {"enabled": true}}}}'
-
-# --- MetalLB IP pool ---
-
-log "configuring MetalLB IP pool..."
-DOCKER_SUBNET=$(${RUNTIME} network inspect bridge -f '{{range .IPAM.Config}}{{.Subnet}}{{end}}' 2>/dev/null || echo "172.18.0.0/16")
-POOL_PREFIX=$(echo "${DOCKER_SUBNET}" | sed 's|\.[0-9]*/.*|.200|')
-POOL_END=$(echo "${DOCKER_SUBNET}" | sed 's|\.[0-9]*/.*|.220|')
-
-log "MetalLB pool: ${POOL_PREFIX}-${POOL_END}"
-kubectl apply -f - <<EOF
-apiVersion: metallb.io/v1beta1
-kind: IPAddressPool
-metadata:
-  name: dev-pool
-  namespace: metallb-system
-spec:
-  addresses:
-  - ${POOL_PREFIX}-${POOL_END}
----
-apiVersion: metallb.io/v1beta1
-kind: L2Advertisement
-metadata:
-  name: dev-l2
-  namespace: metallb-system
-EOF
 
 # --- Gateway ---
 
@@ -105,5 +81,9 @@ spec:
       namespaces:
         from: All
 EOF
+
+log "creating demo MCP resources..."
+kubectl create namespace toystore 2>/dev/null || true
+kubectl apply -f "${REPO_DIR}/scripts/mcp-demo.yaml"
 
 log "cluster setup complete"

--- a/scripts/mcp-demo.yaml
+++ b/scripts/mcp-demo.yaml
@@ -1,0 +1,89 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: mcp-test-server
+  namespace: toystore
+  labels:
+    app: mcp-test-server
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mcp-test-server
+  template:
+    metadata:
+      labels:
+        app: mcp-test-server
+    spec:
+      containers:
+        - name: mcp-test-server
+          image: ghcr.io/kuadrant/mcp-gateway/test-server1:latest
+          imagePullPolicy: IfNotPresent
+          command: ["/mcp-test-server"]
+          args: ["--http", "0.0.0.0:9090"]
+          ports:
+            - containerPort: 9090
+              name: http
+          env:
+            - name: LOG_LEVEL
+              value: "info"
+          resources:
+            limits:
+              memory: "128Mi"
+              cpu: "100m"
+            requests:
+              memory: "64Mi"
+              cpu: "50m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mcp-test-server
+  namespace: toystore
+  labels:
+    app: mcp-test-server
+spec:
+  ports:
+    - name: http
+      port: 9090
+      targetPort: 9090
+  selector:
+    app: mcp-test-server
+  type: ClusterIP
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: mcp-test-server-route
+  namespace: toystore
+  labels:
+    mcp-server: "true"
+spec:
+  parentRefs:
+    - name: mcp-gateway
+      namespace: gateway-system
+  hostnames:
+    - "mcp-test-server.mcp.local"
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /
+      backendRefs:
+        - name: mcp-test-server
+          port: 9090
+---
+apiVersion: mcp.kuadrant.io/v1alpha1
+kind: MCPServerRegistration
+metadata:
+  name: toystore-mcp-server
+  namespace: toystore
+  labels:
+    mcp.kuadrant.io/managed: "true"
+spec:
+  prefix: toystore_
+  targetRef:
+    group: gateway.networking.k8s.io
+    kind: HTTPRoute
+    name: mcp-test-server-route


### PR DESCRIPTION
## Summary

- Replaces the manual MCP Gateway Makefile install from #719 with oinc's native `mcp-gateway` addon
- Adds demo MCP resources (test server, HTTPRoute, MCPServerRegistration) to `scripts/mcp-demo.yaml`
- Bumps default OCP version from 4.21 to 4.22

Supersedes #719.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a sample MCP test server with internal service, HTTPRoute, and server registration.
  * Cluster setup now deploys the MCP demo in the `toystore` namespace.
  * Cluster creation now includes the MCP gateway addon.

* **Bug Fixes**
  * Improved installation validation and reporting for the command-line tool.
  * Updated end-to-end HTTPRoute tests to use the shared ingress gateway and verify gateway options.

* **Chores**
  * Updated the default OpenShift version to 4.22.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->