### PR TITLE
Updating e2e Docs

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -91,6 +91,7 @@ npx playwright test --config=e2e/playwright.config.ts
 - `e2e/tests/httproute-crud.spec.ts` - HTTPRoute create, edit, and delete operations
 - `e2e/tests/mcp-overview.spec.ts` - MCP Overview dashboard
 - `e2e/tests/mcp-setup-wizard.spec.ts` - MCP Management setup wizard
+- `e2e/tests/mcp-wizard.spec.ts` - MCP server registration wizard
 - `e2e/tests/overview.spec.ts` - Overview dashboard cards, stats, and navigation
 - `e2e/tests/policy-forms.spec.ts` - Policy creation forms (DNS, TLS, Auth, RateLimit, etc.)
 - `e2e/tests/rbac.spec.ts` - RBAC permission tests
@@ -204,6 +205,7 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
   | `src/components/(KuadrantOverview\|KuadrantPolicies\|ResourceList\|DropdownWithKebab)` | `overview`, `rbac` |
   | `src/components/(dnspolicy\|tlspolicy\|ratelimitpolicy\|authpolicy)/` | `policy-forms`, `rbac` |
   | `src/components/(httproute\|issuer)/` | `rbac`, `httproute-crud` |
+  | `src/components/mcp/` | `mcp-setup-wizard`, `mcp-overview`, `mcp-wizard` |
   | `src/components/(AttachedResources\|gateway/GatewaySingleOverview\|httproute/HTTPRouteSingleOverview\|grpcroute/)` | `attached-tab` |
   | `src/components/NoPermissionsView` | `apiproduct-rbac`, `rbac` |
 
@@ -297,3 +299,4 @@ oinc destroy
 6. CI may run the full smoke suite when:
   - The changed files do not match any `component-to-spec` mapping, which triggers the full smoke fallback
   - Modifications to shared modules (`src/utils/`, `src/hooks/`, `src/constants/`, etc.) trigger the full smoke fallback
+  

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -9,6 +9,9 @@
 ## Installation
 
 ### Install oinc
+
+> **Note:** Replace `oinc-linux-amd64` with your platform (e.g., `oinc-darwin-arm64` for Apple Silicon).
+
 ```bash
 OINC_VERSION="v0.4.3"
 curl -fL -o oinc "https://github.com/jasonmadigan/oinc/releases/download/${OINC_VERSION}/oinc-linux-amd64"
@@ -111,10 +114,11 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
   | Tag | When it runs | What to tag |
   |---|---|---|
   | `@smoke` | Every PR (via suite router) | Critical-path flows that are fast and reliable |
-  | `@nightly` | Daily at 02:00 UTC (full suite) | Edge cases, validation, slower flows, duplicate coverage, UI |
+  | `@nightly` | Daily at 02:00 UTC (full suite, all tags) | Edge cases, validation, slower flows, duplicate coverage, UI |
 
   **Rules:**
-  - Every test must have exactly one tag — untagged tests are skipped during smoke runs
+  - Every test must have exactly one tag — untagged tests are skipped during smoke runs but run in nightly
+  - Directly-edited test files (in `test_specs`) run with all tags, including untagged tests
   - Default to `@nightly` when adding a new test; only use `@smoke` for critical, reliable flows
 
 ## CI Pipeline
@@ -165,7 +169,7 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
 ### Paths Filter (build, lint, i18n)
 
   `build.yaml`, `lint.yaml`, and `i18n.yaml` each have a `changes` job that skips
-  the check for **docs-only PRs.** If every changed file matches a docs-only pattern
+  the check for **non-code PRs.** If every changed file matches a skip pattern
   (`.md`, `docs/`, `.github/`, `charts/`, `config/`, `kuadrant-dev-setup/`,
   `.devcontainer/`, `LICENSE`), the build/lint/i18n jobs are skipped entirely.
   Non-PR events (`merge_group`, `workflow_dispatch`) always run.
@@ -232,10 +236,10 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
 
   Prevents new spec files from silently dodging the suite router.
 
-### Adding new components
+### Adding new tests
 
   - Tag the test with exactly one of `@smoke` or `@nightly` (default to `@nightly`)
-  - Add an `if` block in `build/suite-router.sh` mapping the relevant component
+  - Add or update an `if` block in `build/suite-router.sh` mapping the relevant component
   - Run `yarn check:spec-map` to verify that the spec is referenced by `suite-router.sh`
   - Verify separately that the new component path matches the intended router mapping
   - Add the file to the [Test Files](#test-files) list above

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -137,6 +137,29 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
   On nightly failures, `e2e-nightly.yaml` automatically opens a GitHub issue with the
   failed test names extracted from `playwright-results.json`.
 
+### Failure Classification
+
+  `e2e-common.yaml` classifies every run into one of three failure types:
+
+  | Type | Meaning | Trigger |
+  |---|---|---|
+  | `none` | All steps passed | — |
+  | `infrastructure` | Cluster setup or dev server failed | `setup` or `wait-server` step failed |
+  | `test` | Tests themselves failed | Any Playwright test step failed |
+
+  The nightly workflow uses this classification to label auto-opened issues:
+  `nightly-infrastructure` for infra errors, `nightly-failure` for test failures.
+  Infrastructure issues only download test results when tests actually ran, avoiding
+  noise from cluster setup failures.
+
+### Paths Filter (build, lint, i18n)
+
+  `build.yaml`, `lint.yaml`, and `i18n.yaml` each have a `changes` job that skips
+  the check for **docs-only PRs.** If every changed file matches a docs-only pattern
+  (`.md`, `docs/`, `.github/`, `charts/`, `config/`, `kuadrant-dev-setup/`,
+  `.devcontainer/`, `LICENSE`), the build/lint/i18n jobs are skipped entirely.
+  Non-PR events (`merge_group`, `workflow_dispatch`) always run.
+
 ### Suite Router (`build/suite-router.sh`)
 
   The suite router optimises PR CI by running only the e2e specs relevant to changed

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -43,13 +43,19 @@ curl http://localhost:9001  # Plugin dev server should respond
 npx playwright test --config=e2e/playwright.config.ts
 
 # 5. Run specific test file
-npx playwright test e2e/tests/apikey-lifecycle.spec.ts --config=e2e/playwright.config.ts
+npx playwright test --config=e2e/playwright.config.ts e2e/tests/apikey-lifecycle.spec.ts
 
-# 6. Run with headed browser (visible UI)
-npx playwright test e2e/tests/apikey-lifecycle.spec.ts --config=e2e/playwright.config.ts --headed
+# 6. Run only smoke tests
+npx playwright test --config=e2e/playwright.config.ts --grep @smoke
 
-# 7. Run with debug mode
-npx playwright test e2e/tests/apikey-lifecycle.spec.ts --config=e2e/playwright.config.ts --debug
+# 7. Run only nightly tests
+npx playwright test --config=e2e/playwright.config.ts --grep @nightly
+
+# 8. Run with headed browser (visible UI)
+npx playwright test --config=e2e/playwright.config.ts e2e/tests/apikey-lifecycle.spec.ts --headed
+
+# 9. Run with debug mode
+npx playwright test --config=e2e/playwright.config.ts e2e/tests/apikey-lifecycle.spec.ts --debug
 ```
 
 ### Quick Start (If Already Set Up)
@@ -84,8 +90,115 @@ npx playwright test --config=e2e/playwright.config.ts
 - `e2e/tests/rbac.spec.ts` - RBAC permission tests
 - `e2e/tests/topology.spec.ts` - Policy topology rendering, filtering, and navigation
 
-PR CI runs the smoke subset listed in `.github/workflows/e2e-common.yaml`; the nightly
-run executes every spec in `e2e/tests/`.
+See [Test Tags](#test-tags) and [CI Pipeline](#ci-pipeline) for how these are selected and filtered in CI.
+
+## Test Tags 
+
+Every test must be tagged with exactly one of `@smoke` or `@nightly`:
+
+  ```typescript
+  test('approve request', { tag: '@smoke' }, async ({ page }) => { ... })
+  test('validate empty title shows error', { tag: '@nightly' }, async ({ page }) => { ... })
+  ```
+
+  | Tag | When it runs | What to tag |
+  |---|---|---|
+  | `@smoke` | Every PR (via suite router) | Critical-path flows that are fast and reliable |
+  | `@nightly` | Daily at 02:00 UTC (full suite) | Edge cases, validation, slower flows, duplicate coverage, UI |
+
+  **Rules:**
+  - Every test must have exactly one tag — untagged tests are skipped during smoke runs
+  - Default to `@nightly` when adding a new test; only use `@smoke` for critical, reliable flows
+
+## CI Pipeline
+
+  Three GitHub Actions workflows manage e2e testing:
+
+  | Workflow | Trigger | What runs |
+  |---|---|---|
+  | `e2e.yaml` | PRs to `main`/`release-*` | Runs the suite router, then calls `e2e-common.yaml` with `suite: smoke` |
+  | `e2e-nightly.yaml` | Cron daily at 02:00 UTC | Calls `e2e-common.yaml` with `suite: full` (all specs, all tags) |
+  | `e2e-common.yaml` | Called by the above two | Reusable workflow that does the actual work (see below) |
+
+### What `e2e-common.yaml` does
+
+  1. Checks out the repo, sets up Node 22, installs `oinc` and Helm
+  2. Runs `yarn install` and installs Playwright's Chromium
+  3. Starts the plugin dev server (`yarn start`) in the background
+  4. Runs `./e2e/setup.sh` — creates the oinc cluster with addons (gateway-api, cert-manager, MetalLB, Istio, Kuadrant), applies RBAC and test fixtures
+  5. Waits up to 60s for the dev server to be ready
+  6. Runs Playwright tests (see suite router below for how specs are selected)
+  7. Uploads `playwright-report/` and `playwright-results.json` as artifacts
+  8. Tears down the cluster
+
+  On nightly failures, `e2e-nightly.yaml` automatically opens a GitHub issue with the
+  failed test names extracted from `playwright-results.json`.
+
+### Suite Router (`build/suite-router.sh`)
+
+  The suite router optimises PR CI by running only the e2e specs relevant to changed
+  files instead of the full suite. It diffs against `origin/main` and produces **two
+  separate lists**:
+
+  | Output | Contains | How it runs in CI |
+  |---|---|---|
+  | `specs` | Spec files mapped from changed **source** components | `--grep @smoke` (smoke tests only) |
+  | `test_specs` | Spec files that were **directly edited** | No `--grep` filter (all tags run) |
+
+  **Why two lists?** If you edited a test file, you want all its tests to run —
+  including any `@nightly` tests you may have just written. But if you only touched
+  source code, running `@smoke` is enough to validate nothing broke.
+
+  Files that appear in both lists are removed from `specs` to avoid running them twice.
+
+### Component mapping 
+  
+  The router maps source paths to spec files:
+
+  | Changed path | Spec files triggered |
+  |---|---|
+  | `src/components/apikey/` | `apikey-lifecycle`, `apikey-approvals`, `apiproduct-apikeys-tab` |
+  | `src/components/apiproduct/APIProductsListPage` | `api-product-list` |
+  | `src/components/apiproduct/APIProductAPIKeysTab` | `apiproduct-apikeys-tab` |
+  | `src/components/apiproduct/APIProductDefinitionTab` or `APIProductPoliciesTab` | `apiproduct-details-tabs` |
+  | `src/components/apiproduct/APIProductOverviewTab`, `ContactInfoEdit`, etc. | `apiproduct-overview-tab` |
+  | `src/components/apiproduct/` (catch-all) | `apiproduct-crud`, `apiproduct-overview-tab`, `api-product-list`, `apiproduct-rbac` |
+  | `src/components/topology/` | `topology`, `rbac` |
+  | `src/components/gateway/` | `gateway-crud`, `overview`, `rbac` |
+  | `src/components/(dnspolicy\|tlspolicy\|ratelimitpolicy\|authpolicy)/` | `policy-forms`, `rbac` |
+  | `src/components/(httproute\|issuer)/` | `rbac`, `httproute-crud` |
+  | `src/components/NoPermissionsView` | `apiproduct-rbac`, `rbac` |
+
+  **Shared-file fallback** — if any of these paths changed, the router outputs empty
+  lists and CI falls back to running **all** `@smoke` tests:
+
+  `src/utils/`, `src/hooks/`, `src/constants/`, `e2e/tests/helpers.ts`,
+  `e2e/manifests/`, `e2e/setup.sh`, `e2e/teardown.sh`, `scripts/`, `package.json`,
+  `yarn.lock`, `.github/workflows/`
+
+  If nothing matches at all (unrecognised paths, no component mapping hit), it also
+  falls back to the full smoke suite.
+
+### Spec Map Check (`build/check-spec-map.sh`)
+
+  This script verifies that every `*.spec.ts` file in `e2e/tests/` is referenced
+  somewhere in `suite-router.sh`. It runs as a CI gate (the `check-spec-map` job in
+  `e2e.yaml`) and locally via:
+
+  ```bash
+  yarn check:spec-map
+  ```
+
+  Prevents new spec files from silently dodging the suite router.
+
+### Adding new components
+
+  - Tag the test with exactly one of `@smoke` or `@nightly` (default to `@nightly`)
+  - Add an `if` block in `build/suite-router.sh` mapping the relevant component
+  - Run `yarn check:spec-map` to verify that the spec is referenced by `suite-router.sh`
+  - Verify separately that the new component path matches the intended router mapping
+  - Add the file to the [Test Files](#test-files) list above
+  - **Run locally** to verify: `npx playwright test e2e/tests/your-file.spec.ts --config=e2e/playwright.config.ts`
 
 ## Test Environment
 
@@ -143,3 +256,6 @@ oinc destroy
 3. Tests use automatic approval via payment-api (approvalMode: automatic)
 4. Each test run creates unique resource names to avoid conflicts
 5. Tests run with retries=1 (will retry once if failed)
+6. CI may run the full smoke suite when:
+  - The changed files do not match any `component-to-spec` mapping, which triggers the full smoke fallback
+  - Modifications to shared modules (`src/utils/`, `src/hooks/`, `src/constants/`, etc.) trigger the full smoke fallback

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -194,15 +194,16 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
 
   | Changed path | Spec files triggered |
   |---|---|
-  | `src/components/apikey/` | `apikey-lifecycle`, `apikey-approvals`, `apiproduct-apikeys-tab` |
+  | `src/components/apikey/` | `apikey-lifecycle`, `apikey-approvals`, `apiproduct-apikeys-tab`, `data-view-regressions` |
   | `src/components/apiproduct/APIProductsListPage` | `api-product-list` |
-  | `src/components/apiproduct/APIProductAPIKeysTab` | `apiproduct-apikeys-tab` |
+  | `src/components/apiproduct/APIProductAPIKeysTab` | `apiproduct-apikeys-tab`, `data-view-regressions` |
   | `src/components/apiproduct/APIProductDefinitionTab` or `APIProductPoliciesTab` | `apiproduct-details-tabs` |
   | `src/components/apiproduct/APIProductOverviewTab`, `ContactInfoEdit`, etc. | `apiproduct-overview-tab` |
   | `src/components/apiproduct/` (catch-all) | `apiproduct-crud`, `apiproduct-overview-tab`, `api-product-list`, `apiproduct-rbac` |
   | `src/components/topology/` | `topology`, `rbac` |
-  | `src/components/gateway/` | `gateway-crud`, `overview`, `rbac` |
-  | `src/components/(KuadrantOverview\|KuadrantPolicies\|ResourceList\|DropdownWithKebab)` | `overview`, `rbac` |
+  | `src/components/gateway/` | `gateway-crud`, `overview`, `rbac`, `data-view-regressions` |
+  | `src/components/(KuadrantOverview\|KuadrantPolicies\|ResourceList\|DropdownWithKebab)` | `overview`, `rbac`, `data-view-regressions` |
+  | `src/components/KuadrantDataView` | `data-view-regressions` |
   | `src/components/(dnspolicy\|tlspolicy\|ratelimitpolicy\|authpolicy)/` | `policy-forms`, `rbac` |
   | `src/components/(httproute\|issuer)/` | `rbac`, `httproute-crud` |
   | `src/components/mcp/` | `mcp-setup-wizard`, `mcp-overview`, `mcp-wizard` |

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -147,10 +147,16 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
   | `infrastructure` | Cluster setup or dev server failed | `setup` or `wait-server` step failed |
   | `test` | Tests themselves failed | Any Playwright test step failed |
 
+  Cluster timeouts, network errors during setup, and dev server readiness failures
+  all fall under `infrastructure` because they occur in the `setup` or `wait-server`
+  steps. Only failures in the Playwright test steps (`tests`, `tests-full`,
+  `tests-changed`) are classified as `test`.
+
   The nightly workflow uses this classification to label auto-opened issues:
   `nightly-infrastructure` for infra errors, `nightly-failure` for test failures.
-  Infrastructure issues only download test results when tests actually ran, avoiding
-  noise from cluster setup failures.
+  Test results are only downloaded when `type=test`, so infrastructure-only failures
+  skip the results download and failed-test extraction — avoiding noise from cluster
+  setup failures where no tests ran.
 
 ### Paths Filter (build, lint, i18n)
 
@@ -163,8 +169,9 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
 ### Suite Router (`build/suite-router.sh`)
 
   The suite router optimises PR CI by running only the e2e specs relevant to changed
-  files instead of the full suite. It diffs against `origin/main` and produces **two
-  separate lists**:
+  files instead of the full suite. In CI, it diffs against the PR base branch
+  (`origin/${GITHUB_BASE_REF}`); locally, it defaults to `origin/main` (with a
+  `HEAD~1` fallback). It produces **two separate lists**:
 
   | Output | Contains | How it runs in CI |
   |---|---|---|

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -86,8 +86,11 @@ npx playwright test --config=e2e/playwright.config.ts
 - `e2e/tests/apiproduct-rbac.spec.ts` - API product RBAC
 - `e2e/tests/api-product-list.spec.ts` - API product list page
 - `e2e/tests/attached-tab.spec.ts` - Attached tab for Gateway, HTTPRoute, and GRPCRoute detail views
+- `e2e/tests/data-view-regressions.spec.ts` - DataView regressions
 - `e2e/tests/gateway-crud.spec.ts` - Gateway create, edit, and delete operations
 - `e2e/tests/httproute-crud.spec.ts` - HTTPRoute create, edit, and delete operations
+- `e2e/tests/mcp-overview.spec.ts` - MCP Overview dashboard
+- `e2e/tests/mcp-setup-wizard.spec.ts` - MCP Management setup wizard
 - `e2e/tests/overview.spec.ts` - Overview dashboard cards, stats, and navigation
 - `e2e/tests/policy-forms.spec.ts` - Policy creation forms (DNS, TLS, Auth, RateLimit, etc.)
 - `e2e/tests/rbac.spec.ts` - RBAC permission tests

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -85,6 +85,9 @@ npx playwright test --config=e2e/playwright.config.ts
 - `e2e/tests/apiproduct-overview-tab.spec.ts` - API product overview tab
 - `e2e/tests/apiproduct-rbac.spec.ts` - API product RBAC
 - `e2e/tests/api-product-list.spec.ts` - API product list page
+- `e2e/tests/attached-tab.spec.ts` - Attached tab for Gateway, HTTPRoute, and GRPCRoute detail views
+- `e2e/tests/gateway-crud.spec.ts` - Gateway create, edit, and delete operations
+- `e2e/tests/httproute-crud.spec.ts` - HTTPRoute create, edit, and delete operations
 - `e2e/tests/overview.spec.ts` - Overview dashboard cards, stats, and navigation
 - `e2e/tests/policy-forms.spec.ts` - Policy creation forms (DNS, TLS, Auth, RateLimit, etc.)
 - `e2e/tests/rbac.spec.ts` - RBAC permission tests
@@ -116,7 +119,7 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
 
   | Workflow | Trigger | What runs |
   |---|---|---|
-  | `e2e.yaml` | PRs to `main`/`release-*` | Runs the suite router, then calls `e2e-common.yaml` with `suite: smoke` |
+  | `e2e.yaml` | PRs to `main`/`release-*`, `merge_group`, `workflow_dispatch` | Runs the suite router, then calls `e2e-common.yaml` with `suite: smoke` |
   | `e2e-nightly.yaml` | Cron daily at 02:00 UTC | Calls `e2e-common.yaml` with `suite: full` (all specs, all tags) |
   | `e2e-common.yaml` | Called by the above two | Reusable workflow that does the actual work (see below) |
 
@@ -165,8 +168,10 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
   | `src/components/apiproduct/` (catch-all) | `apiproduct-crud`, `apiproduct-overview-tab`, `api-product-list`, `apiproduct-rbac` |
   | `src/components/topology/` | `topology`, `rbac` |
   | `src/components/gateway/` | `gateway-crud`, `overview`, `rbac` |
+  | `src/components/(KuadrantOverview\|KuadrantPolicies\|ResourceList\|DropdownWithKebab)` | `overview`, `rbac` |
   | `src/components/(dnspolicy\|tlspolicy\|ratelimitpolicy\|authpolicy)/` | `policy-forms`, `rbac` |
   | `src/components/(httproute\|issuer)/` | `rbac`, `httproute-crud` |
+  | `src/components/(AttachedResources\|gateway/GatewaySingleOverview\|httproute/HTTPRouteSingleOverview\|grpcroute/)` | `attached-tab` |
   | `src/components/NoPermissionsView` | `apiproduct-rbac`, `rbac` |
 
   **Shared-file fallback** — if any of these paths changed, the router outputs empty
@@ -198,7 +203,7 @@ Every test must be tagged with exactly one of `@smoke` or `@nightly`:
   - Run `yarn check:spec-map` to verify that the spec is referenced by `suite-router.sh`
   - Verify separately that the new component path matches the intended router mapping
   - Add the file to the [Test Files](#test-files) list above
-  - **Run locally** to verify: `npx playwright test e2e/tests/your-file.spec.ts --config=e2e/playwright.config.ts`
+  - **Run locally** to verify: `npx playwright test --config=e2e/playwright.config.ts e2e/tests/your-file.spec.ts`
 
 ## Test Environment
 


### PR DESCRIPTION
## Description

- The e2e CI pipeline has grown with smoke/nightly split, suite router, and spec map check — but none of it was documented in the e2e README
- Updated `e2e/README.md` with the full CI pipeline design, test tagging rules, and a checklist for adding new tests

Fixes #664 

## Type of change

  - [x] [docs] Documentation changes

## Changes made

  - Added --grep commands: Steps 6–7 for running only **@smoke** or **@nightly** tagged tests
  - Standardised flag order: --config now comes first in all commands for consistency

### New sections

**Test Tags**

  - Tagging rules: Explains **@smoke vs @nightly** — when each runs, what to tag with each, and the rule that every test must have exactly one tag
  - Code example: Shows the Playwright syntax for applying tags

**CI Pipeline**

  - Workflow overview: Documents the three GitHub Actions workflows (`e2e.yaml, e2e-nightly.yaml, e2e-common.yaml`) and their triggers
  - `e2e-common.yaml` steps: End-to-end breakdown of what the reusable workflow does
  - Suite router: Explains the two-list design (`specs` vs t`est_specs`), and the **`component-to-spec` mapping** table
  - Shared-file fallback: Documents which paths trigger a full smoke run
  - Spec map check: What `build/check-spec-map.sh` does and how to run it locally
  - Adding new components: Checklist for adding new spec files to the suite router

  **Important Notes**

  Added CI fallback note: Documents when CI triggers a full smoke fallback (unmatched paths, shared module changes)

## Test plan

- [ ] All Markdown anchor links (#test-tags, #ci-pipeline, #test-files) resolve correctly
- [ ] No broken formatting in GitHub preview

## Checklist

- [ ] All user-facing strings use `t()` and are added to `locales/en/plugin__kuadrant-console-plugin.json`
- [ ] CSS classes are prefixed with `kuadrant-` — no bare `.pf-*` or `.co-*` selectors, no hex colors
- [ ] No `console.log` statements left in
- [ ] Commits include `Signed-off-by` line (`git commit -s`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Standardised Playwright end-to-end test commands and added smoke-only and nightly-only examples.
  * Expanded the test-file and tagging guidance, including required `@smoke` and `@nightly` tags.
  * Documented CI workflows, failure classification, suite routing, component mappings, path filtering and fallback behaviour.
  * Added guidance for validating test mappings and introducing new components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->