### PR TITLE
Prefer Docker for local oinc runtime detection

### DIFF
--- a/scripts/lib.sh
+++ b/scripts/lib.sh
@@ -4,10 +4,11 @@
 log() { echo "==> $*"; }
 
 detect_runtime() {
-  if command -v podman &>/dev/null; then
-    echo "podman"
-  elif command -v docker &>/dev/null; then
+  # Prefer the Docker CLI (including OrbStack), matching oinc's runtime detection.
+  if command -v docker &>/dev/null; then
     echo "docker"
+  elif command -v podman &>/dev/null; then
+    echo "podman"
   else
     echo "error: no container runtime found (need podman or docker)"
     exit 1


### PR DESCRIPTION
## Summary

- Prefer the Docker CLI, including OrbStack, when both Docker and Podman are installed
- Match oinc's own runtime priority so rerunning `make oinc` does not contact an unused Podman machine
- Keep Podman as the fallback when Docker is unavailable

## Test evidence

- `bash -n scripts/lib.sh start-local.sh scripts/cluster-setup.sh scripts/teardown.sh` — passed
- `shellcheck scripts/lib.sh` — passed
- Mocked Docker-owned console with unreachable Podman — `start-local.sh` reused the console and exited 0

Closes #741

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Docker is now selected as the container runtime when both Docker and Podman are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->