### PR TITLE
Enable Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+version: 2
+
+updates:
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+      time: '09:00'
+      timezone: 'Etc/UTC'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'javascript'
+    commit-message:
+      prefix: 'build'
+      include: 'scope'
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
+      development-dependencies:
+        dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'tuesday'
+      time: '09:00'
+      timezone: 'Etc/UTC'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'infrastructure'
+    commit-message:
+      prefix: 'ci'
+      include: 'scope'
+    groups:
+      github-actions:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'
+
+  - package-ecosystem: 'docker'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'wednesday'
+      time: '09:00'
+      timezone: 'Etc/UTC'
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'infrastructure'
+    commit-message:
+      prefix: 'build'
+      include: 'scope'
+    groups:
+      docker-images:
+        patterns:
+          - '*'
+        update-types:
+          - 'minor'
+          - 'patch'


### PR DESCRIPTION
## Summary

- Enable scheduled dependency updates for Yarn, GitHub Actions, and Docker.
- Reduce PR noise with staggered weekly checks, minor/patch grouping, and per-ecosystem PR caps while leaving major and security updates isolated.

## Test evidence

- `yarn prettier --check .github/dependabot.yml` — passed
- Parsed with `js-yaml` and validated against the published Dependabot JSON schema — passed
- `git diff --check` — passed

Closes #782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated weekly dependency update checks for npm packages, GitHub Actions, and Docker.
  * Grouped compatible minor and patch updates to simplify maintenance.
  * Standardised update pull requests with labels, commit messages, schedules, and limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->