### PR TITLE
test(e2e): fix flaky yaml test and review nits

### DIFF
--- a/e2e/tests/apiproduct-apikeys-tab.spec.ts
+++ b/e2e/tests/apiproduct-apikeys-tab.spec.ts
@@ -150,9 +150,9 @@ async function navigateToAPIProductAPIKeysTab(
     },
     { ns: namespace, name: productName },
   );
-  await page.waitForLoadState('domcontentloaded');
 
   // Wait for the tab content to load - either the table header or empty state
+  // (pushState doesn't hit the network, so waitForLoadState is meaningless here)
   await expect(page.locator('th:has-text("Name"), th:has-text("Requester")').first()).toBeVisible({
     timeout: 30_000,
   });
@@ -164,7 +164,6 @@ async function navigateAsOwner(page: Parameters<typeof impersonateUser>[0]) {
   await dismissConsoleTour(page);
   await impersonateUser(page, 'test-api-owner');
   await navigateToAPIProductAPIKeysTab(page);
-  await page.waitForLoadState('domcontentloaded');
 }
 
 // ── View API Keys Tab ─────────────────────────────────────────────────────────

--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -415,8 +415,13 @@ spec:
     await expect(createButton).toBeEnabled({ timeout: 10000 });
     await createButton.click();
 
-    // ResourceYAMLEditor navigates to the k8s details page after creation (not our custom page).
-    // Use a full page.goto() so the console properly loads our custom list route.
+    // Wait for ResourceYAMLEditor to finish creating and navigate to the details page
+    await expect(page).toHaveURL(
+      new RegExp(`devportal\\.kuadrant\\.io~v1alpha1~APIProduct/${yamlProductName}`),
+      { timeout: 15_000 },
+    );
+
+    // Navigate to our custom list route (ResourceYAMLEditor goes to k8s details, not ours)
     await page.goto(`/kuadrant/apiproducts/ns/${TEST_NAMESPACE}`);
     await page.waitForLoadState('domcontentloaded');
     await page.waitForSelector('table', { timeout: 15000 });

--- a/e2e/tests/helpers.ts
+++ b/e2e/tests/helpers.ts
@@ -145,7 +145,6 @@ export async function spaNavigate(page: Page, path: string): Promise<void> {
     window.history.pushState({}, '', p);
     window.dispatchEvent(new PopStateEvent('popstate'));
   }, path);
-  await page.waitForLoadState('domcontentloaded');
 }
 
 // Scroll through all pagination pages looking for a row matching `text`.

--- a/e2e/tests/httproute-crud.spec.ts
+++ b/e2e/tests/httproute-crud.spec.ts
@@ -168,6 +168,18 @@ test.describe('HTTPRoute CRUD', () => {
         'jsonpath={.spec.parentRefs[0].name}',
       ]),
     ).toBe(gateway);
+
+    expect(
+      kubectl([
+        'get',
+        'httproute',
+        routeName,
+        '-n',
+        namespace,
+        '-o',
+        'jsonpath={.spec.parentRefs[0].namespace}',
+      ]),
+    ).toBe(gatewayNamespace);
   });
 
   test('edits an existing HTTPRoute', { tag: '@smoke' }, async ({ page }) => {


### PR DESCRIPTION
## Description

Addresses review feedback from #721 and #720, and fixes a flaky YAML creation test.

## Changes

- Remove `waitForLoadState('domcontentloaded')` after `pushState()` calls - pushState doesn't hit the network so this wait was a no-op (PR #721 feedback)
- Add `parentRefs[0].namespace` assertion to HTTPRoute create test to catch cross-namespace regressions (PR #720 feedback)
- Fix flaky YAML APIProduct creation test by waiting for ResourceYAMLEditor to navigate to the details page (confirming creation succeeded) before navigating to the list page

## Testing

- `yarn lint` passes
- `yarn i18n` passes
- Changes are test-only, no source code modified

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved end-to-end navigation reliability across API Product and API Key workflows.
  * Added verification that newly created API Products load their details correctly.
  * Confirmed HTTPRoutes reference the expected `gateway-system` namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->