### PR TITLE
fix night test

### DIFF
--- a/e2e/tests/apiproduct-crud.spec.ts
+++ b/e2e/tests/apiproduct-crud.spec.ts
@@ -7,6 +7,41 @@ async function navigateToAPIProductCreate(page: Page, namespace = 'kuadrant-test
   await dismissConsoleTour(page);
 }
 
+// <ResourceYAMLEditor> is a Monaco editor, so it can't be filled like a plain input.
+// Set its content through the *visible* editor's model — getModels()[0] can be a
+// stale model whose onChange isn't wired to this editor, which silently drops the
+// change and makes YAML-driven tests flaky.
+async function setEditorValue(page: Page, yaml: string): Promise<void> {
+  await page.waitForSelector('.monaco-editor .view-lines', { state: 'visible', timeout: 20_000 });
+  await page.waitForFunction(
+    () => {
+      type MonacoType = {
+        editor?: { getEditors?: () => Array<{ getDomNode: () => Element | null; getModel: () => unknown }> };
+      };
+      const monaco = (window as unknown as { monaco?: MonacoType }).monaco;
+      const el = document.querySelector('.monaco-editor');
+      const editors = monaco?.editor?.getEditors?.() ?? [];
+      return !!el && editors.some((e) => !!e.getDomNode() && el.contains(e.getDomNode()) && !!e.getModel());
+    },
+    { timeout: 20_000 },
+  );
+  await page.evaluate((value) => {
+    type MonacoType = {
+      editor?: {
+        getEditors?: () => Array<{ getDomNode: () => Element | null; getModel: () => { setValue(v: string): void } | null }>;
+        getModels?: () => Array<{ setValue(v: string): void }>;
+      };
+    };
+    const monaco = (window as unknown as { monaco?: MonacoType }).monaco;
+    const el = document.querySelector('.monaco-editor');
+    const editors = monaco?.editor?.getEditors?.() ?? [];
+    const visible = editors.find((e) => !!e.getDomNode() && !!el && el.contains(e.getDomNode()));
+    const model = visible?.getModel() ?? monaco?.editor?.getModels?.()[0];
+    model?.setValue(value);
+  }, yaml);
+  await page.waitForTimeout(500);
+}
+
 // Note: Tests rely on test-httproute HTTPRoute existing in the test namespace
 // This is created by applying e2e/manifests/test-apiproduct-fixtures.yaml before running tests
 
@@ -139,8 +174,14 @@ test.describe('APIProduct CRUD Operations', () => {
   });
 
   test('should validate resource name format', { tag: '@nightly' }, async ({ page }) => {
+    // Full page load to a namespace-scoped URL so the console sets activeNamespace to
+    // TEST_NAMESPACE before we SPA-navigate to the create page. Without this,
+    // useActiveNamespace() returns '#ALL_NS#' and HTTPRouteSelect stays disabled.
+    await page.goto(`/k8s/ns/${TEST_NAMESPACE}`);
+    await page.waitForLoadState('domcontentloaded');
     await navigateToAPIProductCreate(page, TEST_NAMESPACE);
     await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('#display-name')).toBeVisible({ timeout: 20000 });
 
     const displayNameInput = page.locator('#display-name');
     const resourceNameInput = page.locator('#resource-name');
@@ -393,22 +434,12 @@ spec:
     kind: HTTPRoute
     name: test-httproute`;
 
-    // Wait for Monaco to initialise
-    await page.waitForFunction(
-      () => {
-        const monaco = (window as unknown as { monaco?: { editor?: { getModels?: () => unknown[] } } }).monaco;
-        return (monaco?.editor?.getModels?.()?.length ?? 0) > 0;
-      },
-      { timeout: 20000 },
-    );
-
-    // Set YAML content via Monaco API (triggers onDidChangeModelContent → onChange)
-    await page.evaluate((yaml) => {
-      const monaco = (window as unknown as { monaco?: { editor?: { getModels?: () => { setValue(v: string): void }[] } } }).monaco;
-      monaco?.editor?.getModels?.()[0]?.setValue(yaml);
-    }, yamlContent);
-
-    await page.waitForTimeout(500);
+    // Set the YAML content on the *visible* editor's model. Targeting
+    // getModels()[0] is unreliable — the console can keep other Monaco models
+    // around, so index 0 may be a stale model whose onChange isn't wired to
+    // this ResourceYAMLEditor, leaving the default (empty-named) resource to be
+    // created. Match the editor against the mounted .monaco-editor DOM node.
+    await setEditorValue(page, yamlContent);
 
     // Click the Create button rendered by ResourceYAMLEditor
     const createButton = page.locator('button:has-text("Create")').last();

--- a/e2e/tests/mcp-resource-pages.spec.ts
+++ b/e2e/tests/mcp-resource-pages.spec.ts
@@ -140,24 +140,44 @@ async function expectEditorContains(
 }
 
 // <ResourceYAMLEditor> is a Monaco editor, so it can't be filled like a plain input.
-// Set its content through Monaco's model API, which triggers onChange like real typing.
+// Set its content through the *visible* editor's model, which triggers onChange like
+// real typing. Targeting getModels()[0] is unreliable — the console can keep other
+// Monaco models around, so index 0 may be a stale model whose onChange isn't wired to
+// this editor, silently dropping the change and making YAML-driven tests flaky.
 async function setEditorValue(page: import('@playwright/test').Page, yaml: string): Promise<void> {
+  await page.waitForSelector('.monaco-editor .view-lines', { state: 'visible', timeout: 20_000 });
   await page.waitForFunction(
     () => {
-      const monaco = (
-        window as unknown as { monaco?: { editor?: { getModels?: () => unknown[] } } }
-      ).monaco;
-      return (monaco?.editor?.getModels?.()?.length ?? 0) > 0;
+      type MonacoType = {
+        editor?: {
+          getEditors?: () => Array<{ getDomNode: () => Element | null; getModel: () => unknown }>;
+        };
+      };
+      const monaco = (window as unknown as { monaco?: MonacoType }).monaco;
+      const el = document.querySelector('.monaco-editor');
+      const editors = monaco?.editor?.getEditors?.() ?? [];
+      return (
+        !!el && editors.some((e) => !!e.getDomNode() && el.contains(e.getDomNode()) && !!e.getModel())
+      );
     },
     { timeout: 20_000 },
   );
   await page.evaluate((value) => {
-    const monaco = (
-      window as unknown as {
-        monaco?: { editor?: { getModels?: () => { setValue(v: string): void }[] } };
-      }
-    ).monaco;
-    monaco?.editor?.getModels?.()[0]?.setValue(value);
+    type MonacoType = {
+      editor?: {
+        getEditors?: () => Array<{
+          getDomNode: () => Element | null;
+          getModel: () => { setValue(v: string): void } | null;
+        }>;
+        getModels?: () => Array<{ setValue(v: string): void }>;
+      };
+    };
+    const monaco = (window as unknown as { monaco?: MonacoType }).monaco;
+    const el = document.querySelector('.monaco-editor');
+    const editors = monaco?.editor?.getEditors?.() ?? [];
+    const visible = editors.find((e) => !!e.getDomNode() && !!el && el.contains(e.getDomNode()));
+    const model = visible?.getModel() ?? monaco?.editor?.getModels?.()[0];
+    model?.setValue(value);
   }, yaml);
   await page.waitForTimeout(500);
 }

--- a/e2e/tests/policy-forms.spec.ts
+++ b/e2e/tests/policy-forms.spec.ts
@@ -92,24 +92,44 @@ async function gotoPage(page: Page, path: string): Promise<void> {
 const createPagePath = (namespace: string, gvk: string) => `/k8s/ns/${namespace}/${gvk}/~new`;
 
 // <ResourceYAMLEditor> is a Monaco editor, so it can't be filled like a plain input.
-// Set its content through Monaco's model API, which triggers onChange like real typing.
+// Set its content through the *visible* editor's model, which triggers onChange like
+// real typing. Targeting getModels()[0] is unreliable — the console can keep other
+// Monaco models around, so index 0 may be a stale model whose onChange isn't wired to
+// this editor, silently dropping the change and making YAML-driven tests flaky.
 async function setEditorValue(page: Page, yaml: string): Promise<void> {
+  await page.waitForSelector('.monaco-editor .view-lines', { state: 'visible', timeout: 20_000 });
   await page.waitForFunction(
     () => {
-      const monaco = (
-        window as unknown as { monaco?: { editor?: { getModels?: () => unknown[] } } }
-      ).monaco;
-      return (monaco?.editor?.getModels?.()?.length ?? 0) > 0;
+      type MonacoType = {
+        editor?: {
+          getEditors?: () => Array<{ getDomNode: () => Element | null; getModel: () => unknown }>;
+        };
+      };
+      const monaco = (window as unknown as { monaco?: MonacoType }).monaco;
+      const el = document.querySelector('.monaco-editor');
+      const editors = monaco?.editor?.getEditors?.() ?? [];
+      return (
+        !!el && editors.some((e) => !!e.getDomNode() && el.contains(e.getDomNode()) && !!e.getModel())
+      );
     },
     { timeout: 20_000 },
   );
   await page.evaluate((value) => {
-    const monaco = (
-      window as unknown as {
-        monaco?: { editor?: { getModels?: () => { setValue(v: string): void }[] } };
-      }
-    ).monaco;
-    monaco?.editor?.getModels?.()[0]?.setValue(value);
+    type MonacoType = {
+      editor?: {
+        getEditors?: () => Array<{
+          getDomNode: () => Element | null;
+          getModel: () => { setValue(v: string): void } | null;
+        }>;
+        getModels?: () => Array<{ setValue(v: string): void }>;
+      };
+    };
+    const monaco = (window as unknown as { monaco?: MonacoType }).monaco;
+    const el = document.querySelector('.monaco-editor');
+    const editors = monaco?.editor?.getEditors?.() ?? [];
+    const visible = editors.find((e) => !!e.getDomNode() && !!el && el.contains(e.getDomNode()));
+    const model = visible?.getModel() ?? monaco?.editor?.getModels?.()[0];
+    model?.setValue(value);
   }, yaml);
   await page.waitForTimeout(500);
 }


### PR DESCRIPTION
Body:

## What

Fixes one hard-failing nightly test and four flaky e2e tests surfaced by the nightly run.

## Root causes

### `apiproduct-crud.spec.ts` › `should validate resource name format` (hard fail)
The APIProduct create form derives its namespace from `useActiveNamespace()`, not from
the URL. `HTTPRouteSelect` disables its toggle whenever the namespace is `#ALL_NS#`
(`isDisabled={isDisabled || isAllNamespaces}`). Unlike the sibling create/YAML tests,
this test skipped the full `page.goto('/k8s/ns/...')` load that sets the active
namespace, so `#httproute-select` stayed permanently disabled and the click timed out.

### 4 flaky tests using the Monaco YAML editor
`setEditorValue` (and an inline copy in `apiproduct-crud.spec.ts`) targeted
`monaco.editor.getModels()[0]`. The console keeps multiple Monaco models around, so
index `0` can point at a stale model whose `onChange` isn't wired to the visible
`ResourceYAMLEditor`. When that happened:
- YAML → Form hydration never fired (OIDCPolicy radio unchecked; TokenRateLimitPolicy
  kept its auto-generated name instead of `yaml-guard-check`);
- Create posted the default empty-named resource, so the page stayed on `~new` /
  the resource was never created (APIProduct + MCPServerRegistration YAML tabs).

On retry the model ordering differed, so `[0]` sometimes hit the right model — hence
the flakiness.

## Changes

- `apiproduct-crud.spec.ts`: add the namespace-setting preamble to the name-validation
  test; replace the inline Monaco call with the robust `setEditorValue` helper.
- `policy-forms.spec.ts` / `mcp-resource-pages.spec.ts`: rewrite `setEditorValue` to set
  the value on the **visible** editor, located via `getEditors()` matched against the
  mounted `.monaco-editor` DOM node (same approach already used by
  `expectEditorContains`), with a `getModels()[0]` fallback.

Only spec files changed — no new specs, so `build/suite-router.sh` needs no update.

## Test plan

```bash
npx playwright test --config=e2e/playwright.config.ts \
  e2e/tests/apiproduct-crud.spec.ts \
  e2e/tests/policy-forms.spec.ts \
  e2e/tests/mcp-resource-pages.spec.ts \
  -g "should validate resource name format|should create APIProduct via YAML view and verify in list|creates an MCPServerRegistration from the YAML tab|YAML target hydrates the Form Target Type and selector|YAML with an unsupported target kind does not populate the Form target" \
  --repeat-each=3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved YAML editor interactions in resource creation and policy forms by targeting the active, visible editor.
  * Fixed validation flows that could use stale editor content.
  * Improved namespace-scoped HTTPRoute validation by ensuring the correct page context is loaded first.

* **Tests**
  * Strengthened end-to-end coverage for YAML editing and resource name validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->