### PR TITLE
fix: update MCP resource versions from v1alpha1 to v1

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ The plugin manages these Custom Resource Definitions (CRDs):
 11. **APIKeyApproval** (`devportal.kuadrant.io/v1alpha1`) - Approval records for API key requests
 
 ### MCP Resources
-12. **MCPGatewayExtension** (`mcp.kuadrant.io/v1alpha1`) - Extends a Gateway with MCP protocol support via an EnvoyFilter
+12. **MCPGatewayExtension** (`mcp.kuadrant.io/v1`) - Extends a Gateway with MCP protocol support via an EnvoyFilter
 13. **ReferenceGrant** (`gateway.networking.k8s.io/v1beta1`) - Cross-namespace reference permissions for Gateway API resources
 
 ## Common Patterns

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -27,8 +27,8 @@ Key resources managed on this page:
 
 | Resource | API Group | Purpose |
 |-|-|-|
-| `MCPGatewayExtension` | `mcp.kuadrant.io/v1alpha1` | Extends a Gateway with MCP capabilities (public host, OAuth, session store) |
-| `MCPServerRegistration` | `mcp.kuadrant.io/v1alpha1` | Registers an MCP server behind an HTTPRoute with prefix routing |
+| `MCPGatewayExtension` | `mcp.kuadrant.io/v1` | Extends a Gateway with MCP capabilities (public host, OAuth, session store) |
+| `MCPServerRegistration` | `mcp.kuadrant.io/v1` | Registers an MCP server behind an HTTPRoute with prefix routing |
 | `ReferenceGrant` | `gateway.networking.k8s.io/v1beta1` | Allows cross-namespace references between MCPGatewayExtensions and Gateways |
 
 MCP Gateways are identified by finding Gateway resources that have an MCPGatewayExtension targeting them via `spec.targetRef`. The summary cards compute health based on the Gateway's `Accepted` and `Programmed` conditions, and server readiness based on the `Ready` condition.

--- a/e2e/manifests/test-mcp-resources.yaml
+++ b/e2e/manifests/test-mcp-resources.yaml
@@ -15,7 +15,7 @@ spec:
       namespaces:
         from: Same
 ---
-apiVersion: mcp.kuadrant.io/v1alpha1
+apiVersion: mcp.kuadrant.io/v1
 kind: MCPGatewayExtension
 metadata:
   name: mcp-gateway-extension
@@ -27,7 +27,7 @@ spec:
     name: mcp-gateway
     sectionName: http
 ---
-apiVersion: mcp.kuadrant.io/v1alpha1
+apiVersion: mcp.kuadrant.io/v1
 kind: MCPServerRegistration
 metadata:
   name: test-mcp-server

--- a/e2e/tests/mcp-overview.spec.ts
+++ b/e2e/tests/mcp-overview.spec.ts
@@ -65,7 +65,7 @@ test.describe('MCP Overview dashboard', () => {
     await btn.click();
 
     await expect(page).toHaveURL(
-      /\/k8s\/ns\/kuadrant-test\/mcp\.kuadrant\.io~v1alpha1~MCPGatewayExtension\/~new/,
+      /\/k8s\/ns\/kuadrant-test\/mcp\.kuadrant\.io~v1~MCPGatewayExtension\/~new/,
       { timeout: 15_000 },
     );
   });
@@ -80,7 +80,7 @@ test.describe('MCP Overview dashboard', () => {
     await internalItem.click();
 
     await expect(page).toHaveURL(
-      /\/k8s\/ns\/kuadrant-test\/mcp\.kuadrant\.io~v1alpha1~MCPServerRegistration\/~new/,
+      /\/k8s\/ns\/kuadrant-test\/mcp\.kuadrant\.io~v1~MCPServerRegistration\/~new/,
       { timeout: 15_000 },
     );
   });
@@ -187,7 +187,7 @@ test.describe('MCP Overview dashboard', () => {
     await link.click();
 
     await expect(page).toHaveURL(
-      /\/k8s\/ns\/kuadrant-test\/mcp\.kuadrant\.io~v1alpha1~MCPGatewayExtension\/mcp-gateway-extension/,
+      /\/k8s\/ns\/kuadrant-test\/mcp\.kuadrant\.io~v1~MCPGatewayExtension\/mcp-gateway-extension/,
       { timeout: 15_000 },
     );
   });

--- a/scripts/mcp-demo.yaml
+++ b/scripts/mcp-demo.yaml
@@ -74,7 +74,7 @@ spec:
         - name: mcp-test-server
           port: 9090
 ---
-apiVersion: mcp.kuadrant.io/v1alpha1
+apiVersion: mcp.kuadrant.io/v1
 kind: MCPServerRegistration
 metadata:
   name: toystore-mcp-server

--- a/src/components/mcp/MCPExtensionStep.tsx
+++ b/src/components/mcp/MCPExtensionStep.tsx
@@ -43,7 +43,7 @@ const MCPExtensionStep: React.FC<MCPExtensionStepProps> = ({
   // Build YAML resource from form state for the YAML editor
   const extensionResource = React.useMemo<MCPGatewayExtension>(() => {
     const resource: MCPGatewayExtension = {
-      apiVersion: 'mcp.kuadrant.io/v1alpha1',
+      apiVersion: 'mcp.kuadrant.io/v1',
       kind: 'MCPGatewayExtension',
       metadata: {
         name: formState.extensionName || '',

--- a/src/components/mcp/MCPVerifyStep.tsx
+++ b/src/components/mcp/MCPVerifyStep.tsx
@@ -220,7 +220,7 @@ const MCPVerifyStep: React.FC<MCPVerifyStepProps> = ({
 
       // 4. Create MCPGatewayExtension
       const mcpExtensionResource: MCPGatewayExtension = {
-        apiVersion: 'mcp.kuadrant.io/v1alpha1',
+        apiVersion: 'mcp.kuadrant.io/v1',
         kind: 'MCPGatewayExtension',
         metadata: {
           name: formState.extensionName,

--- a/src/utils/resources.test.ts
+++ b/src/utils/resources.test.ts
@@ -207,7 +207,7 @@ describe('MCPGatewayExtension resource', () => {
   it('is registered in the resource registry', () => {
     expect(getGVK('MCPGatewayExtension')).toEqual({
       group: 'mcp.kuadrant.io',
-      version: 'v1alpha1',
+      version: 'v1',
       kind: 'MCPGatewayExtension',
     });
   });

--- a/src/utils/resources.ts
+++ b/src/utils/resources.ts
@@ -323,7 +323,7 @@ export const RESOURCES = {
 
   // mcp resources
   MCPGatewayExtension: {
-    gvk: { group: 'mcp.kuadrant.io', version: 'v1alpha1', kind: 'MCPGatewayExtension' },
+    gvk: { group: 'mcp.kuadrant.io', version: 'v1', kind: 'MCPGatewayExtension' },
     plural: 'MCPGatewayExtensions',
     isPolicy: false,
     isGatewayAPI: false,
@@ -331,7 +331,7 @@ export const RESOURCES = {
     isKuadrantInternal: false,
   },
   MCPServerRegistration: {
-    gvk: { group: 'mcp.kuadrant.io', version: 'v1alpha1', kind: 'MCPServerRegistration' },
+    gvk: { group: 'mcp.kuadrant.io', version: 'v1', kind: 'MCPServerRegistration' },
     plural: 'MCPServerRegistrations',
     isPolicy: false,
     isGatewayAPI: false,


### PR DESCRIPTION
## Description
Updates all MCP resource references from v1alpha1 to v1 to match upstream CRD promotion and avoid webhook validation warnings.

<img width="666" height="222" alt="image" src="https://github.com/user-attachments/assets/211fc19a-4520-439e-82a3-0072db908020" />


## Changes
- Update GVK definitions in resources.ts
- Update hardcoded apiVersion in MCPExtensionStep and MCPVerifyStep
- Update e2e test fixtures and URL patterns
- Update test assertions and documentation

## Testing
- yarn lint and yarn i18n pass
- e2e tests updated to match v1 URLs

Closes #743

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated documented MCP resource API versions from `v1alpha1` to `v1`.

- **Bug Fixes**
  - Updated MCP resource creation, verification and demo configurations to use the current `v1` API.

- **Tests**
  - Updated test fixtures, resource URL assertions and validation checks to reflect the `v1` API version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->