### PR TITLE
test: assert policy limit replacement removes old limit

### DIFF
--- a/e2e/tests/policy-forms.spec.ts
+++ b/e2e/tests/policy-forms.spec.ts
@@ -1099,6 +1099,7 @@ spec:
         await expect(page.locator('text=default')).toBeVisible({ timeout: 10_000 });
 
         // remove existing limit and add updated one
+        await page.locator('button[aria-label="Close"]').click();
         await page.getByRole('button', { name: 'Add Limit' }).click();
         await page.locator('#new-limit-name').fill('updated');
         await page.locator('#new-limit-value').fill('200');
@@ -1126,6 +1127,17 @@ spec:
             'jsonpath={.spec.limits.updated.rates[0].limit}',
           ]),
         ).toBe('200');
+        expect(
+          kubectl([
+            'get',
+            'tokenratelimitpolicy',
+            policyName,
+            '-n',
+            namespace,
+            '-o',
+            'jsonpath={.spec.limits.default}',
+          ]),
+        ).toBe('');
       },
     );
   });


### PR DESCRIPTION
## Summary

- assert that the previous `default` limit is removed when the policy form replaces it with `updated`
- retain the existing assertion that the new limit is set to `200`
- perform the explicit UI click on the Close button to properly simulate the removal of the old limit (since the application logically maintains limits as a map and intentionally preserves them unless explicitly removed).

## Related

Addresses the CodeRabbit review comment in #734.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for editing token rate-limit policies.
  * Added verification that the original default limit is removed after an updated limit is saved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->