### PR TITLE
fix: restore overview CSS import and remove gateway create sticky footer background

### DIFF
--- a/src/components/KuadrantOverviewPage.tsx
+++ b/src/components/KuadrantOverviewPage.tsx
@@ -51,6 +51,7 @@ import {
   NamespaceBar,
   checkAccess,
 } from '@openshift-console/dynamic-plugin-sdk';
+import './kuadrant.css';
 import ResourceList from './ResourceList';
 import { sortable, SortByDirection } from '@patternfly/react-table';
 import { EXTERNAL_LINKS } from '../constants/links';

--- a/src/components/gateway/GatewayCreatePage.tsx
+++ b/src/components/gateway/GatewayCreatePage.tsx
@@ -1567,21 +1567,19 @@ const GatewayCreatePage: React.FC<GatewayCreatePageProps> = ({ onFormChange }) =
         )}
 
         {!isLoading && createView === 'form' && (
-          <PageSection hasBodyWrapper={false} stickyOnBreakpoint={{ default: 'bottom' }}>
-            <ActionGroup className="pf-u-mt-0">
-              <KuadrantCreateUpdate
-                validation={formValidation()}
-                model={gatewayModel}
-                resource={gatewayObject}
-                policyType="Gateway"
-                navigate={navigate}
-                redirectPath={`/k8s/ns/${selectedNamespace}/${gatewayModel?.apiGroup}~${gatewayModel?.apiVersion}~${gatewayModel?.kind}/${gatewayName}`}
-              />
-              <Button variant="link" onClick={() => navigate(-1)} className="pf-v6-u-ml-md">
-                {t('Cancel')}
-              </Button>
-            </ActionGroup>
-          </PageSection>
+          <ActionGroup className="pf-u-mt-0">
+            <KuadrantCreateUpdate
+              validation={formValidation()}
+              model={gatewayModel}
+              resource={gatewayObject}
+              policyType="Gateway"
+              navigate={navigate}
+              redirectPath={`/k8s/ns/${selectedNamespace}/${gatewayModel?.apiGroup}~${gatewayModel?.apiVersion}~${gatewayModel?.kind}/${gatewayName}`}
+            />
+            <Button variant="link" onClick={() => navigate(-1)} className="pf-v6-u-ml-md">
+              {t('Cancel')}
+            </Button>
+          </ActionGroup>
         )}
       </PageSection>
 


### PR DESCRIPTION
## Description
Two small UI regressions on the overview and Gateway create pages.

## Changes
- Restore `import './kuadrant.css';` in `KuadrantOverviewPage.tsx`, dropped by mistake in `e451574` ("Fix null values"). Without it, `.kuadrant-resource-create-container` / `.kuadrant-overview-create-button` never apply, so Create Gateway/Policy/HTTPRoute buttons fall back to normal block flow and stack under the card title instead of sitting inline beside it.
- Remove the sticky `PageSection` wrapper (`stickyOnBreakpoint`) around the Create/Cancel buttons in `GatewayCreatePage.tsx`, added in `962f8a3`. It triggered PatternFly 6's default sticky-footer gray background, which no other create page uses. Footer now matches the plain `ActionGroup` pattern used elsewhere.

## Testing
- `yarn lint` - clean
- `npx tsc --noEmit` - clean
- `yarn jest src/components/KuadrantOverviewPage.test.tsx` - passing
- Verified `e2e/tests/gateway-crud.spec.ts` selectors are role-based (not tied to the removed `PageSection` wrapper), unaffected by the change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated the Kuadrant overview page styling.
  - Improved the gateway creation form layout by removing the sticky action area, allowing the action controls to appear naturally within the page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->