### PR TITLE
fix: restart console container when plugin not registered

### DIFF
--- a/start-local.sh
+++ b/start-local.sh
@@ -29,9 +29,43 @@ cleanup() {
   log "cluster is still running. tear down with: make oinc-teardown"
 }
 
+RUNTIME=$(detect_runtime)
+HOST=$(container_host "${RUNTIME}")
+PLUGIN_NAME=$(node -p "require('${SCRIPT_DIR}/package.json').consolePlugin.name")
+PLUGIN_URL="http://${HOST}:${PLUGIN_PORT}"
+
+console_has_plugin() {
+  "${RUNTIME}" inspect oinc-console --format '{{json .Config.Cmd}}' 2>/dev/null \
+    | grep -q "${PLUGIN_NAME}"
+}
+
+restart_console_with_plugin() {
+  log "console running without plugin, restarting with plugin wired..."
+  local image
+  image=$("${RUNTIME}" inspect oinc-console --format '{{.Config.Image}}')
+  local env_args=()
+  while IFS= read -r var; do
+    env_args+=(-e "${var}")
+  done < <("${RUNTIME}" inspect oinc-console --format '{{range .Config.Env}}{{println .}}{{end}}' | grep -v '^$')
+
+  "${RUNTIME}" rm -f oinc-console >/dev/null 2>&1
+  "${RUNTIME}" run -d --name oinc-console \
+    "${env_args[@]}" \
+    -p "127.0.0.1:${CONSOLE_PORT}:9000" \
+    "${image}" \
+    /opt/bridge/bin/bridge \
+    --public-dir=/opt/bridge/static \
+    -plugins "${PLUGIN_NAME}=${PLUGIN_URL}"
+  log "console restarted with plugin registered"
+}
+
 if kubectl get nodes &>/dev/null 2>&1; then
   if curl -sf "http://localhost:${CONSOLE_PORT}" >/dev/null 2>&1; then
-    log "existing cluster and console detected, skipping setup"
+    if console_has_plugin; then
+      log "existing cluster and console detected, skipping setup"
+    else
+      restart_console_with_plugin
+    fi
   else
     log "cluster running but console is down, recreating..."
     oinc delete --force


### PR DESCRIPTION
## Summary

- When `make oinc` detects a running cluster and console, it previously skipped setup entirely
- If the console container was started without the `--console-plugin` flag, the plugin never loads (404 on all plugin routes)
- Now checks whether the running console container has the plugin wired and, if not, restarts just the console container with the correct `-plugins` flag
- Preserves the cluster, env vars, and image; no full rebuild needed

## Test plan

- [ ] Run `make oinc` with a cluster whose console was started without plugin registration; verify console restarts with plugin loaded
- [ ] Run `make oinc` with a properly configured console; verify it skips setup as before
- [ ] Run `make oinc` with no cluster; verify full setup still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local setup now automatically detects the available container runtime, host address and plugin configuration.
  * Existing console instances can be updated automatically to register the plugin.
* **Improvements**
  * Existing console settings, including the image and environment configuration, are preserved during updates.
  * Setup is skipped when the plugin is already registered, avoiding unnecessary container recreation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->