### PR TITLE
Verify PatternFly 6.6 themes across plugin pages

### DIFF
--- a/src/components/apikey/ApprovalModal.css
+++ b/src/components/apikey/ApprovalModal.css
@@ -9,16 +9,7 @@
   position: sticky;
   top: 0;
   z-index: 1;
-}
-
-/* Light theme - white background */
-.pf-v6-theme-light .kuadrant-approval-modal__sticky-header {
-  background-color: var(--pf-v6-global--BackgroundColor--100);
-}
-
-/* Dark theme - dark background */
-.pf-v6-theme-dark .kuadrant-approval-modal__sticky-header {
-  background-color: var(--pf-v6-global--BackgroundColor--100);
+  background-color: var(--pf-t--global--background--color--primary--default);
 }
 
 .kuadrant-approval-modal__confirmation-text {

--- a/src/components/apikey/RejectionModal.css
+++ b/src/components/apikey/RejectionModal.css
@@ -11,16 +11,7 @@
   position: sticky;
   top: 0;
   z-index: 1;
-}
-
-/* Light theme */
-.pf-v6-theme-light .kuadrant-rejection-modal__sticky-header {
-  background-color: var(--pf-v6-global--BackgroundColor--100);
-}
-
-/* Dark theme */
-.pf-v6-theme-dark .kuadrant-rejection-modal__sticky-header {
-  background-color: var(--pf-v6-global--BackgroundColor--100);
+  background-color: var(--pf-t--global--background--color--primary--default);
 }
 
 .kuadrant-rejection-modal__single-details {

--- a/src/components/kuadrant.css
+++ b/src/components/kuadrant.css
@@ -9,22 +9,11 @@
 .kuadrant-policy-topology .policy-node .pf-topology__node__background {
   stroke-dasharray: 5, 5 !important;
   stroke-width: 2 !important;
-  stroke: #06c;
+  stroke: var(--pf-t--global--border--color--brand--default);
   animation: dash-animation 2s linear infinite !important;
-  fill: #bee1f4;
-  fill-opacity: 0.5;
+  fill: var(--pf-t--global--color--brand--default);
+  fill-opacity: 0.15;
 }
-
-.pf-theme-dark .kuadrant-policy-topology .policy-node .pf-topology__node__background,
-.pf-v6-theme-dark .kuadrant-policy-topology .policy-node .pf-topology__node__background {
-  fill: #1f4173;
-  fill-opacity: 0.5;
-  stroke: #73bcf7;
-  stroke-dasharray: 5, 5 !important;
-  stroke-width: 2 !important;
-  animation: dash-animation 2s linear infinite !important;
-}
-
 
 @keyframes dash-animation {
   to {
@@ -32,66 +21,43 @@
   }
 }
 
-/* dark theme text */
-.pf-v6-theme-dark .kuadrant-policy-topology svg text,
-.pf-theme-dark .kuadrant-policy-topology svg text,
-.pf-v6-theme-dark .kuadrant-policy-topology .pf-topology-container__graph text,
-.pf-theme-dark .kuadrant-policy-topology .pf-topology-container__graph text,
-.pf-v6-theme-dark .kuadrant-policy-topology .pf-topology-visualization-surface svg text,
-.pf-theme-dark .kuadrant-policy-topology .pf-topology-visualization-surface svg text {
-  fill: #fff !important;
-}
-
-/* light theme text */
-.pf-v6-theme-light .kuadrant-policy-topology svg text,
-.pf-theme-light .kuadrant-policy-topology svg text {
-  fill: #151515 !important;
-}
-
-.kuadrant-policy-topology svg text {
-  fill: #151515;
-}
-
-.pf-v6-theme-dark .kuadrant-policy-topology svg text {
-  fill: #fff !important;
+/* Theme semantic tokens cover light, dark, glass, and high-contrast. */
+.kuadrant-policy-topology svg text,
+.kuadrant-policy-topology .pf-topology-container__graph text,
+.kuadrant-policy-topology .pf-topology-visualization-surface svg text {
+  fill: var(--pf-t--global--text--color--regular) !important;
 }
 
 /* badge text */
-.kuadrant-policy-topology .pf-topology__node__label__badge > text {
-  fill: #fff !important;
+.kuadrant-policy-topology
+  .pf-topology-visualization-surface
+  .pf-topology__node__label__badge
+  > text {
+  fill: var(--pf-t--global--text--color--inverse) !important;
 }
 
-/* dark theme icons */
-.pf-v6-theme-dark .kuadrant-policy-topology .kuadrant-topology-node-icon,
-.pf-theme-dark .kuadrant-policy-topology .kuadrant-topology-node-icon {
-  color: #d2d2d2 !important;
-  fill: #d2d2d2 !important;
-}
-
-/* light theme icons */
-.pf-v6-theme-light .kuadrant-policy-topology .kuadrant-topology-node-icon,
-.pf-theme-light .kuadrant-policy-topology .kuadrant-topology-node-icon {
-  color: #6a6e73 !important;
-  fill: #6a6e73 !important;
+.kuadrant-policy-topology .kuadrant-topology-node-icon {
+  color: var(--pf-t--global--icon--color--regular) !important;
+  fill: var(--pf-t--global--icon--color--regular) !important;
 }
 
 /* group label styling */
 .kuadrant-policy-topology .pf-topology__group__label .pf-topology__node__label__background {
-  fill: #292929 !important;
+  fill: var(--pf-t--global--background--color--inverse--default) !important;
 }
 
 .kuadrant-policy-topology g.pf-topology__group__label > text {
-  fill: #fff !important;
+  fill: var(--pf-t--global--text--color--inverse) !important;
 }
 
 /* hover state */
 .kuadrant-policy-topology .pf-topology__group.pf-m-hover g.pf-topology__group__label > text {
-  fill: #fff !important;
+  fill: var(--pf-t--global--text--color--inverse) !important;
 }
 
 /* additional specificity for group labels */
 .kuadrant-policy-topology .pf-topology-visualization-surface g.pf-topology__group__label > text {
-  fill: #fff !important;
+  fill: var(--pf-t--global--text--color--inverse) !important;
 }
 
 .kuadrant-page-title {


### PR DESCRIPTION
## Summary

- Replace topology theme-specific selectors and hard-coded colours with Kuadrant-scoped PatternFly semantic tokens so light, dark, glass, and high-contrast themes use their own palette.
- Replace theme-specific API-key approval and denial modal sticky-header colours with the semantic primary background token.

## Test evidence

- `yarn stylelint src/components/apikey/ApprovalModal.css src/components/apikey/RejectionModal.css src/components/kuadrant.css --allow-empty-input` — passed
- `yarn test --runInBand` — 198 tests passed
- `yarn build` — passed
- `yarn check:spec-map` — passed
- Local verification against `origin-console:latest` exercised all 25 plugin page routes in light, dark, glass, and high-contrast themes, including topology colours and approval/denial sticky headers

Closes #653