### PR TITLE
docs: versioning and OpenShift compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Based on https://github.com/openshift/console-plugin-template
 ## Screenshots
 
 ![Overview](docs/images/overview.gif)
+
 ## Running
 
 - Target a running OCP with `oc login`
@@ -101,6 +102,9 @@ Two easy ways to deploy.
 
 ### Via `kubectl` or `oc`
 
+`install.yaml` uses the 4.22+ `latest` image. For OCP 4.21 and earlier, replace
+it with `quay.io/kuadrant/console-plugin:v0.6.0` before applying the manifest.
+
 `oc apply -f install.yaml`
 
 or
@@ -176,15 +180,23 @@ Update `settings.json` (File > Preferences > Settings):
 ```json
 "editor.formatOnSave": true
 ```
+
 ## Version matrix
 
-| kuadrant-console-plugin version | PatternFly version | Openshift console version | Dynamic Plugin SDK |
-|---------------------------------|--------------------|---------------------------|--------------------|
-|         v0.0.3 - v0.0.18        |          5         |          v4.17.x          |       v1.6.0       |
-|                TBD              |          5         |          v4.18.x          |       v1.8.0       |
-|                TBD              |          6         |          v4.19.x          |         TBD        |
+| OpenShift console | Image    | Branch        |
+| ----------------- | -------- | ------------- |
+| 4.21 and earlier  | `v0.6.0` | `release-0.x` |
+| 4.22 and later    | `latest` | `main`        |
 
-Openshift console is configured to share modules with its dynamic plugins (console plugins). For more information on versions and changes to the shared modules, please see the shared modules [documentation](https://www.npmjs.com/package/@openshift-console/dynamic-plugin-sdk?activeTab=readme)
+`v0.6.0` declares `latestSupportedOpenshiftVersion: "4.19"`, but is supported
+through 4.21. The `release-0.x` branch corrects the metadata and receives
+backports.
+
+`latest` is the unreleased 4.22 build from `main`. Choose the image by OpenShift
+version, not by which tag looks newest.
+
+See [Versioning and OpenShift compatibility](docs/versioning.md) for runtime
+versions and loading rules.
 
 ## Maintenance
 
@@ -236,4 +248,3 @@ Deletions are confirmed interactively in batches of 25.
 ## Troubleshooting
 
 For troubleshooting common issues, please see [TROUBLESHOOTING.md](TROUBLESHOOTING.md).
-

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -16,6 +16,52 @@ The tag push triggers `build-push.yaml`, which builds and pushes the
 Use the guarded Claude command for the happy path. The manual steps below are
 the equivalent fallback and are also useful when diagnosing a failed release.
 
+## Maintaining release streams
+
+### New console generation
+
+If a console release changes a shared-module major:
+
+1. Land compatible prerequisites before the SDK bump.
+2. Cut a branch for the outgoing generation. Give each stream a distinct
+   `consolePlugin.version`.
+3. Bump the SDK, React and React Router together. Set the new `pluginAPI` floor
+   and `latestSupportedOpenshiftVersion`.
+4. Test against a real cluster. Federation failures do not appear in
+   `yarn build`.
+
+Before merging, check that CI, image tags, Quay cleanup and the release process
+cover both branches. Update the local console image and README matrix as well.
+
+### Operator image selection
+
+The Kuadrant operator reads `ClusterVersion/version.status.desired.version`,
+maps it to a `RELATED_IMAGE_*` value, and updates the plugin Deployment. These
+image values also appear in the OLM bundle's `relatedImages`, so `oc-mirror` can
+find them.
+
+This mapping first handled the PatternFly 5/6 split. For each new console
+generation, add the OCP range and an immutable plugin image to the operator's
+release configuration, OLM bundle and Helm chart. Test the boundary and the
+cluster-upgrade path. The 4.22 work is tracked in
+[Kuadrant/kuadrant-console-plugin#737](https://github.com/Kuadrant/kuadrant-console-plugin/issues/737).
+
+### SDK and shared modules
+
+Use the `X.Y-latest` SDK dist-tag for the target console generation. Wait for GA
+before adopting a new generation; prerelease peer ranges can still change.
+
+The console supplies shared modules at runtime. A dependency bump in this repo
+changes the build and lockfile, not the code running in the console. If the SDK
+peer range excludes a fixed version needed for scanning, widen it with a patch
+under `.yarn/patches`. Check the version shipped by the console separately.
+
+### Backports
+
+Send applicable bug fixes and SDK-independent changes to `release-0.x` in a PR
+with a `[backport]` title. Do not backport code that needs React 18, React Router
+7 or SDK 4.22. Review cherry-picks normally; the branches have diverged.
+
 ## Prerequisites
 
 - Push access to `Kuadrant/console-plugin`

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,50 @@
+# Versioning and OpenShift compatibility
+
+OpenShift Console provides React, React Router, `react-i18next`, Redux,
+PatternFly Topology and the SDK to dynamic plugins as Module Federation
+singletons. These modules use `allowFallback: false`; the plugin cannot ship a
+second copy.
+
+The versions in `package.json` provide TypeScript types and federation version
+requirements at build time. `ConsoleRemotePlugin` derives `requiredVersion`
+from the SDK's `peerDependencies`. SDK 4.22.0 was the first release to declare
+the shared modules as peers.
+
+OCP 4.22 moved React from 17 to 18 and React Router from 5 to 7. A 4.22 plugin
+build fails on a 4.21 console because it receives the older singletons. We keep
+separate branches for the two console generations.
+
+## Loading checks
+
+| Setting                                            | Effect                                                                    |
+| -------------------------------------------------- | ------------------------------------------------------------------------- |
+| `consolePlugin.dependencies["@console/pluginAPI"]` | Hard gate. The console rejects a plugin outside this range.               |
+| Federation `requiredVersion`                       | Logs a warning on mismatch, then loads the host singleton.                |
+| `consolePlugin.latestSupportedOpenshiftVersion`    | Metadata written to the ConsolePlugin resource. It does not gate loading. |
+
+## Console runtimes
+
+The values below come from the matching SDK package manifests.
+
+| OCP        | SDK                   | React | React Router            | PF Topology | react-i18next |
+| ---------- | --------------------- | ----- | ----------------------- | ----------- | ------------- |
+| 4.17       | `1.6.0`               | 17    | 5.3.x                   | 5.3.0       | 11.x          |
+| 4.18       | `4.18.0`              | 17    | 5.3.x (+ v5-compat 6.x) | 5.3.0       | 11.x          |
+| 4.19       | `4.19.1`              | 17    | 5.3.x (+ v5-compat 6.x) | 6.2.x       | 11.x          |
+| 4.20       | `4.20.0`              | 17    | 5.3.x (+ v5-compat 6.x) | 6.2.x       | 11.x          |
+| 4.21       | `4.21.0`              | 17    | 5.3.x (+ v5-compat 6.x) | 6.2.x       | 11.x          |
+| 4.22       | `4.22.0`              | 18    | 7.13.x                  | 6.4.x       | 16.5.x        |
+| 4.23 / 5.0 | `4.23.0-prerelease.5` | 18    | 7.18.x                  | 6.6.x       | 16.5.x        |
+
+`react-router-dom-v5-compat` is still shared by the 4.23 and 5.0 console
+branches, but is deprecated. Support ends when the console removes that share
+name.
+
+## Plugin streams
+
+| Stream  | OCP              | Branch        | Release  | Image tags                                              | `pluginAPI`  | `latestSupportedOpenshiftVersion` |
+| ------- | ---------------- | ------------- | -------- | ------------------------------------------------------- | ------------ | --------------------------------- |
+| Current | 4.22+            | `main`        | none yet | `latest`, `<git sha>`                                   | `>=4.22.0-0` | `4.22`                            |
+| Legacy  | 4.21 and earlier | `release-0.x` | `v0.6.0` | `v0.6.0`, `release-0.x-latest`, `release-0.x-<git sha>` | `*`          | `4.21`                            |
+
+`main` builds against React Router 7.13.x, matching OCP 4.22.


### PR DESCRIPTION
## Summary

- Replace the stale README matrix with the images to use before and after OCP 4.22.
- Document why the 4.22 build needs a separate stream, and keep the branch and operator maintenance notes in `RELEASE.md`.

## Test evidence

`git diff --check` passes. Documentation only.

Relates to #650, #651, #653, #654, #656 and #737.
