### PR TITLE
fix: copy .yarn directory before yarn install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN yarn config set --home enableGlobalCache true
 WORKDIR /usr/src/app
 
 COPY package.json yarn.lock .yarnrc.yml ./
+COPY .yarn .yarn
 RUN YARN_ENABLE_SCRIPTS=false yarn install --immutable
 
 COPY . .


### PR DESCRIPTION
## Summary
- the build-push CI was failing because yarn install couldn't find a patch file (`.yarn/patches/@openshift-console-dynamic-plugin-sdk-npm-4.22.0-40a905f3df.patch`) referenced in yarn.lock
- the Dockerfile copied `package.json`, `yarn.lock`, and `.yarnrc.yml` but never copied `.yarn/`, so the patch dir didn't exist in the build context when `yarn install --immutable` ran
- added `COPY .yarn .yarn` before the install step

## Test plan
- [x] ran `docker build --platform linux/amd64 --target builder .` locally — yarn install and yarn build both complete successfully
- [ ] confirm CI build-push workflow passes on this branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the container build process to ensure required package manager files are available during dependency installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->