### PR TITLE
fix(e2e): fix night test

### DIFF
--- a/e2e/tests/api-product-list.spec.ts
+++ b/e2e/tests/api-product-list.spec.ts
@@ -181,7 +181,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
     await page.waitForTimeout(1000);
 
     // Verify filter label is shown
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
 
     // Verify only Published products are shown
     await expect(page.locator('a:has-text("toystore-api")')).toBeVisible();
@@ -204,7 +204,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
     await page.waitForTimeout(1000);
 
     // Verify filter label is shown
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("Draft")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Draft")')).toBeVisible();
 
     // Verify only Draft product is shown
     await expect(page.locator('a:has-text("draft-api")')).toBeVisible();
@@ -225,7 +225,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
       await page.waitForTimeout(1000);
 
       // Verify filter is active
-      const filterLabel = page.locator('.pf-v6-c-label.pf-m-filled:has-text("Published")');
+      const filterLabel = page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")');
       await expect(filterLabel).toBeVisible();
 
       // Verify Draft API is not shown
@@ -562,8 +562,8 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Verify both filter labels are shown
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("store")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("store")')).toBeVisible();
 
     // Verify only Published products with "store" in name are shown
     await expect(page.locator('a:has-text("gamestore-api")')).toBeVisible();
@@ -588,9 +588,9 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Verify both filter labels are shown
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
     await expect(
-      page.locator('.pf-v6-c-label.pf-m-filled:has-text("kuadrant-test")'),
+      page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("kuadrant-test")'),
     ).toBeVisible();
 
     // Verify only Published products in kuadrant-test namespace are shown
@@ -610,7 +610,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Verify status filter label is shown
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
 
     // Verify HTTPRoute filter badge is shown
     const badge = selectToggle.locator('.pf-v6-c-badge');
@@ -651,8 +651,8 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(500);
 
     // Verify both filter chips are shown
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("game")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("game")')).toBeVisible();
 
     await page
       .locator('[data-ouia-component-id="APIProductsDataViewToolbar-clear-all-filters"]')
@@ -661,9 +661,9 @@ test.describe('APIProduct List Page - Combined Filters', () => {
 
     // Verify filter chips are gone
     await expect(
-      page.locator('.pf-v6-c-label.pf-m-filled:has-text("Published")'),
+      page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")'),
     ).not.toBeVisible();
-    await expect(page.locator('.pf-v6-c-label.pf-m-filled:has-text("game")')).not.toBeVisible();
+    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("game")')).not.toBeVisible();
 
     // Verify full list restored (draft-api visible, paginating if needed)
     expect(await findRowWithPagination(page, 'draft-api')).toBe(true);

--- a/e2e/tests/api-product-list.spec.ts
+++ b/e2e/tests/api-product-list.spec.ts
@@ -52,6 +52,9 @@ const selectCheckboxFilter = async (
   return { toggle, value };
 };
 
+const toolbarChip = (page: Page, text: string) =>
+  page.locator(`.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("${text}")`);
+
 test.describe('APIProduct List Page - Display and Filters', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto('/');
@@ -181,7 +184,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
     await page.waitForTimeout(1000);
 
     // Verify filter label is shown
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
+    await expect(toolbarChip(page, 'Published')).toBeVisible();
 
     // Verify only Published products are shown
     await expect(page.locator('a:has-text("toystore-api")')).toBeVisible();
@@ -204,7 +207,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
     await page.waitForTimeout(1000);
 
     // Verify filter label is shown
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Draft")')).toBeVisible();
+    await expect(toolbarChip(page, 'Draft')).toBeVisible();
 
     // Verify only Draft product is shown
     await expect(page.locator('a:has-text("draft-api")')).toBeVisible();
@@ -225,7 +228,7 @@ test.describe('APIProduct List Page - Status Filter', () => {
       await page.waitForTimeout(1000);
 
       // Verify filter is active
-      const filterLabel = page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")');
+      const filterLabel = toolbarChip(page, 'Published');
       await expect(filterLabel).toBeVisible();
 
       // Verify Draft API is not shown
@@ -562,8 +565,8 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Verify both filter labels are shown
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("store")')).toBeVisible();
+    await expect(toolbarChip(page, 'Published')).toBeVisible();
+    await expect(toolbarChip(page, 'store')).toBeVisible();
 
     // Verify only Published products with "store" in name are shown
     await expect(page.locator('a:has-text("gamestore-api")')).toBeVisible();
@@ -588,10 +591,8 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Verify both filter labels are shown
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
-    await expect(
-      page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("kuadrant-test")'),
-    ).toBeVisible();
+    await expect(toolbarChip(page, 'Published')).toBeVisible();
+    await expect(toolbarChip(page, 'kuadrant-test')).toBeVisible();
 
     // Verify only Published products in kuadrant-test namespace are shown
     await expect(page.locator('a:has-text("gamestore-api")')).toBeVisible();
@@ -610,7 +611,7 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Verify status filter label is shown
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
+    await expect(toolbarChip(page, 'Published')).toBeVisible();
 
     // Verify HTTPRoute filter badge is shown
     const badge = selectToggle.locator('.pf-v6-c-badge');
@@ -651,8 +652,8 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(500);
 
     // Verify both filter chips are shown
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")')).toBeVisible();
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("game")')).toBeVisible();
+    await expect(toolbarChip(page, 'Published')).toBeVisible();
+    await expect(toolbarChip(page, 'game')).toBeVisible();
 
     await page
       .locator('[data-ouia-component-id="APIProductsDataViewToolbar-clear-all-filters"]')
@@ -660,10 +661,8 @@ test.describe('APIProduct List Page - Combined Filters', () => {
     await page.waitForTimeout(1000);
 
     // Verify filter chips are gone
-    await expect(
-      page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("Published")'),
-    ).not.toBeVisible();
-    await expect(page.locator('.pf-v6-c-toolbar .pf-v6-c-label.pf-m-filled:has-text("game")')).not.toBeVisible();
+    await expect(toolbarChip(page, 'Published')).not.toBeVisible();
+    await expect(toolbarChip(page, 'game')).not.toBeVisible();
 
     // Verify full list restored (draft-api visible, paginating if needed)
     expect(await findRowWithPagination(page, 'draft-api')).toBe(true);

--- a/e2e/tests/apikey-lifecycle.spec.ts
+++ b/e2e/tests/apikey-lifecycle.spec.ts
@@ -503,10 +503,10 @@ EOF
       await page.waitForLoadState('domcontentloaded');
       const expiredRow = page.locator(`tr:has-text("${keyName}")`);
       await expect(
-        expiredRow.locator('td[data-label="status"]:has-text("Expired")'),
+        expiredRow.locator('td[data-label="Status"]:has-text("Expired")'),
       ).toBeVisible({ timeout: 15_000 });
       await expect(
-        expiredRow.locator(`td[data-label="expires"]:has-text("${PAST_LABEL}")`),
+        expiredRow.locator(`td[data-label="Expires"]:has-text("${PAST_LABEL}")`),
       ).toBeVisible();
     },
   );

--- a/e2e/tests/attached-tab.spec.ts
+++ b/e2e/tests/attached-tab.spec.ts
@@ -135,7 +135,7 @@ spec:
 
       const authpolicyRow = page.locator(`tr:has(a[data-test="${authpolicy}"])`);
       await expect(
-        authpolicyRow.getByRole('cell', { name: 'AuthPolicy', exact: true }),
+        authpolicyRow.locator('td[data-label="Type"]:has-text("AuthPolicy")'),
       ).toBeVisible();
     },
   );

--- a/e2e/tests/mcp-overview.spec.ts
+++ b/e2e/tests/mcp-overview.spec.ts
@@ -141,11 +141,11 @@ test.describe('MCP Overview dashboard', () => {
 
     const filterToggle = extensionsCard.locator('.pf-v6-c-menu-toggle').first();
     await filterToggle.click();
-    await page.getByRole('option', { name: 'Gateway name' }).click();
+    await page.getByRole('menuitem', { name: 'Gateway name' }).click();
 
     const filterSelect = extensionsCard.locator('.pf-v6-c-menu-toggle').nth(1);
     await filterSelect.click();
-    await page.getByRole('option', { name: 'mcp-gateway' }).click();
+    await page.getByRole('menuitem', { name: 'mcp-gateway' }).click();
 
     await expect(page.locator('text=mcp-gateway-extension').first()).toBeVisible();
   });
@@ -162,11 +162,11 @@ test.describe('MCP Overview dashboard', () => {
     const toolbar = serversCard.locator('.pf-v6-c-toolbar');
     const filterToggle = toolbar.locator('.pf-v6-c-menu-toggle').first();
     await filterToggle.click();
-    await page.getByRole('option', { name: 'Status' }).click();
+    await page.getByRole('menuitem', { name: 'Status' }).click();
 
     const filterSelect = toolbar.locator('.pf-v6-c-menu-toggle').nth(1);
     await filterSelect.click();
-    await page.getByRole('option', { name: 'Offline' }).click();
+    await page.getByRole('menuitem', { name: 'Offline' }).click();
 
     await expect(serversCard.locator('text=test-mcp-server').first()).toBeVisible();
   });

--- a/e2e/tests/mcp-setup-wizard.spec.ts
+++ b/e2e/tests/mcp-setup-wizard.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect, Page } from '@playwright/test';
 import { execFileSync } from 'child_process';
-import { dismissConsoleTour, spaNavigate } from './helpers';
+import { dismissConsoleTour, spaNavigate, TEST_NAMESPACE } from './helpers';
 
 const uid = () => `${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
 
@@ -130,6 +130,8 @@ test.describe('MCP Management', () => {
     });
 
     test('next is disabled until a gateway is selected', { tag: '@nightly' }, async ({ page }) => {
+      await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
+      await page.waitForLoadState('networkidle');
       await spaNavigate(page, '/kuadrant/mcp/setup-wizard');
 
       await expect(page.locator('[data-test="mcp-gateway-select"]')).toBeVisible({ timeout: 15_000 });


### PR DESCRIPTION
## Summary
  - **api-product-list** (7 tests): filter chip locators matched both toolbar chips and table status labels — scoped to `.pf-v6-c-toolbar` to avoid strict mode violations
  - **apikey-lifecycle** (1 test): case-sensitive `data-label` attribute selectors (`"status"` → `"Status"`, `"expires"` → `"Expires"`)
  - **attached-tab** (1 test): `getByRole('cell', { name: 'AuthPolicy' })` failed because table is in a 50%-width card, triggering PatternFly grid mode which prepends column labels to cell content — switched to
  `locator('text=AuthPolicy')`
  - **mcp-overview** (2 tests): filter dropdowns use `role="menuitem"`, not `role="option"` — updated selectors
  - **mcp-setup-wizard** (1 test): gateway select had no options because namespace wasn't set — added navigation to `kuadrant-test` before opening wizard

  ## Test plan
  - [ ] All 12 previously failing nightly tests pass in CI
  - [ ] No regressions in smoke tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for API product filters, API key expiry states, attached tabs, and MCP overview filters.
  * Updated assertions to align with visible labels, filter controls, roles, and table content.
  * Stabilised the MCP setup wizard test by selecting the default test namespace and waiting for page loading to complete.
  * Improved test coverage for clearing filters and selecting gateway and status options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->