### PR TITLE
Upgrade nanoid to 3.3.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "lodash": "4.18.0",
     "node-forge": "^1.3.2",
     "qs": "6.14.1",
-    "brace-expansion@^5": "^5.0.7"
+    "brace-expansion@^5": "^5.0.7",
+    "nanoid": "3.3.18"
   },
   "devDependencies": {
     "@openshift-console/dynamic-plugin-sdk": "patch:@openshift-console/dynamic-plugin-sdk@npm%3A4.22.0#~/.yarn/patches/@openshift-console-dynamic-plugin-sdk-npm-4.22.0-40a905f3df.patch",
@@ -145,6 +146,7 @@
     "i18next": "^25.8.0",
     "i18next-parser": "^9.0.1",
     "js-yaml": "^4.3.1",
+    "nanoid": "3.3.18",
     "pluralize": "^8.0.0",
     "swagger-ui-react": "5.10.5"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -12278,6 +12278,7 @@ __metadata:
     jest: "npm:^30.4.2"
     jest-environment-jsdom: "npm:^30.4.1"
     js-yaml: "npm:^4.3.1"
+    nanoid: "npm:3.3.18"
     pluralize: "npm:^8.0.0"
     prettier: "npm:^2.7.1"
     prettier-stylelint: "npm:^0.4.2"
@@ -13232,12 +13233,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.1, nanoid@npm:^3.3.4":
-  version: 3.3.7
-  resolution: "nanoid@npm:3.3.7"
+"nanoid@npm:3.3.18":
+  version: 3.3.18
+  resolution: "nanoid@npm:3.3.18"
   bin:
     nanoid: bin/nanoid.cjs
-  checksum: 10c0/e3fb661aa083454f40500473bb69eedb85dc160e763150b9a2c567c7e9ff560ce028a9f833123b618a6ea742e311138b591910e795614a629029e86e180660f3
+  checksum: 10c0/b994b4e396730f8be2520923284e2040d61eaee55cc6d4935ef6d38d34bafdc46133eda4d3faea5073bda545aa6079d82b886caeac5c731cf9ac18bcc1301425
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Upgrade nanoid from 3.3.7 to 3.3.18
- Added `resolutions` field to ensure all transitive nanoid consumers use the same version

## Test plan

- [ ] Unit tests pass
- [ ] Build succeeds

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s runtime package configuration to include `nanoid` version 3.3.18.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->