### PR TITLE
feat: upgrade to React 18 and SDK 4.22

### DIFF
--- a/__mocks__/jestSetup.ts
+++ b/__mocks__/jestSetup.ts
@@ -1,0 +1,3 @@
+import { TextEncoder, TextDecoder } from 'util';
+
+Object.assign(global, { TextEncoder, TextDecoder });

--- a/e2e/tests/api-product-list.spec.ts
+++ b/e2e/tests/api-product-list.spec.ts
@@ -11,11 +11,11 @@ import {
 test.describe('APIProduct List Page - Display and Filters', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
     await navigateToAPIProducts(page);
     await dismissConsoleTour(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test.afterEach(async ({ page }) => {
@@ -110,11 +110,11 @@ test.describe('APIProduct List Page - Display and Filters', () => {
 test.describe('APIProduct List Page - Status Filter', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
     await navigateToAPIProducts(page);
     await dismissConsoleTour(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test.afterEach(async ({ page }) => {
@@ -226,11 +226,11 @@ test.describe('APIProduct List Page - Status Filter', () => {
 test.describe('APIProduct List Page - Name Filter', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
     await navigateToAPIProducts(page);
     await dismissConsoleTour(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test.afterEach(async ({ page }) => {
@@ -325,11 +325,11 @@ test.describe('APIProduct List Page - Name Filter', () => {
 test.describe('APIProduct List Page - Namespace Filter', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
     await navigateToAPIProducts(page);
     await dismissConsoleTour(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test.afterEach(async ({ page }) => {
@@ -424,11 +424,11 @@ test.describe('APIProduct List Page - Namespace Filter', () => {
 test.describe('APIProduct List Page - HTTPRoute Filter', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
     await navigateToAPIProducts(page);
     await dismissConsoleTour(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test.afterEach(async ({ page }) => {
@@ -580,11 +580,11 @@ test.describe('APIProduct List Page - HTTPRoute Filter', () => {
 test.describe('APIProduct List Page - Combined Filters', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
     await navigateToAPIProducts(page);
     await dismissConsoleTour(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   });
 
   test.afterEach(async ({ page }) => {

--- a/e2e/tests/apikey-approvals.spec.ts
+++ b/e2e/tests/apikey-approvals.spec.ts
@@ -33,11 +33,11 @@ async function navigateAsOwner(page: Parameters<typeof navigateToAPIKeyApprovals
     }),
   );
   await page.goto('/');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await impersonateUser(page, 'test-api-owner');
   await navigateToAPIKeyApprovals(page);
   await dismissConsoleTour(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 }
 
 // ── RBAC ──────────────────────────────────────────────────────────────────────
@@ -45,7 +45,7 @@ async function navigateAsOwner(page: Parameters<typeof navigateToAPIKeyApprovals
 test.describe('APIKey Approvals - RBAC', () => {
   test('user without apikeyrequests access cannot see the approval table', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
     await impersonateUser(page, 'test-dev');
 
@@ -54,7 +54,7 @@ test.describe('APIKey Approvals - RBAC', () => {
       window.history.pushState({}, '', path);
       window.dispatchEvent(new PopStateEvent('popstate'));
     }, '/kuadrant/apikey-approvals/ns/kuadrant-test');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(page.locator('th:has-text("Requester")')).not.toBeVisible({ timeout: 10_000 });
     await expect(page.locator('td:has-text("alice@example.com")')).not.toBeVisible();
@@ -134,7 +134,7 @@ EOF
       execSync(`timeout 30 bash -c 'until kubectl get apikeyrequests -n kuadrant-test | grep -q ${aliceKey}; do sleep 1; done'`, { stdio: 'inherit' });
 
       await page.reload();
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
     });
 
     test.afterEach(async () => {

--- a/e2e/tests/apikey-lifecycle.spec.ts
+++ b/e2e/tests/apikey-lifecycle.spec.ts
@@ -40,7 +40,7 @@ async function spaNavigate(page: Page, path: string): Promise<void> {
     window.history.pushState({}, '', p);
     window.dispatchEvent(new PopStateEvent('popstate'));
   }, path);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 }
 
 async function navigateToMyAPIKeys(page: Page, namespace: string): Promise<void> {
@@ -63,7 +63,7 @@ test.describe('API Key Lifecycle', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
   });
 
@@ -75,7 +75,7 @@ test.describe('API Key Lifecycle', () => {
   test('should complete full API key lifecycle: request, reveal, and delete', { tag: '@smoke' }, async ({ page }) => {
     // Step 1: Navigate to My API Keys page
     await navigateToMyAPIKeys(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Dismiss tour modal if it appears after navigation
     await dismissConsoleTour(page);
@@ -198,7 +198,7 @@ test.describe('API Key Lifecycle', () => {
     // Step 10: Navigate to API key details page
     const apiKeyNameLink = apiKeyRow.locator(`a:has-text("${testAPIKeyName}")`);
     await apiKeyNameLink.click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Verify we're on the details page
     await expect(page.getByRole('heading', { name: testAPIKeyName, exact: true })).toBeVisible({
@@ -237,7 +237,7 @@ test.describe('API Key Lifecycle', () => {
     await confirmDeleteButton.click();
 
     // Step 14: Verify redirect back to list page
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await expect(page.getByRole('heading', { name: 'My API Keys', exact: true })).toBeVisible({
       timeout: 15000,
     });
@@ -250,7 +250,7 @@ test.describe('API Key Lifecycle', () => {
   test('should show disabled request button when namespace is not selected', { tag: '@smoke' }, async ({ page }) => {
     // Navigate to all namespaces view
     await spaNavigate(page, '/kuadrant/apikeys/all-namespaces');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
 
     // Request button should be disabled in all-namespaces view
@@ -267,7 +267,7 @@ test.describe('API Key Lifecycle', () => {
 
   test('should validate API key name format in request form', { tag: '@nightly' }, async ({ page }) => {
     await navigateToMyAPIKeys(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
 
     // Open request modal
@@ -318,7 +318,7 @@ test.describe('API Key Lifecycle', () => {
 
   test('should filter API products in request form', { tag: '@nightly' }, async ({ page }) => {
     await navigateToMyAPIKeys(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
 
     // Open request modal
@@ -387,11 +387,11 @@ test.describe('API Key expiry lifecycle', () => {
       }),
     );
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-api-owner');
     await navigateToAPIKeyApprovals(page);
     await dismissConsoleTour(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
   }
 
   let consumerNs: string;
@@ -481,7 +481,7 @@ EOF
 
       // Step 4: My API Keys shows "X days left"
       await spaNavigate(page, `/kuadrant/apikeys/ns/${consumerNs}`);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       const keyRow = page.locator(`tr:has-text("${keyName}")`);
       await expect(keyRow.locator('td:has-text("days left")')).toBeVisible({ timeout: 15_000 });
       await expect(keyRow.locator(`td:has-text("${FUTURE_LABEL}")`)).toBeVisible();
@@ -500,7 +500,7 @@ EOF
 
       // Step 7: reload → Expired badge + "Expired (date)" in Expires column
       await spaNavigate(page, `/kuadrant/apikeys/ns/${consumerNs}`);
-      await page.waitForLoadState('networkidle');
+      await page.waitForLoadState('domcontentloaded');
       const expiredRow = page.locator(`tr:has-text("${keyName}")`);
       await expect(
         expiredRow.locator('td[data-label="status"]:has-text("Expired")'),

--- a/e2e/tests/apiproduct-apikeys-tab.spec.ts
+++ b/e2e/tests/apiproduct-apikeys-tab.spec.ts
@@ -150,7 +150,7 @@ async function navigateToAPIProductAPIKeysTab(
     },
     { ns: namespace, name: productName },
   );
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 
   // Wait for the tab content to load - either the table header or empty state
   await expect(page.locator('th:has-text("Name"), th:has-text("Requester")').first()).toBeVisible({
@@ -160,11 +160,11 @@ async function navigateToAPIProductAPIKeysTab(
 
 async function navigateAsOwner(page: Parameters<typeof impersonateUser>[0]) {
   await page.goto('/');
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await dismissConsoleTour(page);
   await impersonateUser(page, 'test-api-owner');
   await navigateToAPIProductAPIKeysTab(page);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 }
 
 // ── View API Keys Tab ─────────────────────────────────────────────────────────

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -17,7 +17,7 @@ test.describe('APIProduct CRUD Operations', () => {
 
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
   });
 
@@ -35,7 +35,7 @@ test.describe('APIProduct CRUD Operations', () => {
   test('should navigate from list page to create page via Create button', { tag: '@smoke' }, async ({ page }) => {
     // Navigate to API Products list page
     await navigateToAPIProducts(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Wait for page to load and verify we're on the list page (use exact role match to avoid matching empty state)
     await expect(page.getByRole('heading', { name: 'API Products', exact: true })).toBeVisible({
@@ -61,7 +61,7 @@ test.describe('APIProduct CRUD Operations', () => {
     // TEST_NAMESPACE before we SPA-navigate to the create page. Without this,
     // useActiveNamespace() returns '#ALL_NS#' and k8sCreate posts to an invalid namespace.
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     // Wait for form to render — confirms routing and component mount, not just URL change
     await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
@@ -140,7 +140,7 @@ test.describe('APIProduct CRUD Operations', () => {
 
   test('should validate resource name format', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     const displayNameInput = page.locator('#display-name');
     const resourceNameInput = page.locator('#resource-name');
@@ -201,7 +201,7 @@ test.describe('APIProduct CRUD Operations', () => {
   test('should sync between Form and YAML views', { tag: '@smoke' }, async ({ page }) => {
     // Full page load first so activeNamespace is set correctly before SPA navigation
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
@@ -265,7 +265,7 @@ test.describe('APIProduct CRUD Operations', () => {
 
     // Form -> YAML: verify YAML reflects form values
     await page.locator('button:has-text("YAML View")').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Poll Monaco API directly until YAML is populated
     const yamlHandle = await page.waitForFunction(
@@ -295,7 +295,7 @@ test.describe('APIProduct CRUD Operations', () => {
 
     // State retention: verify form values survive a tab switch to YAML and back
     await page.locator('button:has-text("Form View")').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     await expect(page.locator('#display-name')).toHaveValue('YAML Sync Test');
     await expect(page.locator('#resource-name')).toHaveValue(resourceName);
@@ -306,7 +306,7 @@ test.describe('APIProduct CRUD Operations', () => {
 
   test('should disable Deprecated and Retired statuses', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Scroll to publish status section
     await page.locator('text=Lifecycle and Visibility').scrollIntoViewIfNeeded();
@@ -332,7 +332,7 @@ test.describe('APIProduct CRUD Operations', () => {
 
   test('should prevent form submission on Enter in tags', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Fill required fields first
     await page.locator('#display-name').fill('Enter Key Test');
@@ -366,13 +366,13 @@ test.describe('APIProduct CRUD Operations', () => {
 
   test('should create APIProduct via YAML view and verify in list', { tag: '@smoke' }, async ({ page }) => {
     await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForSelector('#display-name', { state: 'visible', timeout: 20000 });
 
     // Switch to YAML view
     await page.locator('button:has-text("YAML View")').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     const yamlProductName = `yaml-product-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
     generatedResourceName = yamlProductName;
@@ -418,7 +418,7 @@ spec:
     // ResourceYAMLEditor navigates to the k8s details page after creation (not our custom page).
     // Use a full page.goto() so the console properly loads our custom list route.
     await page.goto(`/kuadrant/apiproducts/ns/${TEST_NAMESPACE}`);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('table', { timeout: 15000 });
 
     const found = await findRowWithPagination(page, yamlProductName);
@@ -588,7 +588,7 @@ EOF`, { stdio: 'inherit' });
 
     // Switch to YAML view
     await page.locator('button:has-text("YAML View")').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // Wait for Monaco to initialise with existing resource YAML
     const yamlHandle = await page.waitForFunction(
@@ -647,7 +647,7 @@ EOF`, { stdio: 'inherit' });
     await saveButton.click();
 
     // Verify redirect to list
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await expect(page.getByRole('heading', { name: 'API Products', exact: true })).toBeVisible({
       timeout: 20000,
     });
@@ -707,7 +707,7 @@ EOF`, { stdio: 'inherit' });
 
   test('should auto-generate resource name with unique suffix', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     const displayNameInput = page.locator('#display-name');
     const resourceNameInput = page.locator('#resource-name');
@@ -733,7 +733,7 @@ EOF`, { stdio: 'inherit' });
 
   test('should handle special characters in display name conversion', { tag: '@nightly' }, async ({ page }) => {
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     const displayNameInput = page.locator('#display-name');
     const resourceNameInput = page.locator('#resource-name');

--- a/e2e/tests/apiproduct-rbac.spec.ts
+++ b/e2e/tests/apiproduct-rbac.spec.ts
@@ -14,14 +14,14 @@ async function impersonateAndNavigate(
   targetUrl: string,
 ): Promise<void> {
   await page.goto(startUrl);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await impersonateUser(page, 'test-dev');
   // now on Projects page, impersonated as test-dev
   await page.evaluate((url: string) => {
     window.history.pushState({}, '', url);
     window.dispatchEvent(new PopStateEvent('popstate'));
   }, targetUrl);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 }
 
 // test-dev: no API Management permissions.

--- a/e2e/tests/attached-tab.spec.ts
+++ b/e2e/tests/attached-tab.spec.ts
@@ -27,7 +27,7 @@ function deleteNamespace(namespace: string): void {
 
 async function gotoPage(page: Page, path: string): Promise<void> {
   await page.goto(path);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await dismissConsoleTour(page);
 }
 

--- a/e2e/tests/gateway-crud.spec.ts
+++ b/e2e/tests/gateway-crud.spec.ts
@@ -31,7 +31,7 @@ function deleteNamespace(namespace: string): void {
 
 async function gotoPage(page: Page, path: string): Promise<void> {
   await page.goto(path);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await dismissConsoleTour(page);
 }
 

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -109,7 +109,7 @@ export async function impersonateUser(page: Page, username: string): Promise<voi
     state: 'visible',
     timeout: 10_000,
   });
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 }
 
 // stop impersonation if active
@@ -145,7 +145,7 @@ export async function spaNavigate(page: Page, path: string): Promise<void> {
     window.history.pushState({}, '', p);
     window.dispatchEvent(new PopStateEvent('popstate'));
   }, path);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 }
 
 // Scroll through all pagination pages looking for a row matching `text`.
@@ -196,7 +196,7 @@ export async function navigateToAPIKeyApprovals(page: Page, namespace?: string):
   // Full page navigation so the console reads the namespace from the URL and updates its
   // active namespace state. spaNavigate (pushState) does not trigger the namespace update.
   await page.goto(`/kuadrant/apikey-approvals/ns/${ns}`);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
 }
 
 // wait for RBAC permission checks to finish loading.

--- a/e2e/tests/httproute-crud.spec.ts
+++ b/e2e/tests/httproute-crud.spec.ts
@@ -31,7 +31,7 @@ function deleteNamespace(namespace: string): void {
 
 async function gotoPage(page: Page, path: string): Promise<void> {
   await page.goto(path);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await dismissConsoleTour(page);
 }
 

--- a/e2e/tests/overview.spec.ts
+++ b/e2e/tests/overview.spec.ts
@@ -12,7 +12,7 @@ import {
 test.describe('Overview dashboard', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
     await spaNavigate(page, `/kuadrant/overview/ns/${TEST_NAMESPACE}`);
     await waitForPermissionsLoaded(page);

--- a/e2e/tests/policy-forms.spec.ts
+++ b/e2e/tests/policy-forms.spec.ts
@@ -52,7 +52,7 @@ spec:
 // URL (pushState does not update the console's namespace state)
 async function gotoPage(page: Page, path: string): Promise<void> {
   await page.goto(path);
-  await page.waitForLoadState('networkidle');
+  await page.waitForLoadState('domcontentloaded');
   await dismissConsoleTour(page);
 }
 

--- a/e2e/tests/rbac.spec.ts
+++ b/e2e/tests/rbac.spec.ts
@@ -13,7 +13,7 @@ import {
 test.describe('RBAC - test-dev persona', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-dev');
   });
 
@@ -42,7 +42,7 @@ test.describe('RBAC - test-dev persona', () => {
   // /kuadrant/overview/ns/default/ (fallback namespace when activeNamespace is #ALL_NS#).
   test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // verify we were redirected to namespace-scoped URL (uses 'default' as fallback)
     await expect(page).toHaveURL(/\/kuadrant\/overview\/ns\/default/, { timeout: 15_000 });
@@ -59,7 +59,7 @@ test.describe('RBAC - test-dev persona', () => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
       window.dispatchEvent(new PopStateEvent('popstate'));
     });
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // should stay on this URL (no redirect since they have permissions)
     await expect(page).toHaveURL('/kuadrant/overview/ns/kuadrant-test', { timeout: 15_000 });
@@ -97,7 +97,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
 
     // go to Auth tab where our test fixture lives
     await page.locator('[data-test-id="horizontal-link-Auth"]').click();
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // wait for the test policy row to appear
     const row = page.locator('tr:has-text("test-auth-policy")');
@@ -110,7 +110,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
 
   test('read-only user sees disabled edit and delete', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-viewer');
 
     await openKebabForTestPolicy(page);
@@ -128,7 +128,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
 
   test('CRUD user sees enabled edit and delete', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-devops');
 
     await openKebabForTestPolicy(page);
@@ -146,7 +146,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
 
   test('admin user sees enabled edit and delete', { tag: '@smoke' }, async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
 
     await openKebabForTestPolicy(page);
@@ -168,7 +168,7 @@ test.describe('RBAC - kebab menu (edit/delete)', () => {
 test.describe('RBAC - test-viewer persona', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-viewer');
   });
 
@@ -210,7 +210,7 @@ test.describe('RBAC - test-viewer persona', () => {
 
   test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@nightly' }, async ({ page }) => {
     await navigateToOverview(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // verify we were redirected to namespace-scoped URL (uses 'default' as fallback)
     await expect(page).toHaveURL(/\/kuadrant\/overview\/ns\/default/, { timeout: 15_000 });
@@ -227,7 +227,7 @@ test.describe('RBAC - test-viewer persona', () => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
       window.dispatchEvent(new PopStateEvent('popstate'));
     });
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // should stay on this URL (no redirect since they have permissions)
     await expect(page).toHaveURL('/kuadrant/overview/ns/kuadrant-test', { timeout: 15_000 });
@@ -251,7 +251,7 @@ test.describe('RBAC - test-viewer persona', () => {
 test.describe('RBAC - test-devops persona', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-devops');
   });
 
@@ -305,7 +305,7 @@ test.describe('RBAC - test-devops persona', () => {
 
   test('overview redirects to namespace-scoped view (namespace-scoped user)', { tag: '@nightly' }, async ({ page }) => {
     await navigateToOverview(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // verify we were redirected to namespace-scoped URL (uses 'default' as fallback)
     await expect(page).toHaveURL(/\/kuadrant\/overview\/ns\/default/, { timeout: 15_000 });
@@ -322,7 +322,7 @@ test.describe('RBAC - test-devops persona', () => {
       window.history.pushState({}, '', '/kuadrant/overview/ns/kuadrant-test');
       window.dispatchEvent(new PopStateEvent('popstate'));
     });
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // should stay on this URL (no redirect since they have permissions)
     await expect(page).toHaveURL('/kuadrant/overview/ns/kuadrant-test', { timeout: 15_000 });
@@ -346,7 +346,7 @@ test.describe('RBAC - test-devops persona', () => {
 test.describe('RBAC - test-admin persona', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await impersonateUser(page, 'test-admin');
   });
 
@@ -383,7 +383,7 @@ test.describe('RBAC - test-admin persona', () => {
 
   test('overview stays on cluster-wide view (no redirect for cluster-admin)', { tag: '@smoke' }, async ({ page }) => {
     await navigateToOverview(page);
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
 
     // verify admin users stay on /kuadrant/overview (cluster-wide view, no redirect)
     await expect(page).toHaveURL('/kuadrant/overview/all-namespaces', { timeout: 15_000 });

--- a/e2e/tests/topology.spec.ts
+++ b/e2e/tests/topology.spec.ts
@@ -26,7 +26,7 @@ async function closeFilterMenu(page: Page): Promise<void> {
 test.describe('Policy Topology', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
-    await page.waitForLoadState('networkidle');
+    await page.waitForLoadState('domcontentloaded');
     await dismissConsoleTour(page);
     await navigateToTopology(page);
 

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -2,6 +2,7 @@ import type { Config } from 'jest';
 
 const config: Config = {
   testEnvironment: 'jsdom',
+  setupFiles: ['<rootDir>/__mocks__/jestSetup.ts'],
   setupFilesAfterEnv: ['@testing-library/jest-dom'],
   transform: {
     '^.+\\.(ts|tsx)$': ['ts-jest', {
@@ -9,9 +10,7 @@ const config: Config = {
         jsx: 'react',
         esModuleInterop: true,
       },
-      // react-i18next 16 widens React.HTMLAttributes.children,
-      // tripping spurious PatternFly prop checks. remove after sdk 4.22 bump
-      diagnostics: false,
+      diagnostics: true,
     }],
   },
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -34,24 +34,22 @@
     "lodash": "4.18.0",
     "node-forge": "^1.3.2",
     "qs": "6.14.1",
-    "brace-expansion@^5": "^5.0.7",
-    "@openshift-console/dynamic-plugin-sdk-webpack/webpack": "^5.100.0"
+    "brace-expansion@^5": "^5.0.7"
   },
   "devDependencies": {
-    "@openshift-console/dynamic-plugin-sdk": "^1.6.0",
-    "@openshift-console/dynamic-plugin-sdk-webpack": "1.2.0",
+    "@openshift-console/dynamic-plugin-sdk": "4.22.0",
+    "@openshift-console/dynamic-plugin-sdk-webpack": "4.22.0",
     "@patternfly/react-core": "^6.4.0",
     "@patternfly/react-icons": "^6.4.0",
     "@playwright/test": "^1.50.0",
     "@testing-library/jest-dom": "^6.9.1",
-    "@testing-library/react": "^12",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.6.1",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",
     "@types/node": "^18.0.0",
-    "@types/react": "^17.0.37",
+    "@types/react": "^18.0.0",
     "@types/react-helmet": "^6.1.4",
-    "@types/react-router-dom": "^5.3.2",
     "@typescript-eslint/eslint-plugin": "^8.0.0",
     "@typescript-eslint/parser": "^8.0.0",
     "copy-webpack-plugin": "^12.0.2",
@@ -64,12 +62,11 @@
     "jest-environment-jsdom": "^30.4.1",
     "prettier": "^2.7.1",
     "prettier-stylelint": "^0.4.2",
-    "react": "^17.0.1",
-    "react-dom": "^17.0.1",
+    "react": "^18.0.0",
+    "react-dom": "^18.0.0",
     "react-helmet": "^6.1.0",
     "react-i18next": "~16.5.8",
-    "react-router": "5.3.x",
-    "react-router-dom": "5.3.x",
+    "react-router": "~7.13.1",
     "style-loader": "^3.3.1",
     "stylelint": "^15.3.0",
     "stylelint-config-standard": "^31.0.0",
@@ -86,7 +83,7 @@
     "version": "0.6.0",
     "displayName": "Kuadrant OpenShift Console Plugin",
     "description": "Kuadrant OpenShift Console Plugin",
-    "latestSupportedOpenshiftVersion": "4.19",
+    "latestSupportedOpenshiftVersion": "4.22",
     "i18n": {
       "loadType": "Preload"
     },
@@ -127,7 +124,7 @@
       "HTTPRouteSingleOverview": "./components/httproute/HTTPRouteSingleOverview"
     },
     "dependencies": {
-      "@console/pluginAPI": "*"
+      "@console/pluginAPI": ">=4.22.0-0"
     }
   },
   "dependencies": {
@@ -135,7 +132,7 @@
     "@babel/preset-env": "^7.25.3",
     "@babel/preset-react": "^7.24.7",
     "@patternfly/react-table": "^6.4.0",
-    "@patternfly/react-topology": "^6.4.0",
+    "@patternfly/react-topology": "~6.4.0",
     "babel-loader": "^8.2.0",
     "graphlib": "^2.1.8",
     "graphlib-dot": "^0.6.4",

--- a/src/components/DropdownWithKebab.tsx
+++ b/src/components/DropdownWithKebab.tsx
@@ -17,7 +17,7 @@ import {
 } from '@patternfly/react-core';
 
 import { k8sDelete, K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { RESOURCES, ResourceKind } from '../utils/resources';
 import useAccessReviews from '../utils/resourceRBAC';
 import { getModelFromResource, getResourceNameFromKind } from '../utils/getModelFromResource';

--- a/src/components/GRPCRoutePoliciesPage.tsx
+++ b/src/components/GRPCRoutePoliciesPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { PageSection, Title } from '@patternfly/react-core';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import './kuadrant.css';
 import AssociatedResourceList from './AssociatedResourceList';
 import {

--- a/src/components/GatewayPoliciesPage.tsx
+++ b/src/components/GatewayPoliciesPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { PageSection, Title } from '@patternfly/react-core';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import './kuadrant.css';
 import AssociatedResourceList from './AssociatedResourceList';
 import {

--- a/src/components/HTTPRoutePoliciesPage.tsx
+++ b/src/components/HTTPRoutePoliciesPage.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import { PageSection, Title } from '@patternfly/react-core';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import './kuadrant.css';
 import AssociatedResourceList from './AssociatedResourceList';
 import {

--- a/src/components/KuadrantCreateUpdate.tsx
+++ b/src/components/KuadrantCreateUpdate.tsx
@@ -8,7 +8,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import { useTranslation } from 'react-i18next';
 import { Button, AlertVariant, Alert, AlertGroup } from '@patternfly/react-core';
-import { NavigateFunction } from 'react-router-dom-v5-compat';
+import { NavigateFunction } from 'react-router';
 
 interface GenericPolicyForm {
   model: K8sModel;

--- a/src/components/KuadrantDNSPolicyCreatePage.tsx
+++ b/src/components/KuadrantDNSPolicyCreatePage.tsx
@@ -24,7 +24,7 @@ import {
   K8sResourceCommon,
   useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation } from 'react-router';
 import { LoadBalancing, HealthCheck } from './dnspolicy/types';
 import LoadBalancingField from './dnspolicy/LoadBalancingField';
 import HealthCheckField from './dnspolicy/HealthCheckField';

--- a/src/components/KuadrantOIDCPolicyCreatePage.tsx
+++ b/src/components/KuadrantOIDCPolicyCreatePage.tsx
@@ -23,7 +23,7 @@ import {
   K8sResourceCommon,
   useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation } from 'react-router';
 import { GatewayResource } from './gateway/types';
 import GatewaySelect from './gateway/GatewaySelect';
 import * as yaml from 'js-yaml';

--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate, useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation, useParams } from 'react-router';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
 import {

--- a/src/components/KuadrantPlanPolicyCreatePage.tsx
+++ b/src/components/KuadrantPlanPolicyCreatePage.tsx
@@ -25,7 +25,7 @@ import {
   K8sResourceCommon,
   useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation } from 'react-router';
 import HTTPRouteSelect from './httproute/HTTPRouteSelect';
 import * as yaml from 'js-yaml';
 import KuadrantCreateUpdate from './KuadrantCreateUpdate';

--- a/src/components/KuadrantPoliciesPage.tsx
+++ b/src/components/KuadrantPoliciesPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { sortable } from '@patternfly/react-table';
 import {

--- a/src/components/KuadrantTLSCreatePage.tsx
+++ b/src/components/KuadrantTLSCreatePage.tsx
@@ -22,7 +22,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import './kuadrant.css';
 import { handleCancel } from '../utils/cancel';
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation } from 'react-router';
 import * as yaml from 'js-yaml';
 import { useTranslation } from 'react-i18next';
 import ClusterIssuerSelect from './issuer/clusterIssuerSelect';

--- a/src/components/KuadrantTokenRateLimitPolicyCreatePage.tsx
+++ b/src/components/KuadrantTokenRateLimitPolicyCreatePage.tsx
@@ -28,7 +28,7 @@ import {
   K8sResourceCommon,
   useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { useNavigate, useLocation } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation } from 'react-router';
 import { GatewayResource } from './gateway/types';
 import GatewaySelect from './gateway/GatewaySelect';
 import * as yaml from 'js-yaml';

--- a/src/components/PolicyTargetRefPage.tsx
+++ b/src/components/PolicyTargetRefPage.tsx
@@ -12,7 +12,7 @@ import {
   DescriptionListDescription,
   Skeleton,
 } from '@patternfly/react-core';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import {
   K8sResourceCommon,
   ResourceLink,

--- a/src/components/apikey/APIKeyApprovalTable.tsx
+++ b/src/components/apikey/APIKeyApprovalTable.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { Table, Thead, Tr, Th, Tbody, Td, SortByDirection } from '@patternfly/react-table';
 import {
   Dropdown,

--- a/src/components/apikey/APIKeyDetailPage.tsx
+++ b/src/components/apikey/APIKeyDetailPage.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useParams, useNavigate } from 'react-router-dom-v5-compat';
+import { useParams, useNavigate } from 'react-router';
 import {
   PageSection,
   Title,
@@ -19,7 +19,7 @@ import {
   TabTitleText,
 } from '@patternfly/react-core';
 import { ExternalLinkAltIcon } from '@patternfly/react-icons';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import {
   useK8sWatchResource,
   k8sDelete,

--- a/src/components/apikey/MyAPIKeysPage.tsx
+++ b/src/components/apikey/MyAPIKeysPage.tsx
@@ -1,8 +1,8 @@
 import * as React from 'react';
-import { useNavigate, useLocation, useParams } from 'react-router-dom-v5-compat';
+import { useNavigate, useLocation, useParams } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import Helmet from 'react-helmet';
-import { Link } from 'react-router-dom-v5-compat';
+import { Link } from 'react-router';
 import { sortable } from '@patternfly/react-table';
 import {
   PageSection,

--- a/src/components/apiproduct/APIProductAPIKeysTab.tsx
+++ b/src/components/apiproduct/APIProductAPIKeysTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import { sortable } from '@patternfly/react-table';
 import {
   PageSection,

--- a/src/components/apiproduct/APIProductCreatePage.tsx
+++ b/src/components/apiproduct/APIProductCreatePage.tsx
@@ -18,7 +18,7 @@ import {
   useActiveNamespace,
   NamespaceBar,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router';
 import { APIProduct } from './types';
 import APIProductForm, { APIProductFormData } from './APIProductForm';
 import { RESOURCES } from '../../utils/resources';

--- a/src/components/apiproduct/APIProductDefinitionTab.tsx
+++ b/src/components/apiproduct/APIProductDefinitionTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import {
   PageSection,
   Title,

--- a/src/components/apiproduct/APIProductForm.tsx
+++ b/src/components/apiproduct/APIProductForm.tsx
@@ -19,7 +19,7 @@ import {
 } from '@patternfly/react-core';
 import { HelpIcon } from '@patternfly/react-icons';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { RESOURCES } from '../../utils/resources';
 import { getModelFromResource } from '../../utils/getModelFromResource';
 import { APIProduct } from './types';

--- a/src/components/apiproduct/APIProductOverviewTab.tsx
+++ b/src/components/apiproduct/APIProductOverviewTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import {
   PageSection,
   DescriptionList,

--- a/src/components/apiproduct/APIProductPoliciesTab.tsx
+++ b/src/components/apiproduct/APIProductPoliciesTab.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import {
   PageSection,
   Title,

--- a/src/components/apiproduct/useAPIProductActions.tsx
+++ b/src/components/apiproduct/useAPIProductActions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
 import {

--- a/src/components/dnspolicy/useDNSPolicyActions.tsx
+++ b/src/components/dnspolicy/useDNSPolicyActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';

--- a/src/components/gateway/GatewayCreatePage.tsx
+++ b/src/components/gateway/GatewayCreatePage.tsx
@@ -40,7 +40,7 @@ import {
 } from '@openshift-console/dynamic-plugin-sdk';
 import * as yaml from 'js-yaml';
 import KuadrantCreateUpdate from '../KuadrantCreateUpdate';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router';
 import { GatewayResource } from './types';
 import type { K8sResourceCommon } from '@openshift-console/dynamic-plugin-sdk';
 import {

--- a/src/components/gateway/GatewaySingleOverview.tsx
+++ b/src/components/gateway/GatewaySingleOverview.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import '../kuadrant.css';
 import { PageSection } from '@patternfly/react-core';
 import {

--- a/src/components/gateway/useGatewayActions.tsx
+++ b/src/components/gateway/useGatewayActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';

--- a/src/components/httproute/HTTPRouteCreatePage.tsx
+++ b/src/components/httproute/HTTPRouteCreatePage.tsx
@@ -26,7 +26,7 @@ import {
   useK8sWatchResource,
   useActiveNamespace,
 } from '@openshift-console/dynamic-plugin-sdk';
-import { useLocation, useNavigate } from 'react-router-dom-v5-compat';
+import { useLocation, useNavigate } from 'react-router';
 import * as yaml from 'js-yaml';
 import ParentReferencesSelect from '../../utils/ParentReferencesSelect';
 import { Table, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';

--- a/src/components/httproute/HTTPRouteSelect.tsx
+++ b/src/components/httproute/HTTPRouteSelect.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import * as React from 'react';
 import { useTranslation } from 'react-i18next';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { RESOURCES } from '../../utils/resources';
 
 interface HTTPRouteSelectProps {

--- a/src/components/httproute/HTTPRouteSingleOverview.tsx
+++ b/src/components/httproute/HTTPRouteSingleOverview.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import Helmet from 'react-helmet';
 import { useTranslation } from 'react-i18next';
-import { useLocation } from 'react-router-dom-v5-compat';
+import { useLocation } from 'react-router';
 import '../kuadrant.css';
 import { PageSection } from '@patternfly/react-core';
 import {

--- a/src/components/httproute/useHTTPRouteActions.tsx
+++ b/src/components/httproute/useHTTPRouteActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { useTranslation } from 'react-i18next';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';

--- a/src/components/oidcpolicy/useOIDCPolicyActions.tsx
+++ b/src/components/oidcpolicy/useOIDCPolicyActions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
 import {

--- a/src/components/planpolicy/usePlanPolicyActions.tsx
+++ b/src/components/planpolicy/usePlanPolicyActions.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
+import { useNavigate } from 'react-router';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
 import {

--- a/src/components/tlspolicy/useTLSPolicyActions.tsx
+++ b/src/components/tlspolicy/useTLSPolicyActions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
 import {

--- a/src/components/tokenratelimitpolicy/useTokenRateLimitPolicyActions.tsx
+++ b/src/components/tokenratelimitpolicy/useTokenRateLimitPolicyActions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { useNavigate } from 'react-router-dom-v5-compat';
 import { useTranslation } from 'react-i18next';
+import { useNavigate } from 'react-router';
 import { ExtensionHookResult } from '@openshift-console/dynamic-plugin-sdk/lib/api/common-types';
 import { Action } from '@openshift-console/dynamic-plugin-sdk/lib/extensions/actions';
 import {

--- a/src/hooks/useKuadrantNamespaceChange.ts
+++ b/src/hooks/useKuadrantNamespaceChange.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useParams, useNavigate, useLocation } from 'react-router-dom-v5-compat';
+import { useParams, useNavigate, useLocation } from 'react-router';
 import { useActiveNamespace } from '@openshift-console/dynamic-plugin-sdk';
 
 /**

--- a/src/utils/cancel.tsx
+++ b/src/utils/cancel.tsx
@@ -1,4 +1,4 @@
-import { NavigateFunction } from 'react-router-dom-v5-compat';
+import { NavigateFunction } from 'react-router';
 
 export function handleCancel(navigate: NavigateFunction) {
   navigate(-1);

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -52,8 +52,6 @@ const config: Configuration = {
             loader: 'ts-loader',
             options: {
               configFile: path.resolve(__dirname, 'tsconfig.json'),
-              // react-i18next 16 widens React.HTMLAttributes.children,
-              // tripping spurious PatternFly prop checks. remove after sdk 4.22 bump
               transpileOnly: true,
             },
           },
@@ -99,8 +97,6 @@ const config: Configuration = {
   plugins: [
     new ConsoleRemotePlugin({
       extensions: allExtensions,
-      // sdk 1.x declares react-i18next ^11; ocp 4.22 provides ~16.5.8. remove after sdk bump
-      validateSharedModules: false,
     }),
     new CopyWebpackPlugin({
       patterns: [{ from: path.resolve(__dirname, 'locales'), to: 'locales' }],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1538,7 +1538,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.1.2, @babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.12.13, @babel/runtime@npm:^7.14.5, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.7.6, @babel/runtime@npm:^7.8.4":
+"@babel/runtime@npm:^7.12.1, @babel/runtime@npm:^7.23.2, @babel/runtime@npm:^7.8.4":
   version: 7.26.10
   resolution: "@babel/runtime@npm:7.26.10"
   dependencies:
@@ -1547,7 +1547,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@babel/runtime@npm:^7.12.5, @babel/runtime@npm:^7.15.4":
+"@babel/runtime@npm:^7.12.5":
   version: 7.29.7
   resolution: "@babel/runtime@npm:7.29.7"
   checksum: 10c0/ca11572f7146b21e0bde6a9ed4bb6a89eafbee5f0944c7eb54d0d8a2dac962c33638a1d611e14faa71dfbb92b4b5f9236232208568a6b7d5c6f3f39ddb91771e
@@ -2803,11 +2803,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@openshift-console/dynamic-plugin-sdk-webpack@npm:1.2.0":
-  version: 1.2.0
-  resolution: "@openshift-console/dynamic-plugin-sdk-webpack@npm:1.2.0"
+"@openshift-console/dynamic-plugin-sdk-webpack@npm:4.22.0":
+  version: 4.22.0
+  resolution: "@openshift-console/dynamic-plugin-sdk-webpack@npm:4.22.0"
   dependencies:
-    "@openshift/dynamic-plugin-sdk-webpack": "npm:^4.0.2"
+    "@openshift/dynamic-plugin-sdk": "npm:^8.0.0"
+    "@openshift/dynamic-plugin-sdk-webpack": "npm:^5.1.1"
     ajv: "npm:^6.12.3"
     chalk: "npm:2.4.x"
     comment-json: "npm:4.x"
@@ -2816,49 +2817,83 @@ __metadata:
     lodash: "npm:^4.17.21"
     read-pkg: "npm:5.x"
     semver: "npm:6.x"
-    webpack: "npm:5.75.0"
   peerDependencies:
-    typescript: ">=4.5.5"
-  checksum: 10c0/736778d82a057fefe01ba054ebc72baa7b6443f98b23f054e05b4947585d6f487ce8fd05110ed92ff7dfd52394214891137ec0fcb96a4535e0f23d75e38bd90b
+    typescript: ">=5.9.3"
+    webpack: ">=5.100.0"
+  checksum: 10c0/078c35b5bd8a1b96d71c36b80acbf24da59c1e3f0dedbdf0ed484635d1b09436c606ac711ee058e3a1e1abc3618ed866ed739dabb04d1f325cdd0135719d00eb
   languageName: node
   linkType: hard
 
-"@openshift-console/dynamic-plugin-sdk@npm:^1.6.0":
-  version: 1.6.0
-  resolution: "@openshift-console/dynamic-plugin-sdk@npm:1.6.0"
+"@openshift-console/dynamic-plugin-sdk@npm:4.22.0":
+  version: 4.22.0
+  resolution: "@openshift-console/dynamic-plugin-sdk@npm:4.22.0"
   dependencies:
-    classnames: "npm:2.x"
-    immutable: "npm:3.x"
+    "@openshift/dynamic-plugin-sdk": "npm:^8.0.0"
+    immutable: "npm:^3.8.3"
     lodash: "npm:^4.17.21"
-    react: "npm:^17.0.1"
-    react-i18next: "npm:^11.7.3"
-    react-redux: "npm:7.2.2"
-    react-router: "npm:5.3.x"
-    react-router-dom: "npm:5.3.x"
-    react-router-dom-v5-compat: "npm:^6.11.2"
-    redux: "npm:4.0.1"
-    redux-thunk: "npm:2.4.0"
-    reselect: "npm:4.x"
-    typesafe-actions: "npm:^4.2.1"
-    whatwg-fetch: "npm:2.x"
-  checksum: 10c0/e98750c8179404a6f2d9538d6237b12f3acbb77b97f95614a78185f10eabf7b065310ffc8200167e341e9b631269fee202974ed589ac946e9272b4383f832ddc
-  languageName: node
-  linkType: hard
-
-"@openshift/dynamic-plugin-sdk-webpack@npm:^4.0.2":
-  version: 4.1.0
-  resolution: "@openshift/dynamic-plugin-sdk-webpack@npm:4.1.0"
-  dependencies:
-    lodash: "npm:^4.17.21"
-    semver: "npm:^7.3.7"
-    yup: "npm:^0.32.11"
+    reselect: "npm:^5.1.1"
+    typesafe-actions: "npm:^5.1.0"
   peerDependencies:
-    webpack: ^5.75.0
-  checksum: 10c0/c917918fee5848cafbc5172195aa76b9651aa371e0e7413e919328f1d43acbee45d73672cdba629a393b8b2784c1323e7766ea2cb61a2308aa767859252dd86b
+    "@patternfly/react-topology": ~6.4.0
+    react: ^18.3.1
+    react-i18next: ~16.5.8
+    react-redux: ~9.2.0
+    react-router: ~7.13.1
+    redux: ~5.0.1
+    redux-thunk: ~3.1.0
+  peerDependenciesMeta:
+    "@patternfly/react-topology":
+      optional: true
+    react:
+      optional: true
+    react-i18next:
+      optional: true
+    react-redux:
+      optional: true
+    react-router:
+      optional: true
+    redux:
+      optional: true
+    redux-thunk:
+      optional: true
+  checksum: 10c0/d2eaf768a44ee595c89eb1007087507fe366296d5cf5b589a82af7ed04d5a6de6bd9ed073879eff80dd0d839073e16c693c00f5483233a34521b9022b4d338b2
   languageName: node
   linkType: hard
 
-"@patternfly/react-core@npm:^6.4.0, @patternfly/react-core@npm:^6.5.1, @patternfly/react-core@npm:^6.6.1":
+"@openshift/dynamic-plugin-sdk-webpack@npm:^5.1.1":
+  version: 5.3.0
+  resolution: "@openshift/dynamic-plugin-sdk-webpack@npm:5.3.0"
+  dependencies:
+    lodash: "npm:^4.17.23"
+    semver: "npm:^7.7.3"
+    zod: "npm:^3.25.67"
+  peerDependencies:
+    "@rspack/core": ^2.0.8
+    webpack: ^5.100.0
+  peerDependenciesMeta:
+    "@rspack/core":
+      optional: true
+    webpack:
+      optional: true
+  checksum: 10c0/7294d01156d86eab453a88fe663145c8c769e1886e0e517159fe7b008827274ab53fe70788c343bbe93cf2e0c20098fb9b59313409e72c9a7060a2c1288ada30
+  languageName: node
+  linkType: hard
+
+"@openshift/dynamic-plugin-sdk@npm:^8.0.0":
+  version: 8.2.0
+  resolution: "@openshift/dynamic-plugin-sdk@npm:8.2.0"
+  dependencies:
+    lodash: "npm:^4.17.23"
+    semver: "npm:^7.7.3"
+    uuid: "npm:^8.3.2"
+    yup: "npm:^1.7.1"
+  peerDependencies:
+    react: ^18 || ^19
+  checksum: 10c0/a9e3e1a145014a13310acd4630c7a2b7a7545b6c089e1d41e99ceaec061c1a270051d44bd26ddd09ec61bb02533ecfab55663cedb41a20d63acf824067eb63ab
+  languageName: node
+  linkType: hard
+
+"@patternfly/react-core@npm:^6.0.0, @patternfly/react-core@npm:^6.4.0, @patternfly/react-core@npm:^6.6.1":
   version: 6.6.1
   resolution: "@patternfly/react-core@npm:6.6.1"
   dependencies:
@@ -2875,7 +2910,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-icons@npm:^6.4.0, @patternfly/react-icons@npm:^6.5.1, @patternfly/react-icons@npm:^6.6.1":
+"@patternfly/react-icons@npm:^6.0.0, @patternfly/react-icons@npm:^6.4.0, @patternfly/react-icons@npm:^6.6.1":
   version: 6.6.1
   resolution: "@patternfly/react-icons@npm:6.6.1"
   dependencies:
@@ -2887,7 +2922,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-styles@npm:^6.5.1, @patternfly/react-styles@npm:^6.6.1":
+"@patternfly/react-styles@npm:^6.0.0, @patternfly/react-styles@npm:^6.6.1":
   version: 6.6.1
   resolution: "@patternfly/react-styles@npm:6.6.1"
   checksum: 10c0/0c50bf72fade26d30e6ff9abe0d2d8dbb5b546fe434067f70665ce704e63767a9f8ea7627871e2c6ce17ea4f475daa931fd420e1f1aee891c1f48b5905e57433
@@ -2918,14 +2953,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@patternfly/react-topology@npm:^6.4.0":
-  version: 6.6.0
-  resolution: "@patternfly/react-topology@npm:6.6.0"
+"@patternfly/react-topology@npm:~6.4.0":
+  version: 6.4.0
+  resolution: "@patternfly/react-topology@npm:6.4.0"
   dependencies:
     "@dagrejs/dagre": "npm:1.1.2"
-    "@patternfly/react-core": "npm:^6.5.1"
-    "@patternfly/react-icons": "npm:^6.5.1"
-    "@patternfly/react-styles": "npm:^6.5.1"
+    "@patternfly/react-core": "npm:^6.0.0"
+    "@patternfly/react-icons": "npm:^6.0.0"
+    "@patternfly/react-styles": "npm:^6.0.0"
     "@types/d3": "npm:^7.4.0"
     "@types/d3-force": "npm:^1.2.1"
     d3: "npm:^7.8.0"
@@ -2938,7 +2973,7 @@ __metadata:
   peerDependencies:
     react: ^17 || ^18 || ^19
     react-dom: ^17 || ^18 || ^19
-  checksum: 10c0/b1afadce79fdf8bb5d095b4916bd40b9ac35b23953a8f5d52353f7ff0024c799ec1110166930a8f8c6b592b8e63475fa17f3c356b322323a89c24027f197c737
+  checksum: 10c0/c4db811821d8b9be67b394a69401ecdd61fb576cda4d84e481ac56997535941e50d7a8f276f778e48a1861b55703deb031859e0c63777814833d08db6115e6e5
   languageName: node
   linkType: hard
 
@@ -3118,13 +3153,6 @@ __metadata:
   bin:
     playwright: cli.js
   checksum: 10c0/2164c03ad97c3653ff02e8818a71f3b2bbc344ac07924c9d8e31cd57505d6d37596015a41f51396b3ed8de6840f59143eaa9c21bf65515963da20740119811da
-  languageName: node
-  linkType: hard
-
-"@remix-run/router@npm:1.15.3":
-  version: 1.15.3
-  resolution: "@remix-run/router@npm:1.15.3"
-  checksum: 10c0/aea197447cee21e137d70f0c93e00de70c64fcfae20ae349ade9dc4202e782bd94dbc88be7302d13b6aa6cde38a701b074cd8e09a161d14cecda832a36dd2695
   languageName: node
   linkType: hard
 
@@ -3815,9 +3843,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/dom@npm:^8.0.0":
-  version: 8.20.1
-  resolution: "@testing-library/dom@npm:8.20.1"
+"@testing-library/dom@npm:^9.0.0":
+  version: 9.3.4
+  resolution: "@testing-library/dom@npm:9.3.4"
   dependencies:
     "@babel/code-frame": "npm:^7.10.4"
     "@babel/runtime": "npm:^7.12.5"
@@ -3827,7 +3855,7 @@ __metadata:
     dom-accessibility-api: "npm:^0.5.9"
     lz-string: "npm:^1.5.0"
     pretty-format: "npm:^27.0.2"
-  checksum: 10c0/614013756706467f2a7f3f693c18377048c210ec809884f0f9be866f7d865d075805ad15f5d100e8a699467fdde09085bf79e23a00ea0a6ab001d9583ef15e5d
+  checksum: 10c0/147da340e8199d7f98f3a4ad8aa22ed55b914b83957efa5eb22bfea021a979ebe5a5182afa9c1e5b7a5f99a7f6744a5a4d9325ae46ec3b33b5a15aed8750d794
   languageName: node
   linkType: hard
 
@@ -3845,17 +3873,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@testing-library/react@npm:^12":
-  version: 12.1.5
-  resolution: "@testing-library/react@npm:12.1.5"
+"@testing-library/react@npm:^14.0.0":
+  version: 14.3.1
+  resolution: "@testing-library/react@npm:14.3.1"
   dependencies:
     "@babel/runtime": "npm:^7.12.5"
-    "@testing-library/dom": "npm:^8.0.0"
-    "@types/react-dom": "npm:<18.0.0"
+    "@testing-library/dom": "npm:^9.0.0"
+    "@types/react-dom": "npm:^18.0.0"
   peerDependencies:
-    react: <18.0.0
-    react-dom: <18.0.0
-  checksum: 10c0/3c2433d2fdb6535261f62cd85d79657989cebd96f9072da03c098a1cfa56dec4dfec83d7c2e93633a3ccebdb178ea8578261533d11551600966edab77af00c8b
+    react: ^18.0.0
+    react-dom: ^18.0.0
+  checksum: 10c0/1ccf4eb1510500cc20a805cb0244c9098dca28a8745173a8f71ea1274d63774f0b7898a35c878b43c797b89c13621548909ff37843b835c1a27ee1efbbdd098c
   languageName: node
   linkType: hard
 
@@ -4356,13 +4384,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/history@npm:*":
-  version: 4.7.9
-  resolution: "@types/history@npm:4.7.9"
-  checksum: 10c0/1bb1d0634706a457152666b6737177ea35e3161925f4460b425b70cbf9cc1c53c566cffd86cf515bf3f74f1e0be38c1b61364397dcac2eedd186ec2d485943fb
-  languageName: node
-  linkType: hard
-
 "@types/hoist-non-react-statics@npm:^3.3.1":
   version: 3.3.7
   resolution: "@types/hoist-non-react-statics@npm:3.3.7"
@@ -4466,13 +4487,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/lodash@npm:^4.14.175":
-  version: 4.17.24
-  resolution: "@types/lodash@npm:4.17.24"
-  checksum: 10c0/b72f60d4daacdad1fa643edb3faba204c02a01eb1ac00a83ff73496a6d236fc55e459c06106e8ced42277dba932d087d8fc090f8de4ef590d3f91e6d6f7ce85a
-  languageName: node
-  linkType: hard
-
 "@types/mime@npm:^1":
   version: 1.3.2
   resolution: "@types/mime@npm:1.3.2"
@@ -4538,12 +4552,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-dom@npm:<18.0.0":
-  version: 17.0.26
-  resolution: "@types/react-dom@npm:17.0.26"
+"@types/react-dom@npm:^18.0.0":
+  version: 18.3.7
+  resolution: "@types/react-dom@npm:18.3.7"
   peerDependencies:
-    "@types/react": ^17.0.0
-  checksum: 10c0/8363921f08afe3f2ef82fe293301a0809ec646975fe9f5bfeb2e823f7237b97e47d27e1c6c2ffff27d15c12ab3cad1de6c77a737e37499fcc52793b0fd674f3f
+    "@types/react": ^18.0.0
+  checksum: 10c0/8bd309e2c3d1604a28a736a24f96cbadf6c05d5288cfef8883b74f4054c961b6b3a5e997fd5686e492be903c8f3380dba5ec017eff3906b1256529cd2d39603e
   languageName: node
   linkType: hard
 
@@ -4556,28 +4570,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/react-router-dom@npm:^5.3.2":
-  version: 5.3.2
-  resolution: "@types/react-router-dom@npm:5.3.2"
-  dependencies:
-    "@types/history": "npm:*"
-    "@types/react": "npm:*"
-    "@types/react-router": "npm:*"
-  checksum: 10c0/4f212bea60632350462e00dfcb5f87ec958354622f81bb7d5c428554df4ed4ea2188dce3b502d1ad8338ea72cb93f61bd1e24ed098e566300f135ab310e70b88
-  languageName: node
-  linkType: hard
-
-"@types/react-router@npm:*":
-  version: 5.1.17
-  resolution: "@types/react-router@npm:5.1.17"
-  dependencies:
-    "@types/history": "npm:*"
-    "@types/react": "npm:*"
-  checksum: 10c0/061285f4eacbafb75828e01447b634ac6db87ea7ca7c5bc591640ea700be0c7360b1365399726944d084abe8e6ae4ea14e5f01121a77371a06de5b49e1ee1f71
-  languageName: node
-  linkType: hard
-
-"@types/react@npm:*, @types/react@npm:^17.0.37":
+"@types/react@npm:*":
   version: 17.0.37
   resolution: "@types/react@npm:17.0.37"
   dependencies:
@@ -4585,6 +4578,16 @@ __metadata:
     "@types/scheduler": "npm:*"
     csstype: "npm:^3.0.2"
   checksum: 10c0/af440f6281bd700a3b65146ff955f230243c8137a3c902e111d1e4ab5bf77724bf0e979cee286e51c7db76e6cdd505cd213c557f04831ca03a1767f7a7fcadba
+  languageName: node
+  linkType: hard
+
+"@types/react@npm:^18.0.0":
+  version: 18.3.31
+  resolution: "@types/react@npm:18.3.31"
+  dependencies:
+    "@types/prop-types": "npm:*"
+    csstype: "npm:^3.2.2"
+  checksum: 10c0/44180549dd045f536ececd39e39aacdf828e76adc1c4a90b132f453e23cc370c4648d9102ae401172ebd8fd8b1977a901a39e214e53ec77171b27514b588c179
   languageName: node
   linkType: hard
 
@@ -6611,7 +6614,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"classnames@npm:2.x, classnames@npm:^2.3.1":
+"classnames@npm:^2.3.1":
   version: 2.5.1
   resolution: "classnames@npm:2.5.1"
   checksum: 10c0/afff4f77e62cea2d79c39962980bf316bacb0d7c49e13a21adaadb9221e1c6b9d3cdb829d8bb1b23c406f4e740507f37e1dcf506f7e3b7113d17c5bab787aa69
@@ -6891,6 +6894,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cookie@npm:^1.0.1":
+  version: 1.1.1
+  resolution: "cookie@npm:1.1.1"
+  checksum: 10c0/79c4ddc0fcad9c4f045f826f42edf54bcc921a29586a4558b0898277fa89fb47be95bc384c2253f493af7b29500c830da28341274527328f18eba9f58afa112c
+  languageName: node
+  linkType: hard
+
 "cookie@npm:~0.7.1":
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
@@ -7111,6 +7121,13 @@ __metadata:
   version: 3.0.9
   resolution: "csstype@npm:3.0.9"
   checksum: 10c0/bca0719a6248445cbad0ba9a45911a0bdcf1ab3b08ae8ce1d7766f9d82d7ce3c5cbb1a542926d52958368c1db290baed50d6c9672a7e5fcca37eba37a28f33a3
+  languageName: node
+  linkType: hard
+
+"csstype@npm:^3.2.2":
+  version: 3.2.3
+  resolution: "csstype@npm:3.2.3"
+  checksum: 10c0/cd29c51e70fa822f1cecd8641a1445bed7063697469d35633b516e60fe8c1bde04b08f6c5b6022136bb669b64c63d4173af54864510fbb4ee23281801841a3ce
   languageName: node
   linkType: hard
 
@@ -9928,30 +9945,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"history@npm:^4.9.0":
-  version: 4.10.1
-  resolution: "history@npm:4.10.1"
-  dependencies:
-    "@babel/runtime": "npm:^7.1.2"
-    loose-envify: "npm:^1.2.0"
-    resolve-pathname: "npm:^3.0.0"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
-    value-equal: "npm:^1.0.1"
-  checksum: 10c0/35377694e4f10f2cf056a9cb1a8ee083e04e4b4717a63baeee4afd565658a62c7e73700bf9e82aa53dbe1ec94e0a25a83c080d63bad8ee6b274a98d2fbc5ed4c
-  languageName: node
-  linkType: hard
-
-"history@npm:^5.3.0":
-  version: 5.3.0
-  resolution: "history@npm:5.3.0"
-  dependencies:
-    "@babel/runtime": "npm:^7.7.6"
-  checksum: 10c0/812ec839386222d6437bd78d9f05db32e47d105ada0ad8834b32626919dd2fee7a10001bc489510f93a8069d02f118214bd8d42a82f7cf9daf8e84fbcbbb2016
-  languageName: node
-  linkType: hard
-
-"hoist-non-react-statics@npm:^3.1.0, hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
+"hoist-non-react-statics@npm:^3.3.0, hoist-non-react-statics@npm:^3.3.2":
   version: 3.3.2
   resolution: "hoist-non-react-statics@npm:3.3.2"
   dependencies:
@@ -11115,13 +11109,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"isarray@npm:0.0.1":
-  version: 0.0.1
-  resolution: "isarray@npm:0.0.1"
-  checksum: 10c0/ed1e62da617f71fe348907c71743b5ed550448b455f8d269f89a7c7ddb8ae6e962de3dab6a74a237b06f5eb7f6ece7a45ada8ce96d87fe972926530f91ae3311
-  languageName: node
-  linkType: hard
-
 "isarray@npm:1.0.0, isarray@npm:~1.0.0":
   version: 1.0.0
   resolution: "isarray@npm:1.0.0"
@@ -11958,22 +11945,21 @@ __metadata:
     "@babel/core": "npm:^7.29.6"
     "@babel/preset-env": "npm:^7.25.3"
     "@babel/preset-react": "npm:^7.24.7"
-    "@openshift-console/dynamic-plugin-sdk": "npm:^1.6.0"
-    "@openshift-console/dynamic-plugin-sdk-webpack": "npm:1.2.0"
+    "@openshift-console/dynamic-plugin-sdk": "npm:4.22.0"
+    "@openshift-console/dynamic-plugin-sdk-webpack": "npm:4.22.0"
     "@patternfly/react-core": "npm:^6.4.0"
     "@patternfly/react-icons": "npm:^6.4.0"
     "@patternfly/react-table": "npm:^6.4.0"
-    "@patternfly/react-topology": "npm:^6.4.0"
+    "@patternfly/react-topology": "npm:~6.4.0"
     "@playwright/test": "npm:^1.50.0"
     "@testing-library/jest-dom": "npm:^6.9.1"
-    "@testing-library/react": "npm:^12"
+    "@testing-library/react": "npm:^14.0.0"
     "@testing-library/user-event": "npm:^14.6.1"
     "@types/jest": "npm:^30.0.0"
     "@types/js-yaml": "npm:^4.0.9"
     "@types/node": "npm:^18.0.0"
-    "@types/react": "npm:^17.0.37"
+    "@types/react": "npm:^18.0.0"
     "@types/react-helmet": "npm:^6.1.4"
-    "@types/react-router-dom": "npm:^5.3.2"
     "@typescript-eslint/eslint-plugin": "npm:^8.0.0"
     "@typescript-eslint/parser": "npm:^8.0.0"
     babel-loader: "npm:^8.2.0"
@@ -11993,12 +11979,11 @@ __metadata:
     pluralize: "npm:^8.0.0"
     prettier: "npm:^2.7.1"
     prettier-stylelint: "npm:^0.4.2"
-    react: "npm:^17.0.1"
-    react-dom: "npm:^17.0.1"
+    react: "npm:^18.0.0"
+    react-dom: "npm:^18.0.0"
     react-helmet: "npm:^6.1.0"
     react-i18next: "npm:~16.5.8"
-    react-router: "npm:5.3.x"
-    react-router-dom: "npm:5.3.x"
+    react-router: "npm:~7.13.1"
     style-loader: "npm:^3.3.1"
     stylelint: "npm:^15.3.0"
     stylelint-config-standard: "npm:^31.0.0"
@@ -12134,13 +12119,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodash-es@npm:^4.17.21":
-  version: 4.18.1
-  resolution: "lodash-es@npm:4.18.1"
-  checksum: 10c0/35d4dcf87ef07f8d090f409447575800108057e360b445f590d0d25d09e3d1e33a163d2fc100d4d072b0f901d5e2fc533cd7c4bfd8eeb38a06abec693823c8b8
-  languageName: node
-  linkType: hard
-
 "lodash.debounce@npm:^4, lodash.debounce@npm:^4.0.8":
   version: 4.0.8
   resolution: "lodash.debounce@npm:4.0.8"
@@ -12192,7 +12170,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.2.0, loose-envify@npm:^1.3.1, loose-envify@npm:^1.4.0":
+"loose-envify@npm:^1.0.0, loose-envify@npm:^1.1.0, loose-envify@npm:^1.4.0":
   version: 1.4.0
   resolution: "loose-envify@npm:1.4.0"
   dependencies:
@@ -12949,13 +12927,6 @@ __metadata:
   bin:
     multicast-dns: cli.js
   checksum: 10c0/5120171d4bdb1577764c5afa96e413353bff530d1b37081cb29cccc747f989eb1baf40574fe8e27060fc1aef72b59c042f72b9b208413de33bcf411343c69057
-  languageName: node
-  linkType: hard
-
-"nanoclone@npm:^0.2.1":
-  version: 0.2.1
-  resolution: "nanoclone@npm:0.2.1"
-  checksum: 10c0/760b569ea841c9678fdf8d763c6d7bb093f0889150087f82d86c536a318b302939c82ce35cdaec999d0f687789d0d79d0f3f75a272d7a98dfac7a067c0b47053
   languageName: node
   linkType: hard
 
@@ -13770,15 +13741,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"path-to-regexp@npm:^1.7.0":
-  version: 1.8.0
-  resolution: "path-to-regexp@npm:1.8.0"
-  dependencies:
-    isarray: "npm:0.0.1"
-  checksum: 10c0/7b25d6f27a8de03f49406d16195450f5ced694398adea1510b0f949d9660600d1769c5c6c83668583b7e6b503f3caf1ede8ffc08135dbe3e982f034f356fbb5c
-  languageName: node
-  linkType: hard
-
 "path-to-regexp@npm:~0.1.12":
   version: 0.1.13
   resolution: "path-to-regexp@npm:0.1.13"
@@ -14330,7 +14292,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.6.2, prop-types@npm:^15.7.2":
+"prop-types@npm:^15.7.2":
   version: 15.7.2
   resolution: "prop-types@npm:15.7.2"
   dependencies:
@@ -14352,7 +14314,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"property-expr@npm:^2.0.4":
+"property-expr@npm:^2.0.5":
   version: 2.0.6
   resolution: "property-expr@npm:2.0.6"
   checksum: 10c0/69b7da15038a1146d6447c69c445306f66a33c425271235bb20507f1846dbf9577a8f9dfafe8acbfcb66f924b270157f155248308f026a68758f35fc72265b3c
@@ -14587,16 +14549,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-dom@npm:^17.0.1":
-  version: 17.0.2
-  resolution: "react-dom@npm:17.0.2"
+"react-dom@npm:^18.0.0":
+  version: 18.3.1
+  resolution: "react-dom@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-    scheduler: "npm:^0.20.2"
+    scheduler: "npm:^0.23.2"
   peerDependencies:
-    react: 17.0.2
-  checksum: 10c0/51abbcb72450fe527ebf978c3bc989ba266630faaa53f47a2fae5392369729e8de62b2e4683598cbe651ea7873cd34ec7d5127e2f50bf4bfe6bd0c3ad9bddcb0
+    react: ^18.3.1
+  checksum: 10c0/a752496c1941f958f2e8ac56239172296fcddce1365ce45222d04a1947e0cc5547df3e8447f855a81d6d39f008d7c32eab43db3712077f09e3f67c4874973e85
   languageName: node
   linkType: hard
 
@@ -14631,24 +14592,6 @@ __metadata:
   peerDependencies:
     react: ">=16.3.0"
   checksum: 10c0/1d2831d9c3b4f5c91f020076aeb6502437a4788077d0c438421e466eb9633d5dc2aacedf7b779a970b807d61cf87793c5ff76ee3190a185d71c90b5cfb367e96
-  languageName: node
-  linkType: hard
-
-"react-i18next@npm:^11.7.3":
-  version: 11.18.6
-  resolution: "react-i18next@npm:11.18.6"
-  dependencies:
-    "@babel/runtime": "npm:^7.14.5"
-    html-parse-stringify: "npm:^3.0.1"
-  peerDependencies:
-    i18next: ">= 19.0.0"
-    react: ">= 16.8.0"
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 10c0/ffc40b157e274bc26fc82fc82761290804fffba33ceed552eb5a8c8c80899ea93a3fa7af4b0d719a9f101f3e08aab6f4754df953f1b720a61aa0317f5459abca
   languageName: node
   linkType: hard
 
@@ -14719,7 +14662,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.6.0, react-is@npm:^16.7.0, react-is@npm:^16.8.1":
+"react-is@npm:^16.13.1, react-is@npm:^16.7.0, react-is@npm:^16.8.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
   checksum: 10c0/33977da7a5f1a287936a0c85639fec6ca74f4f15ef1e59a6bc20338fc73dc69555381e211f7a3529b8150a1f71e4225525b41b60b52965bda53ce7d47377ada1
@@ -14730,27 +14673,6 @@ __metadata:
   version: 17.0.2
   resolution: "react-is@npm:17.0.2"
   checksum: 10c0/2bdb6b93fbb1820b024b496042cce405c57e2f85e777c9aabd55f9b26d145408f9f74f5934676ffdc46f3dcff656d78413a6e43968e7b3f92eea35b3052e9053
-  languageName: node
-  linkType: hard
-
-"react-redux@npm:7.2.2":
-  version: 7.2.2
-  resolution: "react-redux@npm:7.2.2"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.1"
-    hoist-non-react-statics: "npm:^3.3.2"
-    loose-envify: "npm:^1.4.0"
-    prop-types: "npm:^15.7.2"
-    react-is: "npm:^16.13.1"
-  peerDependencies:
-    react: ^16.8.3 || ^17
-    redux: ^2.0.0 || ^3.0.0 || ^4.0.0-0
-  peerDependenciesMeta:
-    react-dom:
-      optional: true
-    react-native:
-      optional: true
-  checksum: 10c0/b613ee76b8b399c210aacd1a4e219e508daea828d6bf0cb1748abfd0725e4cc748e235177f5c7d30295b227364ef77f1ca24fee1e7f7e7d59d4081261bc6b988
   languageName: node
   linkType: hard
 
@@ -14786,64 +14708,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-router-dom-v5-compat@npm:^6.11.2":
-  version: 6.22.3
-  resolution: "react-router-dom-v5-compat@npm:6.22.3"
+"react-router@npm:~7.13.1":
+  version: 7.13.2
+  resolution: "react-router@npm:7.13.2"
   dependencies:
-    history: "npm:^5.3.0"
-    react-router: "npm:6.22.3"
+    cookie: "npm:^1.0.1"
+    set-cookie-parser: "npm:^2.6.0"
   peerDependencies:
-    react: ">=16.8"
-    react-dom: ">=16.8"
-    react-router-dom: 4 || 5
-  checksum: 10c0/67e480addedd50bd9b62e4ddd17035264a9c2b676472a080cca428bbcc2939722487491964181da883bb68cc51e4868c962f2bd6de9e105feb6be529b3ba42c5
-  languageName: node
-  linkType: hard
-
-"react-router-dom@npm:5.3.x":
-  version: 5.3.4
-  resolution: "react-router-dom@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.13"
-    history: "npm:^4.9.0"
-    loose-envify: "npm:^1.3.1"
-    prop-types: "npm:^15.6.2"
-    react-router: "npm:5.3.4"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
-  peerDependencies:
-    react: ">=15"
-  checksum: 10c0/f04f727e2ed2e9d1d3830af02cc61690ff67b1524c0d18690582bfba0f4d14142ccc88fb6da6befad644fddf086f5ae4c2eb7048c67da8a0b0929c19426421b0
-  languageName: node
-  linkType: hard
-
-"react-router@npm:5.3.4, react-router@npm:5.3.x":
-  version: 5.3.4
-  resolution: "react-router@npm:5.3.4"
-  dependencies:
-    "@babel/runtime": "npm:^7.12.13"
-    history: "npm:^4.9.0"
-    hoist-non-react-statics: "npm:^3.1.0"
-    loose-envify: "npm:^1.3.1"
-    path-to-regexp: "npm:^1.7.0"
-    prop-types: "npm:^15.6.2"
-    react-is: "npm:^16.6.0"
-    tiny-invariant: "npm:^1.0.2"
-    tiny-warning: "npm:^1.0.0"
-  peerDependencies:
-    react: ">=15"
-  checksum: 10c0/e15c00dfef199249b4c6e6d98e5e76cc352ce66f3270f13df37cc069ddf7c05e43281e8c308fc407e4435d72924373baef1d2890e0f6b0b1eb423cf47315a053
-  languageName: node
-  linkType: hard
-
-"react-router@npm:6.22.3":
-  version: 6.22.3
-  resolution: "react-router@npm:6.22.3"
-  dependencies:
-    "@remix-run/router": "npm:1.15.3"
-  peerDependencies:
-    react: ">=16.8"
-  checksum: 10c0/a2c85c3d1fa93585e312b1f7e6e21d1ca421875013a8d879e109d3ed41fb035bc93faef4cd42b354ea18d039bc50b679bf752679ad83ac26a986e3432fbd0462
+    react: ">=18"
+    react-dom: ">=18"
+  peerDependenciesMeta:
+    react-dom:
+      optional: true
+  checksum: 10c0/c7620565df0b444507cfceb76733adbd26e28a72fc4d52d344190bcb2e6483427313a3b6076c53d362e2682ccdb1262731bcaa6c3577cbbeea130291a38715f1
   languageName: node
   linkType: hard
 
@@ -14872,13 +14749,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react@npm:^17.0.1":
-  version: 17.0.2
-  resolution: "react@npm:17.0.2"
+"react@npm:^18.0.0":
+  version: 18.3.1
+  resolution: "react@npm:18.3.1"
   dependencies:
     loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: 10c0/07ae8959acf1596f0550685102fd6097d461a54a4fd46a50f88a0cd7daaa97fdd6415de1dcb4bfe0da6aa43221a6746ce380410fa848acc60f8ac41f6649c148
+  checksum: 10c0/283e8c5efcf37802c9d1ce767f302dd569dd97a70d9bb8c7be79a789b9902451e0d16334b05d73299b20f048cbc3c7d288bbbde10b701fa194e2089c237dbea3
   languageName: node
   linkType: hard
 
@@ -15038,25 +14914,6 @@ __metadata:
   peerDependencies:
     immutable: ^3.8.1 || ^4.0.0-rc.1
   checksum: 10c0/c706c9f72a1fbce92d54ab9117ab641b6d7ee69f2860ec6de827dbed5bed918d4677a0895e6564bb59011202bb5e639cf69f4e2d2d14086053b32e5c4e35f512
-  languageName: node
-  linkType: hard
-
-"redux-thunk@npm:2.4.0":
-  version: 2.4.0
-  resolution: "redux-thunk@npm:2.4.0"
-  peerDependencies:
-    redux: ^4
-  checksum: 10c0/2cacc32c859f97f9eff7679305c3e92fd3337dc739e3a3d15cf7870032a1be3b959ac6a225c0be365d6aa9e020fa391f01dd57f847d61bd1517bb154debdc87c
-  languageName: node
-  linkType: hard
-
-"redux@npm:4.0.1":
-  version: 4.0.1
-  resolution: "redux@npm:4.0.1"
-  dependencies:
-    loose-envify: "npm:^1.4.0"
-    symbol-observable: "npm:^1.2.0"
-  checksum: 10c0/40515233ca564c96890b3559945c0938d42af2ce41ad30541a3d64409dafcb61394dcacf8eabd957c7f1f44393f5e9ef74417607a441a08618c629d8d90bc2d1
   languageName: node
   linkType: hard
 
@@ -15331,10 +15188,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"reselect@npm:4.x, reselect@npm:^4.1.8":
+"reselect@npm:^4.1.8":
   version: 4.1.8
   resolution: "reselect@npm:4.1.8"
   checksum: 10c0/06a305a504affcbb67dd0561ddc8306b35796199c7e15b38934c80606938a021eadcf68cfd58e7bb5e17786601c37602a3362a4665c7bf0a96c1041ceee9d0b7
+  languageName: node
+  linkType: hard
+
+"reselect@npm:^5.1.1":
+  version: 5.2.0
+  resolution: "reselect@npm:5.2.0"
+  checksum: 10c0/d0a8497e404b25a769fe792eacae88b9b576c30870450cd243d76ec9427d91a59c4a2cc00d824d283448b444c4c698a8f961d771c8ae39c759313afb31950e2e
   languageName: node
   linkType: hard
 
@@ -15383,13 +15247,6 @@ __metadata:
   dependencies:
     value-or-function: "npm:^4.0.0"
   checksum: 10c0/108f22186cad8748f1f0263944702a9949a12074e49442827845a52048f9156290781ceab8aee3e26ad868347266746704ee59a83a8f2fe2ce35228d054e325e
-  languageName: node
-  linkType: hard
-
-"resolve-pathname@npm:^3.0.0":
-  version: 3.0.0
-  resolution: "resolve-pathname@npm:3.0.0"
-  checksum: 10c0/c6ec49b670dc35b9a303c47fa83ba9348a71e92d64a4c4bb85e1b659a29b407aa1ac1cb14a9b5b502982132ca77482bd80534bca147439d66880d35a137fe723
   languageName: node
   linkType: hard
 
@@ -15638,13 +15495,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"scheduler@npm:^0.20.2":
-  version: 0.20.2
-  resolution: "scheduler@npm:0.20.2"
+"scheduler@npm:^0.23.2":
+  version: 0.23.2
+  resolution: "scheduler@npm:0.23.2"
   dependencies:
     loose-envify: "npm:^1.1.0"
-    object-assign: "npm:^4.1.1"
-  checksum: 10c0/b0982e4b0f34f4ffa4f2f486161c0fd9ce9b88680b045dccbf250eb1aa4fd27413570645455187a83535e2370f5c667a251045547765408492bd883cbe95fcdb
+  checksum: 10c0/26383305e249651d4c58e6705d5f8425f153211aef95f15161c151f7b8de885f24751b377e4a0b3dd42cce09aad3f87a61dab7636859c0d89b7daf1a1e2a5c78
   languageName: node
   linkType: hard
 
@@ -15727,7 +15583,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7":
+"semver@npm:^7.3.4, semver@npm:^7.3.5":
   version: 7.6.3
   resolution: "semver@npm:7.6.3"
   bin:
@@ -15817,6 +15673,13 @@ __metadata:
     parseurl: "npm:~1.3.3"
     send: "npm:~0.19.1"
   checksum: 10c0/36320397a073c71bedf58af48a4a100fe6d93f07459af4d6f08b9a7217c04ce2a4939e0effd842dc7bece93ffcd59eb52f58c4fff2a8e002dc29ae6b219cd42b
+  languageName: node
+  linkType: hard
+
+"set-cookie-parser@npm:^2.6.0":
+  version: 2.7.2
+  resolution: "set-cookie-parser@npm:2.7.2"
+  checksum: 10c0/4381a9eb7ee951dfe393fe7aacf76b9a3b4e93a684d2162ab35594fa4053cc82a4d7d7582bf397718012c9adcf839b8cd8f57c6c42901ea9effe33c752da4a45
   languageName: node
   linkType: hard
 
@@ -16817,13 +16680,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"symbol-observable@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "symbol-observable@npm:1.2.0"
-  checksum: 10c0/009fee50798ef80ed4b8195048288f108b03de162db07493f2e1fd993b33fafa72d659e832b584da5a2427daa78e5a738fb2a9ab027ee9454252e0bedbcd1fdc
-  languageName: node
-  linkType: hard
-
 "symbol-tree@npm:^3.2.4":
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
@@ -17031,17 +16887,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"tiny-invariant@npm:^1.0.2":
-  version: 1.2.0
-  resolution: "tiny-invariant@npm:1.2.0"
-  checksum: 10c0/a7dd29c5256fdc4901e3adadaa203da62bd23c6a79830f7aa99ea2df5e2e82f84051550dcafb82af18b2d61d75dcc17993f01f938e9ad8f20cf4c514fff88d47
-  languageName: node
-  linkType: hard
-
-"tiny-warning@npm:^1.0.0":
+"tiny-case@npm:^1.0.3":
   version: 1.0.3
-  resolution: "tiny-warning@npm:1.0.3"
-  checksum: 10c0/ef8531f581b30342f29670cb41ca248001c6fd7975ce22122bd59b8d62b4fc84ad4207ee7faa95cde982fa3357cd8f4be650142abc22805538c3b1392d7084fa
+  resolution: "tiny-case@npm:1.0.3"
+  checksum: 10c0/c0cbed35884a322265e2cd61ff435168d1ea523f88bf3864ce14a238ae9169e732649776964283a66e4eb882e655992081d4daf8c865042e2233425866111b35
   languageName: node
   linkType: hard
 
@@ -17458,6 +17307,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"type-fest@npm:^2.19.0":
+  version: 2.19.0
+  resolution: "type-fest@npm:2.19.0"
+  checksum: 10c0/a5a7ecf2e654251613218c215c7493574594951c08e52ab9881c9df6a6da0aeca7528c213c622bc374b4e0cb5c443aa3ab758da4e3c959783ce884c3194e12cb
+  languageName: node
+  linkType: hard
+
 "type-fest@npm:^4.41.0":
   version: 4.41.0
   resolution: "type-fest@npm:4.41.0"
@@ -17547,10 +17403,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"typesafe-actions@npm:^4.2.1":
-  version: 4.4.2
-  resolution: "typesafe-actions@npm:4.4.2"
-  checksum: 10c0/9d07a5902f49d94169ccdbe5ca062d54ee710f6067e2b52f59896c0a725ed0a681d4e4f3a71cf0541052d2f741a3c2003f21984e1a0694c5256f0ba6aca63418
+"typesafe-actions@npm:^5.1.0":
+  version: 5.1.0
+  resolution: "typesafe-actions@npm:5.1.0"
+  checksum: 10c0/64e745aed10abf829b8aad3b178492c5f3602455cb02b7d565aad5560c0ded01dc5db06b12055ebb85fc9fd448d54d3444599eca65b074b48d0c9fb796bbb6a2
   languageName: node
   linkType: hard
 
@@ -18032,13 +17888,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"value-equal@npm:^1.0.1":
-  version: 1.0.1
-  resolution: "value-equal@npm:1.0.1"
-  checksum: 10c0/79068098355483ef29f4d3753999ad880875b87625d7e9055cad9346ea4b7662aad3a66f87976801b0dd7a6f828ba973d28b1669ebcd37eaf88cc5f687c1a691
-  languageName: node
-  linkType: hard
-
 "value-or-function@npm:^4.0.0":
   version: 4.0.0
   resolution: "value-or-function@npm:4.0.0"
@@ -18398,13 +18247,6 @@ __metadata:
   dependencies:
     iconv-lite: "npm:0.6.3"
   checksum: 10c0/273b5f441c2f7fda3368a496c3009edbaa5e43b71b09728f90425e7f487e5cef9eb2b846a31bd760dd8077739c26faf6b5ca43a5f24033172b003b72cf61a93e
-  languageName: node
-  linkType: hard
-
-"whatwg-fetch@npm:2.x":
-  version: 2.0.4
-  resolution: "whatwg-fetch@npm:2.0.4"
-  checksum: 10c0/bf2bc1617218c63f2be86edefb95ac5e7f967ae402e468ed550729436369725c3b03a5d1110f62ea789b6f7f399969b1ef720b0bb04e8947fdf94eab7ffac829
   languageName: node
   linkType: hard
 
@@ -18787,18 +18629,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"yup@npm:^0.32.11":
-  version: 0.32.11
-  resolution: "yup@npm:0.32.11"
+"yup@npm:^1.7.1":
+  version: 1.7.1
+  resolution: "yup@npm:1.7.1"
   dependencies:
-    "@babel/runtime": "npm:^7.15.4"
-    "@types/lodash": "npm:^4.14.175"
-    lodash: "npm:^4.17.21"
-    lodash-es: "npm:^4.17.21"
-    nanoclone: "npm:^0.2.1"
-    property-expr: "npm:^2.0.4"
+    property-expr: "npm:^2.0.5"
+    tiny-case: "npm:^1.0.3"
     toposort: "npm:^2.0.2"
-  checksum: 10c0/f0802798dc64b49f313886b983a9bea5f283e2094ee2aa1197587b84f50ac5b5d03af99857c313139e63dc02558fac3aaa343503bdbffa96f70006b39d1f59c9
+    type-fest: "npm:^2.19.0"
+  checksum: 10c0/76b8c7fc2ba467a346935d027a25c067f9653bb0413cd60fbe0518e3d62637a56dbfca49979c4bab1a93d8e9a50843ca73d90bdc271e2f5bce1effa7734e5f28
   languageName: node
   linkType: hard
 
@@ -18806,5 +18645,12 @@ __metadata:
   version: 4.0.2
   resolution: "zenscroll@npm:4.0.2"
   checksum: 10c0/419e87ebe3a22a3b2ac22cd02aeccb900c9c330f539efdb1efc382090157d466373ee615812caef5bbe2da140e3c7df222236c8cfd8e697e97d4d91cf3f81c63
+  languageName: node
+  linkType: hard
+
+"zod@npm:^3.25.67":
+  version: 3.25.76
+  resolution: "zod@npm:3.25.76"
+  checksum: 10c0/5718ec35e3c40b600316c5b4c5e4976f7fee68151bc8f8d90ec18a469be9571f072e1bbaace10f1e85cf8892ea12d90821b200e980ab46916a6166a4260a983c
   languageName: node
   linkType: hard


### PR DESCRIPTION
## Description

OCP 4.22 ships React 18, react-router 7, and SDK 4.22 as federated singletons.
Plugin must declare matching versions or it won't load on 4.22+ consoles.

Closes #637
Closes #651

## Changes

- Bump react/react-dom to ^18.0.0, @types/react to ^18.0.0
- Bump @openshift-console/dynamic-plugin-sdk to 4.22.0
- Bump @openshift-console/dynamic-plugin-sdk-webpack to 4.22.0
- Replace react-router-dom-v5-compat with react-router ~7.13.1
- Remove react-router-dom and @types/react-router-dom
- Bump @testing-library/react to ^14.0.0
- Pin @patternfly/react-topology to ~6.4.0 (match console shared module)
- Add TextEncoder/TextDecoder polyfill for Jest (react-router 7 uses TextEncoder at import time, which jsdom does not provide)
- Set @console/pluginAPI >=4.22.0-0 (plugin loads on 4.22+ only)
- Update latestSupportedOpenshiftVersion to 4.22
- Migrate all router imports across 37 files

## Testing

- [x] `yarn build` passes
- [x] `yarn lint` passes
- [x] `yarn i18n` passes
- [x] `yarn test` passes
- [x] Manual verification on 4.22 cluster
- [x] E2E tests on 4.22 cluster

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Updated application navigation to use the latest routing approach, with no intended changes to existing page behaviour.
  - Improved compatibility with newer supported platform versions and console tooling.
  - Enhanced test setup to support text encoding APIs and provide clearer TypeScript diagnostics.
  - Made end-to-end test navigation more reliable by waiting for document readiness rather than full network inactivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->